### PR TITLE
ci: 升级 claude-code-action v0.x beta → v1 + Max 订阅 OAuth 鉴权

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,7 @@ name: Claude PR Review
 
 # 触发：PR 打开 / 推新 commit / reopen 时自动跑一次 review
 # 互动入口见 claude.yml（在 PR 里 @claude 触发对话）
+# 鉴权：走 Max/Pro 订阅 OAuth（CLAUDE_CODE_OAUTH_TOKEN），本地 `claude setup-token` 生成
 
 on:
   pull_request:
@@ -20,16 +21,19 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@beta
+      - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          mode: review
-          direct_prompt: |
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+
             按 Inalpha 仓库 CLAUDE.md（§3 协作硬约束 + §3.1 金融时效性 + §3.2 prompt 工程纪律 + §4 CI 红线）review 本 PR diff。
 
             ## 必查 red flag
@@ -67,9 +71,14 @@ jobs:
 
             ## review 行为
 
-            - 找到 red flag → inline comment 贴到具体 line + 引用 CLAUDE.md 哪条
-            - 没问题 → 一段中文 LGTM 总结即可，不要硬挑刺
+            - PR 分支已 checkout 在当前工作目录
+            - 找到 red flag → 用 `mcp__github_inline_comment__create_inline_comment`（带 `confirmed: true`）贴到具体 line + 引用 CLAUDE.md 哪条
+            - 顶层总结用 `gh pr comment` 发；没问题 → 一段中文 LGTM 总结即可，不要硬挑刺
             - 措辞参考 CLAUDE.md 简洁风格：不堆模板话、不复读用户 diff
             - 用户措辞翻译表（见 packages/orchestration/src/mastra/agents/orchestrator.ts）
               对你也适用：不要在 review 输出里搬 promote / iterate / verdict / pass /
               abandon 这类英文工程黑话
+            - 只贴 GitHub 评论，不要把审查文字当聊天消息发
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,6 +2,7 @@ name: Claude
 
 # 互动入口：在 PR / issue / review comment 里 @claude 触发对话
 # 自动 review 见 claude-review.yml（PR 打开时无脑跑一次）
+# 鉴权：走 Max/Pro 订阅 OAuth（CLAUDE_CODE_OAUTH_TOKEN），本地 `claude setup-token` 生成
 
 on:
   issue_comment:
@@ -27,11 +28,12 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@beta
+      - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- 把 \`claude.yml\` / \`claude-review.yml\` 从 \`@beta\` 升到 \`@v1\`
- 鉴权从 \`anthropic_api_key\` 换成 \`claude_code_oauth_token\`——走 Max 订阅 usage 配额，不再按 API token 计费
- v0 → v1 字段迁移：删 \`mode: review\`（v1 自动检测）、\`direct_prompt\` → \`prompt\`、加 \`claude_args\` allowlist
- prompt 头部加 \`REPO\` + \`PR NUMBER\` 上下文（v1 推荐）；末尾加"用 \`gh pr comment\` + \`mcp__github_inline_comment\` 发评论"指令
- \`actions/checkout@v4\` → \`@v6\`

## Test plan

- [ ] 这个 PR 本身就是测试 case：merge 前 \`Claude PR Review\` workflow 应自动跑起来在本 PR 留 review 评论
- [ ] 确认 https://github.com/apps/claude 已装到 \`mirror29/inalpha\`（没装的话 workflow 跑但发评论会 403）
- [ ] workflow run 成功 → 把 \`ANTHROPIC_API_KEY\` secret 删掉（已不再使用）
- [ ] **跑通后立刻在 https://claude.ai/settings revoke 当前 OAuth token 重生成**（token 曾在聊天中明文出现过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)