### PR TITLE
feat(D-9): Bull/Bear researcher + swarm 多候选回测 + 并行护栏

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,7 @@ name: Claude PR Review
 
 # 触发：PR 打开 / 推新 commit / reopen 时自动跑一次 review
 # 互动入口见 claude.yml（在 PR 里 @claude 触发对话）
+# 鉴权：走 Max/Pro 订阅 OAuth（CLAUDE_CODE_OAUTH_TOKEN），本地 `claude setup-token` 生成
 
 on:
   pull_request:
@@ -20,16 +21,19 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@beta
+      - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          mode: review
-          direct_prompt: |
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+
             按 Inalpha 仓库 CLAUDE.md（§3 协作硬约束 + §3.1 金融时效性 + §3.2 prompt 工程纪律 + §4 CI 红线）review 本 PR diff。
 
             ## 必查 red flag
@@ -67,9 +71,14 @@ jobs:
 
             ## review 行为
 
-            - 找到 red flag → inline comment 贴到具体 line + 引用 CLAUDE.md 哪条
-            - 没问题 → 一段中文 LGTM 总结即可，不要硬挑刺
+            - PR 分支已 checkout 在当前工作目录
+            - 找到 red flag → 用 `mcp__github_inline_comment__create_inline_comment`（带 `confirmed: true`）贴到具体 line + 引用 CLAUDE.md 哪条
+            - 顶层总结用 `gh pr comment` 发；没问题 → 一段中文 LGTM 总结即可，不要硬挑刺
             - 措辞参考 CLAUDE.md 简洁风格：不堆模板话、不复读用户 diff
             - 用户措辞翻译表（见 packages/orchestration/src/mastra/agents/orchestrator.ts）
               对你也适用：不要在 review 输出里搬 promote / iterate / verdict / pass /
               abandon 这类英文工程黑话
+            - 只贴 GitHub 评论，不要把审查文字当聊天消息发
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,6 +2,7 @@ name: Claude
 
 # 互动入口：在 PR / issue / review comment 里 @claude 触发对话
 # 自动 review 见 claude-review.yml（PR 打开时无脑跑一次）
+# 鉴权：走 Max/Pro 订阅 OAuth（CLAUDE_CODE_OAUTH_TOKEN），本地 `claude setup-token` 生成
 
 on:
   issue_comment:
@@ -27,11 +28,12 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@beta
+      - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/packages/orchestration/src/hooks/handlers/grid-size-cap.ts
+++ b/packages/orchestration/src/hooks/handlers/grid-size-cap.ts
@@ -16,14 +16,15 @@ import type { HookHandler, HookRegistration } from "../types.js";
 
 export const DEFAULT_GRID_MAX = 20;
 
-/** swarm.run_backtest_grid 输入形状（仅取需要的两个数组）。 */
+/** swarm.run_backtest_grid 输入形状（D-9：strategies + candidateIds 共同作策略源）。 */
 type GridInputShape = {
   strategies?: unknown;
+  candidateIds?: unknown;
   symbols?: unknown;
 };
 
-function getArrayLen(value: unknown): number | null {
-  return Array.isArray(value) ? value.length : null;
+function getArrayLen(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
 }
 
 export function createGridSizeCapHandler(opts?: { max?: number }): HookHandler {
@@ -31,17 +32,20 @@ export function createGridSizeCapHandler(opts?: { max?: number }): HookHandler {
   return (ctx) => {
     const input = (ctx.toolInput ?? {}) as GridInputShape;
     const s = getArrayLen(input.strategies);
+    const c = getArrayLen(input.candidateIds);
     const sym = getArrayLen(input.symbols);
 
-    // 缺字段不在这层拦——交 zod / schema 校验报更明确的错
-    if (s === null || sym === null) return;
+    // 缺 symbols 不在这层拦——交 zod / schema 校验报更明确的错
+    if (sym === 0) return;
+    // strategies / candidateIds 都缺 → 交 schema superRefine 拦
+    if (s + c === 0) return;
 
-    const total = s * sym;
+    const total = (s + c) * sym;
     if (total > max) {
       return {
         permissionOverride: "deny",
         message:
-          `grid 上限 ${max}，当前 ${total}（${s} strategies × ${sym} symbols）。` +
+          `grid 上限 ${max}，当前 ${total}（${s} strategies + ${c} candidates × ${sym} symbols）。` +
           `请拆成 ≤ ${max} job 的多次调用，或减少其中一边。`,
       };
     }

--- a/packages/orchestration/src/mastra/agents/orchestrator.ts
+++ b/packages/orchestration/src/mastra/agents/orchestrator.ts
@@ -294,7 +294,10 @@ data.* / paper.run_backtest 的 fromTs / toTs 都是 optional，省略时默认"
 
 **下单 / 回测 当前状态（D-9）**：
 - research.deep_dive —— 5 venue 全支持，自动按 market_type 切 prompt
-- paper.run_backtest —— 内核资产中立，但需后端有该 venue 的历史 K 线（先 backfill）
+- paper.run_backtest —— 内核资产中立，**全市场可跑**（crypto / 美股 / A 股 /
+  港股 / 全球指数 / FRED 宏观）；需后端有该 venue 的历史 K 线（先 backfill）
+- swarm.run_backtest_grid —— 同 paper.run_backtest，**全市场可 grid**；不要
+  因为旧 prompt 印象拒绝美股 / A 股 / 指数的 grid 请求
 - trade.create_plan —— 当前 paper service 撮合只对 crypto 完整测过；其它市场跑通需 D-10+ 工作
 
 ## 多空意识（D-9 起 · 不预设方向）

--- a/packages/orchestration/src/mastra/wired-tools.ts
+++ b/packages/orchestration/src/mastra/wired-tools.ts
@@ -19,6 +19,7 @@ import {
   defaultGridSizeCapRegistration,
   defaultIdempotencyRegistrations,
   defaultInjectCurrentDateRegistration,
+  defaultStrategyCodeAuditRegistration,
   withHooks,
 } from "../hooks/index.js";
 import { DEFAULT_PERMISSIONS, PermissionEngine } from "../permissions/index.js";
@@ -39,6 +40,8 @@ function buildDefaultRunner(
   runner.register(defaultGridSizeCapRegistration());
   // D-9 fix：SessionStart 注入今天日期，挡 LLM 训练 cutoff 早导致日期猜错
   runner.register(defaultInjectCurrentDateRegistration());
+  // D-9 · ADR-0020 E1：自创策略源码 PreToolUse 限长 + 注入串拦截
+  runner.register(defaultStrategyCodeAuditRegistration());
   // ADR-0025 follow-up：DeepSeek 在 Mastra agent loop 偶尔 retry 同 swarm 调用
   // 多次（同 input 同输出）；这对 hook 把重复 deny 掉并把上次结果摘要给 LLM
   const idem = defaultIdempotencyRegistrations();

--- a/packages/orchestration/src/mastra/workflows/backtest-grid.ts
+++ b/packages/orchestration/src/mastra/workflows/backtest-grid.ts
@@ -33,9 +33,17 @@ import { getSettings } from "../../config.js";
 
 const StrategyIdSchema = z.enum(["sma_cross", "buy_and_hold", "mean_reversion"]);
 const TimeframeSchema = z.enum(["1m", "5m", "15m", "1h", "4h", "1d"]);
+// D-9 multi-market：与 tools/paper.ts 保持一致——5 venue × 5 资产全覆盖。
+// crypto 'BTC/USDT' / 美股 'AAPL' / 指数 '^N225' / akshare 'sh.600519' /
+// yfinance '005930.KS' / FRED 'DFF' 都应通过。
 const SymbolSchema = z
   .string()
-  .regex(/^[A-Z0-9]+\/[A-Z0-9]+$/, "symbol 必须是 CCXT 风格 'BASE/QUOTE'");
+  .min(1)
+  .max(50)
+  .regex(
+    /^[\^A-Za-z0-9._/-]+$/,
+    "symbol 不能为空 / 含空格；支持 crypto 'BTC/USDT' / 普通 'AAPL' / 指数 '^N225' / akshare 'sh.600519' / yfinance '005930.KS' / FRED 'DFF'",
+  );
 
 // **Note**：strategies + candidateIds "至少一个非空 / 总数 ≤ 5" 的校验放在
 // expandStep 内部抛错，不放 .superRefine —— mastra 1.36 + zod 4 的 standard-schema

--- a/packages/orchestration/src/mastra/workflows/backtest-grid.ts
+++ b/packages/orchestration/src/mastra/workflows/backtest-grid.ts
@@ -37,8 +37,18 @@ const SymbolSchema = z
   .string()
   .regex(/^[A-Z0-9]+\/[A-Z0-9]+$/, "symbol 必须是 CCXT 风格 'BASE/QUOTE'");
 
+// **Note**：strategies + candidateIds "至少一个非空 / 总数 ≤ 5" 的校验放在
+// expandStep 内部抛错，不放 .superRefine —— mastra 1.36 + zod 4 的 standard-schema
+// adapter 对 .superRefine 处理有缺陷，会把合法 input 误判（dedupes 测试踩过）。
+// 单端 max(5) 仍由 zod 校验；跨端总数 + 互斥由 step 校验，workflow status='failed' 触达。
 const GridInputSchema = z.object({
-  strategies: z.array(StrategyIdSchema).min(1).max(5),
+  /** 内置 baseline 策略（与 candidateIds 至少一个非空） */
+  strategies: z.array(StrategyIdSchema).max(5).optional(),
+  /**
+   * D-9 candidate 路径：LLM 自创策略候选 ID 列表（来自 paper.author_strategy）。
+   * 与 strategies 共同组成笛卡尔积 = (strategies ∪ candidateIds) × symbols。
+   */
+  candidateIds: z.array(z.string().uuid()).max(5).optional(),
   symbols: z.array(SymbolSchema).min(1).max(8),
   venue: z.string().default("binance"),
   timeframe: TimeframeSchema.default("1h"),
@@ -50,26 +60,53 @@ const GridInputSchema = z.object({
   fee_rate: z.number().min(0).lt(1).default(0.001),
 });
 
-const JobSchema = z.object({
-  strategy_id: StrategyIdSchema,
-  symbol: SymbolSchema,
-  venue: z.string(),
-  timeframe: TimeframeSchema,
-  from_ts: z.string(),
-  to_ts: z.string(),
-  initial_cash: z.number(),
-  fee_rate: z.number(),
-});
+const JobSchema = z
+  .object({
+    /** 内置策略 ID；走 candidate 路径时为 null */
+    strategy_id: StrategyIdSchema.nullable(),
+    /** D-9 candidate 路径：候选 UUID；走内置时为 null */
+    candidate_id: z.string().uuid().nullable(),
+    symbol: SymbolSchema,
+    venue: z.string(),
+    timeframe: TimeframeSchema,
+    from_ts: z.string(),
+    to_ts: z.string(),
+    initial_cash: z.number(),
+    fee_rate: z.number(),
+  })
+  .refine(
+    (j) => (j.strategy_id === null) !== (j.candidate_id === null),
+    "Job must have exactly one of strategy_id / candidate_id",
+  );
 type Job = z.infer<typeof JobSchema>;
 
+/** D-9 baseline 对照（candidate 路径 PaperBacktestReport.baseline 透传）。 */
+const BaselineShimSchema = z
+  .object({
+    strategy_id: z.string(),
+    fitness: z.number().nullish(),
+    sharpe: z.number().nullish(),
+    max_drawdown_pct: z.number(),
+    total_return_pct: z.number(),
+    num_trades: z.number().int(),
+  })
+  .nullish();
+
 const ReportShimSchema = z.object({
+  /** 内置 ID 或 'candidate:<uuid>' 字面（agent 区分用） */
   strategy_id: z.string(),
+  /** D-9：candidate 路径回填 UUID；内置路径为 null / undefined */
+  candidate_id: z.string().uuid().nullish(),
   symbol: z.string(),
-  sharpe: z.number().nullable(),
+  sharpe: z.number().nullish(),
   max_drawdown_pct: z.number(),
   total_return_pct: z.number(),
   final_equity: z.number(),
   num_trades: z.number().int(),
+  /** D-9 多目标 fitness（排序候选用）；内置路径为 null / undefined */
+  fitness: z.number().nullish(),
+  /** D-9 candidate 路径自动并跑的 buy_and_hold 对照；内置路径为 null / undefined */
+  baseline: BaselineShimSchema,
 });
 type ReportShim = z.infer<typeof ReportShimSchema>;
 
@@ -116,16 +153,37 @@ const expandStep = createStep({
     const toTs = inputData.to_ts ?? now.toISOString();
     const fromTs = inputData.from_ts ?? new Date(now.getTime() - 30 * 86_400_000).toISOString();
 
-    // 笛卡尔积 + dedupe（同 strategy+symbol+window 合并）
+    // 笛卡尔积 + dedupe（同 source(strategy_id|candidate_id)+symbol+window 合并）
+    // D-9：strategies ∪ candidateIds 两条来源都扇出
     const seen = new Set<string>();
     const out: Job[] = [];
-    for (const s of inputData.strategies) {
+
+    const strategies = inputData.strategies ?? [];
+    const candidateIds = inputData.candidateIds ?? [];
+
+    // 跨端校验（superRefine 在 mastra 1.36 + zod 4 下不稳定，放这里抛）
+    const total = strategies.length + candidateIds.length;
+    if (total === 0) {
+      throw new Error(
+        "grid input invalid: must provide at least one of strategies / candidateIds",
+      );
+    }
+    if (total > 5) {
+      throw new Error(
+        `grid input invalid: strategies + candidateIds total ${total} exceeds 5 ` +
+          `(per-side cap; symbols × total also subject to grid-size-cap 20)`,
+      );
+    }
+
+    // 1. 内置 strategies 笛卡尔
+    for (const s of strategies) {
       for (const sym of inputData.symbols) {
-        const key = `${s}|${sym}|${inputData.timeframe}|${fromTs}|${toTs}`;
+        const key = `s:${s}|${sym}|${inputData.timeframe}|${fromTs}|${toTs}`;
         if (seen.has(key)) continue;
         seen.add(key);
         out.push({
           strategy_id: s,
+          candidate_id: null,
           symbol: sym,
           venue: inputData.venue,
           timeframe: inputData.timeframe,
@@ -136,6 +194,27 @@ const expandStep = createStep({
         });
       }
     }
+
+    // 2. D-9 candidate 笛卡尔
+    for (const cid of candidateIds) {
+      for (const sym of inputData.symbols) {
+        const key = `c:${cid}|${sym}|${inputData.timeframe}|${fromTs}|${toTs}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push({
+          strategy_id: null,
+          candidate_id: cid,
+          symbol: sym,
+          venue: inputData.venue,
+          timeframe: inputData.timeframe,
+          from_ts: fromTs,
+          to_ts: toTs,
+          initial_cash: inputData.initial_cash,
+          fee_rate: inputData.fee_rate,
+        });
+      }
+    }
+
     return out;
   },
 });
@@ -151,8 +230,10 @@ const runOneStep = createStep({
     const client = new PaperClient({ baseUrl: settings.paperServiceUrl, token });
 
     try {
+      // D-9：strategy_id / candidate_id 二选一（refine 已保证），分支调用
       const report: PaperBacktestReport = await client.runBacktest({
-        strategyId: inputData.strategy_id,
+        strategyId: inputData.strategy_id ?? undefined,
+        candidateId: inputData.candidate_id ?? undefined,
         symbol: inputData.symbol,
         venue: inputData.venue,
         timeframe: inputData.timeframe,
@@ -162,13 +243,17 @@ const runOneStep = createStep({
         feeRate: inputData.fee_rate,
       });
       const shim: ReportShim = {
-        strategy_id: inputData.strategy_id,
+        // report.strategy_id 已是 'candidate:<uuid>' 或内置 ID 字符串
+        strategy_id: report.strategy_id,
+        candidate_id: report.candidate_id,
         symbol: inputData.symbol,
         sharpe: report.sharpe,
         max_drawdown_pct: report.max_drawdown_pct,
         total_return_pct: report.total_return_pct,
         final_equity: report.final_equity,
         num_trades: report.num_trades,
+        fitness: report.fitness,
+        baseline: report.baseline,
       };
       return { job: inputData, report: shim, error: null };
     } catch (e: unknown) {
@@ -189,11 +274,11 @@ const aggregateStep = createStep({
     const ok = inputData.filter((r) => r.report !== null && r.error === null);
     const errored = inputData.length - ok.length;
 
-    // 转 Pareto 计算输入
+    // 转 Pareto 计算输入（sharpe nullish → 统一到 null）
     const points: ParetoPoint[] = ok.map((r) => ({
       strategy_id: r.report!.strategy_id,
       symbol: r.report!.symbol,
-      sharpe: r.report!.sharpe,
+      sharpe: r.report!.sharpe ?? null,
       max_drawdown_pct: r.report!.max_drawdown_pct,
       total_return_pct: r.report!.total_return_pct,
     }));

--- a/packages/orchestration/src/tools/paper.ts
+++ b/packages/orchestration/src/tools/paper.ts
@@ -74,7 +74,7 @@ export const paperRunBacktestTool = createTool({
 
     何时不用：
     - 实时跑模拟盘 → 用 paper.start_strategy（D-7 还没做）
-    - 跨多标的批量 → 用 swarm.backtest_grid（D-7 还没做）
+    - **跨多标的 / 多候选 批量** → 用 swarm.run_backtest_grid（D-9 已支持全市场）
     - 单纯查 K 线走势 → data.get_bars
 
     坑：

--- a/packages/orchestration/src/tools/paper.ts
+++ b/packages/orchestration/src/tools/paper.ts
@@ -70,6 +70,7 @@ export const paperRunBacktestTool = createTool({
     - 用户问"这个策略历史表现怎样"
     - 调参对比（fast/slow period 不同跑几次比一下）
     - 验证 entry/exit 信号触发频率
+    - **D-9：跑 LLM 自创策略候选** —— 传 candidateId（来自 paper.author_strategy）而非 strategyId
 
     何时不用：
     - 实时跑模拟盘 → 用 paper.start_strategy（D-7 还没做）
@@ -81,10 +82,12 @@ export const paperRunBacktestTool = createTool({
       （报错 NO_BARS_AVAILABLE 时按 hint 操作）
     - params 是策略特定 dict，sma_cross 支持 fast_period / slow_period / trade_size
     - 报告里 num_trades=0 不一定是 bug，可能是趋势单边没触发交叉
+    - **strategyId 与 candidateId 必须二选一**（都给 / 都不给 → 422）
 
     报告字段（D-7+）：
     - 基础：total_return_pct / num_trades / total_fees / final_equity / num_bars_processed
     - 绩效：sharpe / sortino / max_drawdown_pct / win_rate（数据不足时为 null）
+    - D-9：fitness（多目标合成，ADR-0020）—— 排序候选用这个，不要用裸 Sharpe
     - equity_curve：[(ts, equity)] 序列，前端可直接画图
     - final_positions：结束时残留持仓（趋势策略可能持有到尾盘）
   `.trim(),
@@ -132,10 +135,17 @@ export const paperRunBacktestTool = createTool({
           "D-8c 起：触发本次回测的 strategy_hint（来自 compose_strategy.reasoning 上游）",
         ),
     })
-    .refine(
-      (v) => (v.strategyId != null) !== (v.candidateId != null),
-      { message: "必须给 strategyId 或 candidateId，二选一（不能同给也不能都不给）" },
-    ),
+    .superRefine((data, ctx) => {
+      const hasId = typeof data.strategyId === "string" && data.strategyId.length > 0;
+      const hasCand = typeof data.candidateId === "string" && data.candidateId.length > 0;
+      if (hasId === hasCand) {
+        ctx.addIssue({
+          code: "custom",
+          message: "必须给 strategyId 或 candidateId，二选一（不能同给也不能都不给）",
+          path: ["strategyId"],
+        });
+      }
+    }),
   execute: async (inputData, ctx) => {
     const tc = ctx?.requestContext as ToolRequestContext | undefined;
     const client = await getClient(tc);
@@ -148,6 +158,7 @@ export const paperRunBacktestTool = createTool({
 
     return await client.runBacktest({
       strategyId: inputData.strategyId,
+      candidateId: inputData.candidateId,
       params: inputData.params ?? {},
       venue: inputData.venue ?? "binance",
       symbol: inputData.symbol,
@@ -184,21 +195,24 @@ const FactorInputSchema = z.object({
 export const paperComposeStrategyTool = createTool({
   id: "paper.compose_strategy",
   description: `
-    把 research.deep_dive 输出的 strategy_hint + factors 路由到具体 strategy_id + 正规化参数。
+    把 research.deep_dive 输出的 strategy_hint + factors 路由到内置 baseline 策略 +
+    正规化参数。**D-9 起这是"快速通道"而非默认路径**——研究链路默认走 author_strategy。
 
-    何时用：
-    - 拿到 research.deep_dive 的产物后，**先 compose** 再 paper.run_backtest
-    - 用户问"基于这个研究跑回测"——你不需要自己脑补参数，让 compose 翻译
+    何时用（少数）：
+    - 用户**明确点名**内置策略（"用 sma_cross 跑下 fast=5 slow=20"）
+    - 用户**明确**要看 buy_and_hold 基线表现本身
+    - sanity-check：想快速看 hint 对应的内置策略表现作直觉对照
 
-    何时不用：
-    - 用户明确指定了 strategy_id + params → 直接 run_backtest，不必 compose
-    - hint.family === "none" → compose 会拒绝（rejected_reason 非空），需要换思路或不跑回测
+    何时不用（默认情况）：
+    - 任何"针对当下行情设计策略"的需求 → 走 paper.author_strategy（详见其 description）
+    - hint.family === "none" → 不要硬走 compose；直接 author_strategy 根据 factors 写代码
+    - 想要 buy_and_hold 作 alpha 对照 → **不需要**：run_backtest(candidateId=...) 自动并跑
 
     返回字段：
     - strategy_id：'sma_cross' / 'mean_reversion' / 'buy_and_hold'，或 null（拒绝）
-    - params：可直接喂给 paper.run_backtest 的 params
+    - params：可直接喂给 paper.run_backtest(strategyId=...) 的 params
     - reasoning：组装解释（reasonable 链路）
-    - rejected_reason：non-null 表示拒绝，研究结果不足以驱动策略
+    - rejected_reason：non-null 表示拒绝——这种情况下应转 author_strategy，不是放弃
   `.trim(),
   inputSchema: z.object({
     hint: StrategyHintSchema,

--- a/packages/orchestration/src/tools/swarm.ts
+++ b/packages/orchestration/src/tools/swarm.ts
@@ -20,10 +20,14 @@ import { GridInputSchema, GridOutputSchema } from "../mastra/workflows/backtest-
 export const swarmRunBacktestGridTool = createTool({
   id: "swarm.run_backtest_grid",
   description: `
-    并行批量回测（**策略 × 标的** 笛卡尔积）。
+    并行批量回测（**策略 × 标的** 笛卡尔积）。**D-9：全市场支持**——
+    crypto / 美股 / A 股 / 港股 / 全球指数 / FRED 宏观 序列都可走 grid，
+    venue / symbol 形式同 paper.run_backtest（见其 description 全表）。
 
     何时用：
-    - 用户提"用 A / B / C 策略在 BTC / ETH / SOL 上跑 2024 回测"这类批量需求
+    - 用户提"用 A / B / C 策略在多个标的上跑"——任何市场任何 ticker 都可
+      （crypto BTC/ETH/SOL、美股 AAPL/MSFT/NVDA、A 股 sh.600519/sz.300750、
+      港股 hk.00700、指数 ^GSPC/^N225、FRED 宏观 DFF 等都行）
     - 想找 Pareto 前沿 / topK 看哪个组合 Sharpe-DD 最优
     - **D-9：N 个自创策略候选并行回测**——传 candidateIds 数组，**不要**串行调 paper.run_backtest
 
@@ -36,11 +40,16 @@ export const swarmRunBacktestGridTool = createTool({
     - strategies：内置策略 ID 数组（sma_cross / buy_and_hold / mean_reversion）
     - candidateIds：D-9 自创策略候选 UUID 数组（来自 paper.author_strategy）
     - **strategies 和 candidateIds 至少一个非空；两者总数 ≤ 5**
-    - symbols：交易对数组（CCXT 风格 'BASE/QUOTE'），1-8 个
+    - symbols：标的数组（**任意 venue/格式**，1-8 个），同 grid 内所有 symbol
+      应属同一 venue —— grid 不跨 venue
+    - venue：跟 symbols 配套，按市场分类选（crypto→binance / 美股→yfinance 或 alpaca /
+      A 股→akshare / 全球→yfinance / FRED→fred）
 
     坑：
     - (strategies + candidateIds) × symbols ≤ 20（grid-size-cap hook deny 超出请求）
     - 单 job CPU 上限 3 分钟（服务端 RLIMIT_CPU）
+    - 非 binance venue 首次跑前可能需 data.backfill_bars（缓存缺时 paper 端会
+      报 NO_BARS_AVAILABLE）
     - **不**返回 equity_curve / final_positions 等大字段；只回 summary + Pareto + topK，
       要看完整 report 单跑 paper.run_backtest
 

--- a/packages/orchestration/src/tools/swarm.ts
+++ b/packages/orchestration/src/tools/swarm.ts
@@ -25,20 +25,30 @@ export const swarmRunBacktestGridTool = createTool({
     何时用：
     - 用户提"用 A / B / C 策略在 BTC / ETH / SOL 上跑 2024 回测"这类批量需求
     - 想找 Pareto 前沿 / topK 看哪个组合 Sharpe-DD 最优
+    - **D-9：N 个自创策略候选并行回测**——传 candidateIds 数组，**不要**串行调 paper.run_backtest
 
     何时不用：
     - **单策略单标的** → 用 paper.run_backtest（无 grid 开销）
     - **研究决策** → 用 research.deep_dive
     - **同步下单** → 用 trade.create_plan / approve / execute 三件套
 
+    输入：
+    - strategies：内置策略 ID 数组（sma_cross / buy_and_hold / mean_reversion）
+    - candidateIds：D-9 自创策略候选 UUID 数组（来自 paper.author_strategy）
+    - **strategies 和 candidateIds 至少一个非空；两者总数 ≤ 5**
+    - symbols：交易对数组（CCXT 风格 'BASE/QUOTE'），1-8 个
+
     坑：
-    - strategies × symbols ≤ 20（grid-size-cap hook deny 超出请求）
+    - (strategies + candidateIds) × symbols ≤ 20（grid-size-cap hook deny 超出请求）
     - 单 job CPU 上限 3 分钟（服务端 RLIMIT_CPU）
     - **不**返回 equity_curve / final_positions 等大字段；只回 summary + Pareto + topK，
       要看完整 report 单跑 paper.run_backtest
 
     输出：reports (每 job 一条 ok/errored) + pareto (Sharpe vs maxDD 上凸包) + top_k (top 3
     by Sharpe) + summary (total / ok / errored / wall_time_ms)
+
+    **D-9 报告字段扩展**：candidate 路径的每条 report 含 \`candidate_id\` / \`fitness\` /
+    \`baseline\`（buy_and_hold 对照），用 \`fitness > baseline.fitness\` 判 alpha
   `.trim(),
   inputSchema: GridInputSchema,
   outputSchema: GridOutputSchema,

--- a/packages/orchestration/tests/workflows.backtest-grid.test.ts
+++ b/packages/orchestration/tests/workflows.backtest-grid.test.ts
@@ -89,33 +89,59 @@ describe("pickTopK", () => {
 
 type FetchCall = { url: string; body: unknown };
 
+type BacktestRequestBody = {
+  strategy_id?: string | null;
+  candidate_id?: string | null;
+  symbol: string;
+};
+
 function mockPaperBacktest(opts: {
-  failPredicate?: (body: { strategy_id: string; symbol: string }) => boolean;
-  reportFactory?: (body: { strategy_id: string; symbol: string }) => Record<string, unknown>;
+  failPredicate?: (body: BacktestRequestBody) => boolean;
+  reportFactory?: (body: BacktestRequestBody) => Record<string, unknown>;
 }): FetchCall[] {
   const calls: FetchCall[] = [];
-  const defaultReport = (body: { strategy_id: string; symbol: string }) => ({
-    run_id: null,
-    research_id: null,
-    params_hash: "deadbeef",
-    strategy_id: body.strategy_id,
-    venue: "binance",
-    symbol: body.symbol,
-    timeframe: "1h",
-    initial_cash: 10_000,
-    final_equity: 10_500,
-    total_return_pct: 5,
-    num_trades: 3,
-    total_fees: 1.2,
-    num_bars_processed: 100,
-    period_start: "2024-01-01T00:00:00Z",
-    period_end: "2024-12-31T00:00:00Z",
-    sharpe: 1.5,
-    sortino: 1.8,
-    max_drawdown_pct: 8,
-    win_rate: 0.55,
-    final_positions: [],
-  });
+  const defaultReport = (body: BacktestRequestBody) => {
+    const isCandidate = !!body.candidate_id;
+    // candidate 路径下 strategy_id = 'candidate:<uuid>' 字面（仿真实 paper service 响应）
+    const reportStrategyId = isCandidate
+      ? `candidate:${body.candidate_id}`
+      : body.strategy_id ?? "unknown";
+    return {
+      run_id: null,
+      research_id: null,
+      params_hash: "deadbeef",
+      strategy_id: reportStrategyId,
+      candidate_id: body.candidate_id ?? null,
+      venue: "binance",
+      symbol: body.symbol,
+      timeframe: "1h",
+      initial_cash: 10_000,
+      final_equity: 10_500,
+      total_return_pct: 5,
+      num_trades: 3,
+      total_fees: 1.2,
+      num_bars_processed: 100,
+      period_start: "2024-01-01T00:00:00Z",
+      period_end: "2024-12-31T00:00:00Z",
+      sharpe: 1.5,
+      sortino: 1.8,
+      max_drawdown_pct: 8,
+      win_rate: 0.55,
+      final_positions: [],
+      // D-9 新字段
+      fitness: isCandidate ? 1.2 : null,
+      baseline: isCandidate
+        ? {
+            strategy_id: "buy_and_hold",
+            fitness: 0.5,
+            sharpe: 0.8,
+            max_drawdown_pct: 12,
+            total_return_pct: 4,
+            num_trades: 1,
+          }
+        : null,
+    };
+  };
 
   vi.stubGlobal(
     "fetch",
@@ -267,5 +293,110 @@ describe("backtest_grid workflow (end-to-end)", () => {
     // Pareto 只看 ok 的 3 个
     expect(result.result.pareto.length).toBeGreaterThanOrEqual(1);
     expect(result.result.pareto.length).toBeLessThanOrEqual(3);
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // D-9 · candidate 路径 grid（与 strategies 并列）
+  // ────────────────────────────────────────────────────────────────────
+
+  it("expands candidateIds × symbols into N jobs (D-9 candidate grid)", async () => {
+    const calls = mockPaperBacktest({});
+    const c1 = "550e8400-e29b-41d4-a716-446655440001";
+    const c2 = "550e8400-e29b-41d4-a716-446655440002";
+
+    const wf = mastra.getWorkflow("backtest_grid");
+    const run = await wf.createRun();
+    const result = await run.start({
+      inputData: {
+        candidateIds: [c1, c2],
+        symbols: ["BTC/USDT", "ETH/USDT"],
+        venue: "binance",
+        timeframe: "1h",
+        from_ts: "2024-01-01T00:00:00Z",
+        to_ts: "2024-12-31T00:00:00Z",
+        initial_cash: 10_000,
+        fee_rate: 0.001,
+      },
+    });
+
+    expect(result.status).toBe("success");
+    if (result.status !== "success") return;
+    expect(calls).toHaveLength(4);
+    // 所有 4 个 job 都走 candidate 分支（HTTP body 必有 candidate_id 字段非空）
+    for (const c of calls) {
+      const body = c.body as { strategy_id: string | null; candidate_id: string | null };
+      expect(body.candidate_id).not.toBeNull();
+      expect(body.strategy_id).toBeFalsy();
+    }
+    // shim 透传 D-9 字段
+    const okReports = result.result.reports.filter((r) => r.report !== null);
+    expect(okReports).toHaveLength(4);
+    for (const r of okReports) {
+      expect(r.report!.candidate_id).not.toBeNull();
+      expect(r.report!.fitness).toBe(1.2);
+      expect(r.report!.baseline).not.toBeNull();
+      expect(r.report!.baseline!.strategy_id).toBe("buy_and_hold");
+      expect(r.report!.strategy_id.startsWith("candidate:")).toBe(true);
+    }
+  });
+
+  it("supports mixed strategies + candidateIds in a single grid", async () => {
+    const calls = mockPaperBacktest({});
+    const c1 = "550e8400-e29b-41d4-a716-446655440001";
+
+    const wf = mastra.getWorkflow("backtest_grid");
+    const run = await wf.createRun();
+    const result = await run.start({
+      inputData: {
+        strategies: ["sma_cross"],
+        candidateIds: [c1],
+        symbols: ["BTC/USDT"],
+        venue: "binance",
+        timeframe: "1h",
+        from_ts: "2024-01-01T00:00:00Z",
+        to_ts: "2024-12-31T00:00:00Z",
+        initial_cash: 10_000,
+        fee_rate: 0.001,
+      },
+    });
+
+    expect(result.status).toBe("success");
+    if (result.status !== "success") return;
+    expect(calls).toHaveLength(2);
+    // 一条 strategy 一条 candidate
+    const builtinCall = calls.find(
+      (c) => (c.body as { strategy_id: string | null }).strategy_id === "sma_cross",
+    );
+    const candidateCall = calls.find(
+      (c) => (c.body as { candidate_id: string | null }).candidate_id === c1,
+    );
+    expect(builtinCall).toBeDefined();
+    expect(candidateCall).toBeDefined();
+    // 报告 shim：内置路径 baseline=null, candidate 路径 baseline 非空
+    const builtinShim = result.result.reports.find(
+      (r) => r.report?.strategy_id === "sma_cross",
+    )?.report;
+    const candidateShim = result.result.reports.find(
+      (r) => r.report?.candidate_id === c1,
+    )?.report;
+    expect(builtinShim?.baseline).toBeNull();
+    expect(candidateShim?.baseline).not.toBeNull();
+  });
+
+  it("rejects grid with neither strategies nor candidateIds", async () => {
+    const wf = mastra.getWorkflow("backtest_grid");
+    const run = await wf.createRun();
+    const result = await run.start({
+      inputData: {
+        // 故意不传 strategies / candidateIds
+        symbols: ["BTC/USDT"],
+        venue: "binance",
+        timeframe: "1h",
+        initial_cash: 10_000,
+        fee_rate: 0.001,
+      } as never,
+    });
+    // schema superRefine 拒
+    expect(result.status).not.toBe("success");
   });
 });

--- a/packages/orchestration/tests/workflows.backtest-grid.test.ts
+++ b/packages/orchestration/tests/workflows.backtest-grid.test.ts
@@ -14,6 +14,7 @@ import { clearSettings, setSettings } from "../src/config.js";
 import { mastra } from "../src/mastra/index.js";
 import {
   computeParetoFrontier,
+  GridInputSchema,
   pickTopK,
 } from "../src/mastra/workflows/backtest-grid.js";
 
@@ -381,6 +382,26 @@ describe("backtest_grid workflow (end-to-end)", () => {
     )?.report;
     expect(builtinShim?.baseline).toBeNull();
     expect(candidateShim?.baseline).not.toBeNull();
+  });
+
+  // D-9 multi-market 回归：grid SymbolSchema 不应拒 crypto 之外的市场
+  it.each([
+    ["crypto", "BTC/USDT"],
+    ["us_stock", "AAPL"],
+    ["us_index", "^GSPC"],
+    ["jp_index", "^N225"],
+    ["cn_stock_akshare", "sh.600519"],
+    ["hk_stock_akshare", "hk.00700"],
+    ["kr_stock_yfinance", "005930.KS"],
+    ["fred_macro", "DFF"],
+  ])("GridInputSchema accepts multi-market symbol: %s -> %s", (_label, sym) => {
+    const parsed = GridInputSchema.safeParse({
+      strategies: ["sma_cross"],
+      symbols: [sym],
+      venue: "binance", // venue 字段对 schema 校验无影响，只是默认值
+      timeframe: "1h",
+    });
+    expect(parsed.success).toBe(true);
   });
 
   it("rejects grid with neither strategies nor candidateIds", async () => {

--- a/services/paper/src/inalpha_paper/api/backtest.py
+++ b/services/paper/src/inalpha_paper/api/backtest.py
@@ -32,7 +32,12 @@ async def post_backtest(
     _user: Annotated[User, Depends(get_current_user)],
     authorization: Annotated[str | None, Header()] = None,
 ) -> BacktestResponse:
-    """跑回测：拉数据 → 实例化策略 → 跑引擎 → 落库 → 返回报告。"""
+    """跑回测：拉数据 → 实例化策略 → 跑引擎 → 落库 → 返回报告。
+
+    D-9 起：``strategy_id`` 与 ``candidate_id`` 二选一（Pydantic ``model_validator``
+    保证两者必有其一）。candidate 路径下 strategy_id 校验跳过——LLM 候选不在内置
+    注册表里。
+    """
     # 业务校验
     if req.from_ts >= req.to_ts:
         raise ValidationError(
@@ -40,12 +45,14 @@ async def post_backtest(
             details={"from_ts": req.from_ts.isoformat(), "to_ts": req.to_ts.isoformat()},
         )
 
-    available = list_strategies()
-    if req.strategy_id not in available:
-        raise ValidationError(
-            f"unknown strategy_id {req.strategy_id!r}",
-            details={"available": available},
-        )
+    # 内置策略路径才查注册表；candidate 路径在 runner 里读 DB 自带校验
+    if req.strategy_id is not None:
+        available = list_strategies()
+        if req.strategy_id not in available:
+            raise ValidationError(
+                f"unknown strategy_id {req.strategy_id!r}",
+                details={"available": available},
+            )
 
     # 取 forward 用的 JWT（用户 token），用来调 data-service
     if not authorization or not authorization.startswith("Bearer "):

--- a/services/paper/src/inalpha_paper/engine/pool.py
+++ b/services/paper/src/inalpha_paper/engine/pool.py
@@ -4,8 +4,11 @@
 
 - **spawn context**：跨平台一致（macOS Py 3.8+ 默认就是 spawn；Linux 显式选 spawn 避免 fork
   + asyncio loop 状态在子进程里残留）
-- **worker init 设 rlimit**：每个子进程启动时调一次，CPU 软上限 ``settings.job_timeout_s``，
-  数据段 ``settings.job_mem_gb`` GB（macOS 上 RLIMIT_DATA 部分有效，mmap-only path 仍能绕开）
+- **worker init 设 rlimit + 限 BLAS 线程**：每个子进程启动时调一次，CPU 软上限
+  ``settings.job_timeout_s``，数据段 ``settings.job_mem_gb`` GB（macOS 上 RLIMIT_DATA 部分有效，
+  mmap-only path 仍能绕开）；同时把 ``OMP/MKL/OPENBLAS/NUMEXPR/VECLIB`` 五个 BLAS 线程数环境
+  变量 setdefault 为 ``"1"``——避免 N worker × M BLAS thread/each 超额抢核（spawn 子进程 numpy
+  在 task 反序列化时才 import，此处 setdefault 生效）
 - **预热**：``init_pool()`` 末尾 submit N 个 ``_noop`` 把 worker fork + 关键 import 提前跑完，
   首批真 job 不付 ~200ms 启动税
 - **生命周期**：``init_pool()`` 在 FastAPI lifespan startup 调一次；``shutdown_pool()`` 在
@@ -34,6 +37,29 @@ logger = logging.getLogger(__name__)
 _pool: ProcessPoolExecutor | None = None
 
 
+_BLAS_THREAD_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+)
+
+
+def _set_blas_threads(n: str = "1") -> None:
+    """限制 BLAS / OpenMP 等数值库每进程线程数。
+
+    Why: ProcessPool worker × M BLAS thread/each 会超额抢核（6 worker × 8 thread = 48
+    线程抢 8 核），反而拖慢回测、P99 抖动。spawn 子进程在 ``_worker_init`` 阶段还没
+    import numpy（``inalpha_paper.engine.pool`` 顶层不 import numpy），此时 setdefault
+    这几个环境变量，task 反序列化触发 numpy import 时会读到正确值。
+
+    用 ``setdefault`` 不是 ``=``：用户显式 ``OMP_NUM_THREADS=2`` 时尊重外部覆盖。
+    """
+    for var in _BLAS_THREAD_VARS:
+        os.environ.setdefault(var, n)
+
+
 def _set_rlimits(*, cpu_soft: int, mem_bytes: int) -> None:
     """worker 子进程启动时调一次。失败不 raise（rlimit 不可设也要让 worker 起来）。"""
     try:
@@ -57,7 +83,10 @@ def _worker_init(cpu_soft: int, mem_bytes: int) -> None:
 
     设计取舍：rlimit 只在 worker 内设而不在 main 里设 —— main 进程要处理 N 个并发请求
     + DB pool + httpx client，限太死会自伤；worker 是隔离单元，限严格点没副作用。
+
+    BLAS 线程数在 rlimit 之前设：即使 rlimit 失败也要让 worker 拿到正确的线程上限。
     """
+    _set_blas_threads()
     _set_rlimits(cpu_soft=cpu_soft, mem_bytes=mem_bytes)
 
 

--- a/services/paper/src/inalpha_paper/schemas.py
+++ b/services/paper/src/inalpha_paper/schemas.py
@@ -40,8 +40,16 @@ class BacktestRequest(BaseModel):
         examples=[{"fast_period": 10, "slow_period": 30, "trade_size": 0.01}],
     )
 
-    venue: str = Field(default="binance")
-    symbol: str = Field(..., examples=["BTC/USDT"])
+    venue: str = Field(
+        default="binance",
+        description="数据源；按市场分类：crypto→binance / 美股→yfinance|alpaca / A 股→akshare / 全球指数→yfinance / FRED→fred",
+        examples=["binance", "yfinance", "alpaca", "akshare", "fred"],
+    )
+    symbol: str = Field(
+        ...,
+        description="标的代码；支持 crypto 'BTC/USDT' / 美股 'AAPL' / 指数 '^N225' / akshare 'sh.600519' / yfinance '005930.KS' / FRED 'DFF'",
+        examples=["BTC/USDT", "AAPL", "^N225", "sh.600519", "DFF"],
+    )
     timeframe: str = Field(default="1h", examples=["1m", "5m", "1h", "1d"])
     from_ts: datetime = Field(..., description="起始时间（含），ISO 8601")
     to_ts: datetime = Field(..., description="结束时间（含），ISO 8601")
@@ -321,8 +329,16 @@ class SubmitOrderRequest(BaseModel):
     不维持持仓 / 不写库。给 orchestration 层的 ``executeTradePlan`` tool 用。
     """
 
-    venue: str = Field(default="binance")
-    symbol: str = Field(..., examples=["BTC/USDT"])
+    venue: str = Field(
+        default="binance",
+        description="数据源；按市场分类：crypto→binance / 美股→yfinance|alpaca / A 股→akshare / 全球指数→yfinance / FRED→fred",
+        examples=["binance", "yfinance", "alpaca", "akshare", "fred"],
+    )
+    symbol: str = Field(
+        ...,
+        description="标的代码；支持 crypto 'BTC/USDT' / 美股 'AAPL' / 指数 '^N225' / akshare 'sh.600519' / yfinance '005930.KS' / FRED 'DFF'",
+        examples=["BTC/USDT", "AAPL", "^N225", "sh.600519", "DFF"],
+    )
     side: Literal["BUY", "SELL"]
     order_type: Literal["MARKET", "LIMIT"] = Field(default="MARKET", alias="type")
     quantity: float = Field(..., gt=0, examples=[0.001])
@@ -442,8 +458,16 @@ class CreatePlanRequest(BaseModel):
     """
 
     intent: Literal["open_long", "open_short", "close", "rebalance"]
-    venue: str = Field(default="binance")
-    symbol: str = Field(..., examples=["BTC/USDT"])
+    venue: str = Field(
+        default="binance",
+        description="数据源；按市场分类：crypto→binance / 美股→yfinance|alpaca / A 股→akshare / 全球指数→yfinance / FRED→fred",
+        examples=["binance", "yfinance", "alpaca", "akshare", "fred"],
+    )
+    symbol: str = Field(
+        ...,
+        description="标的代码；支持 crypto 'BTC/USDT' / 美股 'AAPL' / 指数 '^N225' / akshare 'sh.600519' / yfinance '005930.KS' / FRED 'DFF'",
+        examples=["BTC/USDT", "AAPL", "^N225", "sh.600519", "DFF"],
+    )
     side: Literal["BUY", "SELL"]
     order_type: Literal["MARKET", "LIMIT"] = Field(default="MARKET", alias="type")
     quantity: float = Field(..., gt=0)

--- a/services/paper/src/inalpha_paper/strategies/__init__.py
+++ b/services/paper/src/inalpha_paper/strategies/__init__.py
@@ -1,15 +1,23 @@
-"""用户策略实现 + 策略注册表。
+"""**Baseline 与适配器策略** + 策略 ID 注册表（D-9 起重新定位）。
 
-D-7 起步 3 个示例：
+> **架构演变 · 2026-05-25**：
+> D-7 时这里是"内置策略库"，D-8c 时给 ``compose_strategy`` 当路由出口。
+> **D-9 之后**：随着 ADR-0020 E1 MVP（``strategy_authoring``）落地，agent 可以
+> 自己写完整 ``Strategy`` 子类源码。此目录里的策略**降级为基线对照 / 教学 / 适配**，
+> 不再是"穷举库的一部分"。穷举策略空间是 ``strategy_candidates`` 表的职责——
+> LLM 写多少进多少，promote 后人工管理。
 
-- ``sma_cross``：经典快慢均线交叉
-- ``buy_and_hold``：基准对照（第一根 bar 买入持有到结束）
-- ``mean_reversion``：布林带均值回归 long-only
+**当前角色分类**：
 
-策略注册表给 ``POST /backtest`` 用 —— 通过 ``strategy_id`` 字符串路由到具体类。
+| ID | 角色 | 何时被调用 |
+|---|---|---|
+| ``buy_and_hold`` | **首要基线** | 任何 candidate 回测都自动并跑一次（runner candidate 分支强制行为），fitness 对照 |
+| ``sma_cross`` | **教学样本 + 协议契约参考** | ``paper.author_strategy`` description 内嵌简化版作 few-shot；用户明确点名时走 compose 快速通道 |
+| ``mean_reversion`` | 同 sma_cross（教学样本） | 同上 |
+| ``signal_replay`` | **adapter**（D-9 sandbox spike） | LLM 在沙盒生成纯函数 ``generate_signals(bars) -> list[signal]``，本类把 signals 重放进 BacktestEngine |
 
-后续添加策略：实现一个 ``Strategy`` 子类，在 ``_REGISTRY`` 注册一行即可。Phase F+ 接受
-外部贡献时考虑 [ADR-0017 layer 1 沙盒](../../../../docs/decisions/0017-isolation-and-sandboxing.md)。
+alpha 的定义 = candidate.fitness 显著高于 baseline.fitness（buy_and_hold）。
+本注册表**不**应再积累更多策略——具体行情下的策略请走 author / signal_replay 路径。
 """
 from ..strategy.base import Strategy
 from .buy_and_hold import BuyAndHoldStrategy
@@ -18,6 +26,7 @@ from .signal_replay import SignalReplayStrategy
 from .sma_cross import SMACrossStrategy
 
 __all__ = [
+    "BASELINE_BUY_AND_HOLD",
     "BuyAndHoldStrategy",
     "MeanReversionStrategy",
     "SMACrossStrategy",
@@ -27,24 +36,31 @@ __all__ = [
 ]
 
 
-_REGISTRY: dict[str, type[Strategy]] = {
+# 名字常量 —— 避免 runner 等调用方硬编码字符串
+BASELINE_BUY_AND_HOLD: str = "buy_and_hold"
+
+
+_BASELINES: dict[str, type[Strategy]] = {
+    BASELINE_BUY_AND_HOLD: BuyAndHoldStrategy,
     "sma_cross": SMACrossStrategy,
-    "buy_and_hold": BuyAndHoldStrategy,
     "mean_reversion": MeanReversionStrategy,
-    # D-9 sandbox spike：把 LLM 在沙盒生成的 signals 重放进 BacktestEngine（E1 闭环）
+    # D-9 sandbox spike：把 LLM 在沙盒生成的 signals 重放进 BacktestEngine（轻量 candidate 路径）
     "signal_replay": SignalReplayStrategy,
 }
 
 
 def get_strategy_class(strategy_id: str) -> type[Strategy]:
-    """返回 strategy_id 对应的类。未注册抛 ``KeyError``。"""
-    if strategy_id not in _REGISTRY:
+    """返回 strategy_id 对应的 baseline / adapter 类。未注册抛 ``KeyError``。"""
+    if strategy_id not in _BASELINES:
         raise KeyError(
-            f"unknown strategy_id {strategy_id!r}; available: {sorted(_REGISTRY.keys())}"
+            f"unknown strategy_id {strategy_id!r}; available baselines: {sorted(_BASELINES.keys())}"
         )
-    return _REGISTRY[strategy_id]
+    return _BASELINES[strategy_id]
 
 
 def list_strategies() -> list[str]:
-    """已注册的所有 strategy_id。"""
-    return sorted(_REGISTRY.keys())
+    """已注册的 baseline / adapter strategy_id。
+
+    **不**是穷举库——agent 自创策略在 ``strategy_candidates`` 表，由 LLM 写多少进多少。
+    """
+    return sorted(_BASELINES.keys())

--- a/services/paper/tests/test_pool.py
+++ b/services/paper/tests/test_pool.py
@@ -134,6 +134,43 @@ def test_noop_runs_in_subprocess() -> None:
     assert worker_pid != os.getpid()
 
 
+def _get_blas_env() -> dict[str, str | None]:
+    """worker 进程内读 BLAS 相关 env vars（top-level 才 picklable）。"""
+    keys = (
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    )
+    return {k: os.environ.get(k) for k in keys}
+
+
+def test_worker_init_sets_blas_thread_limits() -> None:
+    """spawn worker 内 5 个 BLAS 线程 env vars 都被 setdefault 为 "1"。
+
+    Why: 避免 N worker × M BLAS thread 超额抢核（ADR-0025 §C2 后续护栏）。
+    """
+    pool = init_pool(_make_settings(pool_size=1))
+    assert pool is not None
+    env = pool.submit(_get_blas_env).result(timeout=15)
+    for key, val in env.items():
+        assert val == "1", f"{key}={val!r}, expected '1'"
+
+
+def test_worker_init_respects_external_blas_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """用 setdefault 不是 = —— 用户显式 OMP=2 时尊重外部值。"""
+    monkeypatch.setenv("OMP_NUM_THREADS", "2")
+    pool = init_pool(_make_settings(pool_size=1))
+    assert pool is not None
+    env = pool.submit(_get_blas_env).result(timeout=15)
+    assert env["OMP_NUM_THREADS"] == "2"
+    # 其余未显式设的仍 default 为 "1"
+    assert env["MKL_NUM_THREADS"] == "1"
+
+
 def test_pool_runs_engine_with_buy_and_hold() -> None:
     """端到端：ProcessPool 跑一次 buy_and_hold backtest 返 BacktestReport。"""
     pool = init_pool(_make_settings(pool_size=2))

--- a/services/research/src/inalpha_research/analysts/macro.py
+++ b/services/research/src/inalpha_research/analysts/macro.py
@@ -55,7 +55,13 @@ Therefore you MUST NOT:
 - Quote specific numbers / percentages / pip moves for any indicator unless
   they appear verbatim in the user prompt's calendar/news section.
 - Treat past dates in the calendar as "already-released with known results" —
-  the calendar entries are forward-looking schedule; outcomes are NOT included.
+  the calendar entries (both past_macro_events_last_14d and
+  upcoming_macro_events_next_14d) are NAMES + DATES only; outcomes are NOT
+  included for either group. For past events you know they HAVE happened, but
+  you DO NOT know the surprise direction.
+- Refer to past_macro_events_last_14d events with PAST tense ("CPI was
+  released on ..."), NEVER with "即将" / "upcoming" / "this week" phrasing.
+  Refer to upcoming_macro_events_next_14d with FUTURE / conditional phrasing.
 
 You MAY:
 - Describe **regime / risk framing** based on the event schedule ("CPI release
@@ -173,14 +179,35 @@ def _format_user_prompt(
     market_type: str,
     macro_news: list[dict[str, Any]],
 ) -> str:
-    if events:
-        ev_lines = "\n".join(
+    # 按 as_of 把事件拆成 past / upcoming —— 避免 LLM 把 14 天前已发生的 CPI 说成"即将"
+    as_of_date = as_of.date()
+    past_events: list[dict[str, Any]] = []
+    upcoming_events: list[dict[str, Any]] = []
+    for ev in events:
+        try:
+            ev_date = datetime.fromisoformat(str(ev.get("date"))).date()
+        except (ValueError, TypeError):
+            continue
+        (past_events if ev_date < as_of_date else upcoming_events).append(ev)
+
+    def _fmt(evs: list[dict[str, Any]]) -> str:
+        return "\n".join(
             f"  - {e.get('date')} | {e.get('name')} | impact={e.get('impact')} | {e.get('note')}"
-            for e in events
+            for e in evs
         )
-        ev_block = f"upcoming_macro_events (calendar, NAMES ONLY — no outcomes):\n{ev_lines}"
-    else:
-        ev_block = "upcoming_macro_events: (none in ±14d window)"
+
+    past_block = (
+        f"past_macro_events_last_14d (calendar, NAMES ONLY — outcomes NOT included, "
+        f"do NOT invent surprise direction):\n{_fmt(past_events)}"
+        if past_events
+        else "past_macro_events_last_14d: (none)"
+    )
+    upcoming_block = (
+        f"upcoming_macro_events_next_14d (calendar, NAMES ONLY — no outcomes):\n{_fmt(upcoming_events)}"
+        if upcoming_events
+        else "upcoming_macro_events_next_14d: (none)"
+    )
+    ev_block = f"{past_block}\n\n{upcoming_block}"
 
     if macro_news:
         news_lines = ["live_macro_news (SPY-proxy headlines, newest first):"]

--- a/services/research/src/inalpha_research/api/deep_dive.py
+++ b/services/research/src/inalpha_research/api/deep_dive.py
@@ -38,6 +38,9 @@ async def post_deep_dive(
         base_url=settings.llm_base_url,
         model=settings.llm_model,
         timeout_seconds=settings.llm_timeout_seconds,
+        max_concurrent=settings.llm_max_concurrent,
+        max_retries=settings.llm_max_retries,
+        retry_base_seconds=settings.llm_retry_base_seconds,
     )
 
     try:

--- a/services/research/src/inalpha_research/config.py
+++ b/services/research/src/inalpha_research/config.py
@@ -49,6 +49,30 @@ class ResearchSettings(BaseSettings):
         alias="LLM_TIMEOUT_SECONDS",
         description="单次 LLM 调用超时（秒）",
     )
+    llm_max_concurrent: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        alias="LLM_MAX_CONCURRENT",
+        description="单个 LLM client 实例的并发上限（asyncio.Semaphore）。"
+        "Deep dive 5 analyst + Bull/Bear + manager 共享同一 client，默认 5 不阻塞单链路；"
+        "D-9 swarm grid×N 会把多个 deep dive 串起来跑，超额时第 N+1 个调用排队等放行。",
+    )
+    llm_max_retries: int = Field(
+        default=3,
+        ge=0,
+        le=10,
+        alias="LLM_MAX_RETRIES",
+        description="LLM 调用因可重试错误（RateLimitError / APITimeoutError / InternalServerError）"
+        "失败时的最大重试次数。0 = 不重试。",
+    )
+    llm_retry_base_seconds: float = Field(
+        default=1.0,
+        ge=0.1,
+        le=30.0,
+        alias="LLM_RETRY_BASE_SECONDS",
+        description="指数退避基础间隔（秒），实际退避 = base * 2^attempt + jitter。",
+    )
 
     # ─── Debate ──────────────────────────────────────────────────────
     max_debate_rounds: int = Field(

--- a/services/research/src/inalpha_research/llm/client.py
+++ b/services/research/src/inalpha_research/llm/client.py
@@ -13,11 +13,16 @@
 """
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
+import random
 from collections.abc import Mapping
 from typing import Any, Protocol
 
 from inalpha_shared.errors import InalphaError
+
+logger = logging.getLogger(__name__)
 
 
 class LLMError(InalphaError):
@@ -55,6 +60,14 @@ class DeepSeekLLMClient:
     """走 DeepSeek API（OpenAI 兼容）。
 
     用 openai-python SDK 是因为 DeepSeek 文档明确推荐这条路，且文件少。
+
+    并发与重试护栏（D-9）：
+
+    - ``max_concurrent``：实例级 ``asyncio.Semaphore``。同一 client 被 5 analyst +
+      Bull/Bear + manager 共享 → 限流放这里就够，不需要单独 wrapper
+    - ``max_retries``：对 ``RateLimitError / APITimeoutError / InternalServerError``
+      指数退避重试；其他异常（认证 / 400 / json parse）直接抛 ``LLMError`` 不重试
+    - 退避公式：``base * 2^attempt + uniform(0, base*0.5)`` 抖动，避免雪崩同步
     """
 
     def __init__(
@@ -64,6 +77,9 @@ class DeepSeekLLMClient:
         base_url: str = "https://api.deepseek.com/v1",
         model: str = "deepseek-chat",
         timeout_seconds: float = 60.0,
+        max_concurrent: int = 5,
+        max_retries: int = 3,
+        retry_base_seconds: float = 1.0,
     ) -> None:
         if not api_key:
             raise ValueError("DeepSeekLLMClient: api_key is required")
@@ -76,6 +92,63 @@ class DeepSeekLLMClient:
             timeout=timeout_seconds,
         )
         self._model = model
+        self._semaphore = asyncio.Semaphore(max_concurrent)
+        self._max_retries = max_retries
+        self._retry_base_seconds = retry_base_seconds
+
+    async def _call_with_retry(
+        self,
+        *,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+    ) -> Any:
+        """实际 SDK 调用，对可重试错误指数退避。
+
+        可重试：``RateLimitError``（429）/ ``APITimeoutError`` / ``InternalServerError``（5xx）。
+        不重试：``AuthenticationError`` / ``BadRequestError`` / ``LLMError`` 等。
+        """
+        from openai import APITimeoutError, InternalServerError, RateLimitError
+
+        retriable = (RateLimitError, APITimeoutError, InternalServerError)
+        last_err: Exception | None = None
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                return await self._client.chat.completions.create(
+                    model=self._model,
+                    messages=messages,  # type: ignore[arg-type]
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    response_format={"type": "json_object"},
+                )
+            except retriable as e:
+                last_err = e
+                if attempt >= self._max_retries:
+                    break
+                backoff = self._retry_base_seconds * (2**attempt)
+                jitter = random.uniform(0, self._retry_base_seconds * 0.5)
+                sleep_s = backoff + jitter
+                logger.warning(
+                    "LLM retriable error (attempt %d/%d): %s; sleeping %.2fs",
+                    attempt + 1,
+                    self._max_retries + 1,
+                    type(e).__name__,
+                    sleep_s,
+                )
+                await asyncio.sleep(sleep_s)
+
+        # 走到这说明可重试错误把次数用光
+        assert last_err is not None
+        raise LLMError(
+            f"DeepSeek API call failed after {self._max_retries + 1} attempts: {last_err}",
+            code="LLM_PROVIDER_ERROR",
+            details={
+                "provider": "deepseek",
+                "model": self._model,
+                "error_type": type(last_err).__name__,
+            },
+        ) from last_err
 
     async def complete_json(
         self,
@@ -85,23 +158,27 @@ class DeepSeekLLMClient:
         max_tokens: int = 2048,
         temperature: float = 0.2,
     ) -> dict[str, Any]:
-        try:
-            r = await self._client.chat.completions.create(
-                model=self._model,
-                messages=[
-                    {"role": "system", "content": system},
-                    {"role": "user", "content": user},
-                ],
-                temperature=temperature,
-                max_tokens=max_tokens,
-                response_format={"type": "json_object"},
-            )
-        except Exception as e:
-            raise LLMError(
-                f"DeepSeek API call failed: {e}",
-                code="LLM_PROVIDER_ERROR",
-                details={"provider": "deepseek", "model": self._model},
-            ) from e
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+
+        async with self._semaphore:
+            try:
+                r = await self._call_with_retry(
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
+            except LLMError:
+                # _call_with_retry 已经包过了，原样抛
+                raise
+            except Exception as e:
+                raise LLMError(
+                    f"DeepSeek API call failed: {e}",
+                    code="LLM_PROVIDER_ERROR",
+                    details={"provider": "deepseek", "model": self._model},
+                ) from e
 
         choices = r.choices
         if not choices:
@@ -205,12 +282,17 @@ def build_llm_client(
     base_url: str,
     model: str,
     timeout_seconds: float,
+    max_concurrent: int = 5,
+    max_retries: int = 3,
+    retry_base_seconds: float = 1.0,
 ) -> LLMClient:
     """按 settings 构造 LLM client。
 
     ``provider``:
-    - ``"deepseek"``：真 DeepSeek API（require api_key）
-    - ``"fake"``：返空 FakeLLMClient —— 没注 response 就抛错，**不要在生产用**
+    - ``"deepseek"``：真 DeepSeek API（require api_key）；新增 ``max_concurrent /
+      max_retries / retry_base_seconds`` 由 ``ResearchSettings`` 控制护栏
+    - ``"fake"``：返空 FakeLLMClient —— 没注 response 就抛错，**不要在生产用**；
+      不接收护栏参数（测试不需要限流和退避）
     """
     p = provider.lower()
     if p == "deepseek":
@@ -219,6 +301,9 @@ def build_llm_client(
             base_url=base_url,
             model=model,
             timeout_seconds=timeout_seconds,
+            max_concurrent=max_concurrent,
+            max_retries=max_retries,
+            retry_base_seconds=retry_base_seconds,
         )
     if p == "fake":
         return FakeLLMClient()

--- a/services/research/src/inalpha_research/researchers/__init__.py
+++ b/services/research/src/inalpha_research/researchers/__init__.py
@@ -1,0 +1,18 @@
+"""Bull/Bear researcher 与辩论协调器。
+
+辩论是 5 个 analyst 出完 brief 之后的环节：让 Bull / Bear 两个 LLM 角色
+**轮换发言**，每轮可以读到对方上一轮论点 + 全部 5 个 analyst brief。
+最终把发言序列（``list[DebateTurn]``）传给 Manager 做综合 rating。
+
+灵感：``TauricResearch/TradingAgents`` 的 ``InvestDebateState`` 双方对喷拓扑，
+去掉 LangGraph 依赖、用纯 asyncio 协调（保持 Inalpha 的极简栈）。
+"""
+from .base import Researcher
+from .bear import BearResearcher
+from .bull import BullResearcher
+
+__all__ = [
+    "BearResearcher",
+    "BullResearcher",
+    "Researcher",
+]

--- a/services/research/src/inalpha_research/researchers/base.py
+++ b/services/research/src/inalpha_research/researchers/base.py
@@ -193,9 +193,18 @@ def _format_user_prompt(
     对方上一轮发言（如有）。
     """
     parts: list[str] = [
+        "⚠️ TIME ANCHOR — read before anything else:",
+        f"  as_of = {as_of.isoformat()} — this is the REAL wall-clock NOW.",
+        "  Your training cutoff is earlier than as_of. Any event your training "
+        "data labels as 'upcoming' that has a date < as_of is already HISTORY — "
+        "do NOT write '即将' / 'upcoming' / 'next week' about it.",
+        "  Do NOT cite specific calendar dates (CPI prints, FOMC meetings, "
+        "earnings, halvings, elections, etc.) UNLESS that exact date appears in "
+        "an analyst_brief below. If you need to reference an event that's not in "
+        "the briefs, say 'the briefs do not cover this' instead of guessing.",
+        "",
         f"asset: {symbol} @ {venue}",
         f"timeframe: {timeframe}",
-        f"as_of: {as_of.isoformat()}",
         f"debate_round: {round_no}",
         f"your_role: {role}",
         "",

--- a/services/research/src/inalpha_research/researchers/base.py
+++ b/services/research/src/inalpha_research/researchers/base.py
@@ -1,0 +1,234 @@
+"""Bull/Bear 共同基类 —— 输入 analyst briefs + 辩论 history，输出本轮发言文本。
+
+跟 ``analysts.Analyst`` 的区别：
+
+- analyst 输出**结构化 JSON**（stance / confidence / factors），喂给 manager
+- researcher 输出**自由文本**（一段对喷论证），追加进 ``debate_log``；manager
+  最终读全文做综合
+
+因此 researcher 的 ``LLMClient`` 调用走 ``complete_text``（不存在），暂用
+``complete_json`` 但 prompt 让 LLM 只放一个 ``{"argument": "..."}``——避免给
+``LLMClient`` Protocol 加新方法引发的耦合扩散。
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Literal
+
+from ..llm.client import LLMClient
+from ..schemas import AnalystBrief, DebateTurn
+
+#: 资产类型 —— 细到能让 prompt 切换"对的术语"，避免在 crypto 上谈 P/E 或在 A 股上谈 halving。
+AssetType = Literal["crypto", "us_stock", "cn_stock", "hk_stock", "global_stock"]
+
+
+class Researcher(ABC):
+    """Bull / Bear researcher 共同接口。"""
+
+    #: 角色字符串，落进 ``DebateTurn.role``。子类必须 override。
+    role: Literal["bull", "bear"] = "bull"
+
+    def __init__(self, *, llm: LLMClient) -> None:
+        self._llm = llm
+
+    @abstractmethod
+    def system_prompt(self, *, asset_type: AssetType) -> str:
+        """子类返回自己的 system prompt；``asset_type`` 由 venue + symbol 推断。"""
+
+    async def speak(
+        self,
+        *,
+        venue: str,
+        symbol: str,
+        timeframe: str,
+        as_of: datetime,
+        briefs: list[AnalystBrief],
+        history: list[DebateTurn],
+        round_no: int,
+    ) -> str:
+        """跑一轮发言。返回 LLM 给出的论证文本。"""
+        asset_type = infer_asset_type(venue=venue, symbol=symbol)
+        system = self.system_prompt(asset_type=asset_type)
+        user = _format_user_prompt(
+            role=self.role,
+            venue=venue,
+            symbol=symbol,
+            timeframe=timeframe,
+            as_of=as_of,
+            briefs=briefs,
+            history=history,
+            round_no=round_no,
+        )
+        raw = await self._llm.complete_json(system=system, user=user)
+        argument = str(raw.get("argument", "")).strip()
+        if not argument:
+            argument = "(empty argument from LLM)"
+        return argument
+
+
+#: crypto 交易所识别集合 —— 在 services/data 的 binance/okx/... 加入 CCXT
+#: 时同步扩这里。
+_CRYPTO_VENUES = frozenset(
+    {"binance", "okx", "bybit", "coinbase", "kraken", "huobi", "bitfinex", "bitstamp", "gate"}
+)
+
+#: yfinance 后缀 → 资产类型映射；未列出的统一归 ``global_stock``。
+#: ``""``（无后缀）→ 美股；``^``（指数）→ ``global_stock`` 由调用方处理
+_YF_SUFFIX_TO_TYPE: dict[str, AssetType] = {
+    ".KS": "global_stock",   # 韩国 KOSPI
+    ".KQ": "global_stock",   # 韩国 KOSDAQ
+    ".T": "global_stock",    # 日本东证
+    ".HK": "hk_stock",       # 港股（yfinance 标识）
+    ".SS": "cn_stock",       # 上证
+    ".SZ": "cn_stock",       # 深证
+    ".L": "global_stock",    # 伦交所
+    ".AX": "global_stock",   # ASX
+    ".NS": "global_stock",   # 印度 NSE
+    ".BO": "global_stock",   # 印度 BSE
+    ".TO": "global_stock",   # 多伦多
+    ".SA": "global_stock",   # 巴西
+    ".PA": "global_stock",   # 巴黎
+    ".DE": "global_stock",   # 法兰克福
+    ".F": "global_stock",    # 法兰克福备用
+}
+
+
+def infer_asset_type(*, venue: str, symbol: str = "") -> AssetType:
+    """venue + symbol 二维推断资产类型。
+
+    优先级：crypto venue > venue 显式映射 > symbol 后缀（yfinance 用）> 兜底 ``global_stock``。
+
+    例：
+
+    - ``binance`` + ``BTC/USDT`` → ``crypto``
+    - ``alpaca`` + ``AAPL``      → ``us_stock``
+    - ``akshare`` + ``sh.600519`` → ``cn_stock``
+    - ``akshare`` + ``hk.00700``  → ``hk_stock``
+    - ``akshare`` + ``jp.6758``   → ``global_stock``（日股目前归全球桶）
+    - ``yfinance`` + ``005930.KS`` → ``global_stock``
+    - ``yfinance`` + ``AAPL``      → ``us_stock``（无后缀视为美股）
+    - ``yfinance`` + ``^N225``     → ``global_stock``（指数）
+    """
+    v = venue.lower()
+    if v in _CRYPTO_VENUES:
+        return "crypto"
+
+    if v == "alpaca":
+        return "us_stock"
+
+    if v == "akshare":
+        s = symbol.lower()
+        if s.startswith(("sh.", "sz.")):
+            return "cn_stock"
+        if s.startswith("hk."):
+            return "hk_stock"
+        # jp / uk / de 等
+        return "global_stock"
+
+    if v == "yfinance":
+        if symbol.startswith("^"):
+            return "global_stock"  # 指数
+        if "." not in symbol:
+            return "us_stock"  # 无后缀：AAPL / MSFT / SPY
+        # 找后缀
+        for suffix, atype in _YF_SUFFIX_TO_TYPE.items():
+            if symbol.endswith(suffix):
+                return atype
+        return "global_stock"
+
+    return "global_stock"
+
+
+def fundamental_note_for(asset_type: AssetType) -> str:
+    """给 bull/bear/fundamental prompt 用：返回该资产类型的"基本面术语锚点"。
+
+    让 LLM 在 prompt 框定的范围内选词——美股谈 10-K，A股谈年报，crypto 谈 on-chain。
+    """
+    if asset_type == "crypto":
+        return (
+            "Asset fundamentals (crypto): on-chain flows, supply schedule / unlocks, "
+            "halving cycle phase, exchange reserves, stablecoin liquidity, narrative "
+            "adoption (L2 / RWA / etc.)"
+        )
+    if asset_type == "us_stock":
+        return (
+            "Company fundamentals (US equity): 10-K / 10-Q segment revenue, EPS / "
+            "forward guidance, gross margin trend, FCF, share buyback / dilution, "
+            "analyst consensus revisions"
+        )
+    if asset_type == "cn_stock":
+        return (
+            "Company fundamentals (A-share): 年报 / 季报 ROE / 毛利率 / 净利率, sector "
+            "policy (industrial / regulatory), retail flow vs 北向资金, supply chain "
+            "exposure to USD / commodity prices"
+        )
+    if asset_type == "hk_stock":
+        return (
+            "Company fundamentals (HK equity): interim / annual report, Southbound 资金 "
+            "flow, dual-listing arbitrage vs A-share, regulatory exposure (HKMA / mainland), "
+            "USD-peg / HKD-rates linkage"
+        )
+    # global_stock fallback
+    return (
+        "Company fundamentals (global equity): annual / interim report, segment growth, "
+        "FX exposure, local regulatory / policy context, sector-relative valuation"
+    )
+
+
+def _format_user_prompt(
+    *,
+    role: Literal["bull", "bear"],
+    venue: str,
+    symbol: str,
+    timeframe: str,
+    as_of: datetime,
+    briefs: list[AnalystBrief],
+    history: list[DebateTurn],
+    round_no: int,
+) -> str:
+    """渲染给 Bull/Bear 的 user prompt。
+
+    包含：标的 + as_of + 5 个 analyst brief 摘要 + 完整辩论 history +
+    对方上一轮发言（如有）。
+    """
+    parts: list[str] = [
+        f"asset: {symbol} @ {venue}",
+        f"timeframe: {timeframe}",
+        f"as_of: {as_of.isoformat()}",
+        f"debate_round: {round_no}",
+        f"your_role: {role}",
+        "",
+        "analyst_briefs:",
+    ]
+    for b in briefs:
+        kp = "; ".join(b.key_points[:3]) if b.key_points else "(no key points)"
+        parts.append(
+            f"  [{b.analyst}] stance={b.stance} conf={b.confidence:.2f} "
+            f"summary={b.summary} | top_points: {kp}"
+        )
+
+    if history:
+        parts.append("")
+        parts.append("debate_history (oldest first):")
+        for turn in history:
+            parts.append(f"  Round {turn.round} {turn.role.upper()}: {turn.content}")
+        last_opponent = next(
+            (t for t in reversed(history) if t.role != role),
+            None,
+        )
+        if last_opponent is not None:
+            parts.append("")
+            parts.append(
+                f"opponent_last_turn (rebut this directly!): {last_opponent.content}"
+            )
+    else:
+        parts.append("")
+        parts.append("debate_history: (this is the first turn — make your opening case)")
+
+    parts.append("")
+    parts.append(
+        'Output ONLY a JSON object: {"argument": "<your full argument as one paragraph, '
+        '180-280 words>"}. Do not add any other top-level keys.'
+    )
+    return "\n".join(parts)

--- a/services/research/src/inalpha_research/researchers/bear.py
+++ b/services/research/src/inalpha_research/researchers/bear.py
@@ -1,0 +1,58 @@
+"""Bear Researcher —— 看空方发言人。
+
+读 5 个 analyst brief + 辩论史 + Bull 上一轮（若有）→ 输出一段看空论证。
+风格借鉴 TradingAgents/bear_researcher.py，4 类资产识别。
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from .base import AssetType, Researcher, fundamental_note_for
+
+_ASSET_LABEL: dict[AssetType, str] = {
+    "crypto": "asset",
+    "us_stock": "stock",
+    "cn_stock": "A-share / 个股",
+    "hk_stock": "HK stock / 港股",
+    "global_stock": "stock",
+}
+
+
+def _system_template(asset_type: AssetType) -> str:
+    asset_word = _ASSET_LABEL[asset_type]
+    fundamental_note = fundamental_note_for(asset_type)
+    return f"""
+You are a Bear Analyst making the case against long exposure in the {asset_word}.
+Your task is to present a well-reasoned bearish case — emphasizing downside,
+fragility, and negative indicators.
+
+Key points to focus on:
+- Downside drivers: macro headwinds, supply pressure, valuation stretch, weak demand
+- Risk signals: vol spikes, deep drawdowns, fragile structure, capitulation risk
+- Negative indicators: {fundamental_note}, sentiment euphoria as contrarian top signal
+- Bull counterpoints: when you see a Bull argument in the history, address it directly
+  with data from the analyst briefs — expose over-optimism or cherry-picking
+- Engagement: write as if speaking in a debate — concise, persuasive, rebut specifics
+
+Style rules:
+- One paragraph, 180–280 words, no bullet lists
+- Anchor every claim to a specific analyst brief or factor (e.g. "the risk analyst's
+  ATR/close at 4.2% — well in the high-vol zone", "the sentiment FNG at 82 — extreme greed")
+- Do not invent data not present in the briefs
+- If the briefs are uniformly bullish, still steelman the short case — your job is to
+  expose what bulls might be missing, not to flip stance
+
+Return ONLY a JSON object:
+{{"argument": "<your full bearish argument as one paragraph>"}}
+
+Do not add any other keys.
+""".strip()
+
+
+class BearResearcher(Researcher):
+    """看空 researcher。"""
+
+    role: Literal["bull", "bear"] = "bear"
+
+    def system_prompt(self, *, asset_type: AssetType) -> str:
+        return _system_template(asset_type)

--- a/services/research/src/inalpha_research/researchers/bear.py
+++ b/services/research/src/inalpha_research/researchers/bear.py
@@ -39,6 +39,10 @@ Style rules:
 - Anchor every claim to a specific analyst brief or factor (e.g. "the risk analyst's
   ATR/close at 4.2% — well in the high-vol zone", "the sentiment FNG at 82 — extreme greed")
 - Do not invent data not present in the briefs
+- HARD: do NOT cite specific calendar dates for macro / event-driven items
+  from your training memory. Your training cutoff is earlier than `as_of`,
+  so what was "upcoming" in your training is now history. Reference such
+  events only if they appear in an analyst_brief with their date.
 - If the briefs are uniformly bullish, still steelman the short case — your job is to
   expose what bulls might be missing, not to flip stance
 

--- a/services/research/src/inalpha_research/researchers/bull.py
+++ b/services/research/src/inalpha_research/researchers/bull.py
@@ -1,0 +1,59 @@
+"""Bull Researcher —— 看多方发言人。
+
+读 5 个 analyst brief + 辩论史 + Bear 上一轮（若有）→ 输出一段看多论证。
+风格借鉴 TradingAgents/bull_researcher.py，用 Inalpha 的 4 类资产识别版本
+（``asset_type`` 在 prompt 里自适应 crypto / us_stock / cn_stock / hk_stock / global_stock）。
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from .base import AssetType, Researcher, fundamental_note_for
+
+_ASSET_LABEL: dict[AssetType, str] = {
+    "crypto": "asset",
+    "us_stock": "stock",
+    "cn_stock": "A-share / 个股",
+    "hk_stock": "HK stock / 港股",
+    "global_stock": "stock",
+}
+
+
+def _system_template(asset_type: AssetType) -> str:
+    asset_word = _ASSET_LABEL[asset_type]
+    fundamental_note = fundamental_note_for(asset_type)
+    return f"""
+You are a Bull Analyst advocating for taking long exposure in the {asset_word}.
+Your task is to build a strong, evidence-based bullish case — emphasizing
+upside, structural tailwinds, and positive indicators.
+
+Key points to focus on:
+- Upside drivers: growth potential / supply tightness / adoption / macro tailwinds
+- Strength signals: positive momentum, healthy structure, accumulating capital
+- Positive indicators: {fundamental_note}
+- Bear counterpoints: when you see a Bear argument in the history, address it directly
+  with data from the analyst briefs — don't ignore it
+- Engagement: write as if speaking in a debate — concise, persuasive, rebut specifics
+
+Style rules:
+- One paragraph, 180–280 words, no bullet lists
+- Anchor every claim to a specific analyst brief or factor (e.g. "the technical
+  analyst's RSI 32 reading", "the macro analyst's dovish FOMC outlook")
+- Do not invent data not present in the briefs
+- If the briefs are uniformly bearish, still steelman the long case — your job
+  is to expose what bears might be missing, not to flip stance
+
+Return ONLY a JSON object:
+{{"argument": "<your full bullish argument as one paragraph>"}}
+
+Do not add any other keys.
+""".strip()
+
+
+class BullResearcher(Researcher):
+    """看多 researcher。"""
+
+    role: Literal["bull", "bear"] = "bull"
+
+    def system_prompt(self, *, asset_type: AssetType) -> str:
+        return _system_template(asset_type)

--- a/services/research/src/inalpha_research/researchers/bull.py
+++ b/services/research/src/inalpha_research/researchers/bull.py
@@ -40,6 +40,10 @@ Style rules:
 - Anchor every claim to a specific analyst brief or factor (e.g. "the technical
   analyst's RSI 32 reading", "the macro analyst's dovish FOMC outlook")
 - Do not invent data not present in the briefs
+- HARD: do NOT cite specific calendar dates for macro / event-driven items
+  from your training memory. Your training cutoff is earlier than `as_of`,
+  so what was "upcoming" in your training is now history. Reference such
+  events only if they appear in an analyst_brief with their date.
 - If the briefs are uniformly bearish, still steelman the long case — your job
   is to expose what bears might be missing, not to flip stance
 

--- a/services/research/tests/test_analysts.py
+++ b/services/research/tests/test_analysts.py
@@ -447,4 +447,6 @@ async def test_macro_handles_no_events_in_window(data_client: DataClient) -> Non
 
     assert brief.stance == "neutral"
     user_prompt = llm.calls[0]["user"]
-    assert "(none in ±14d window)" in user_prompt
+    # D-9：events 拆 past / upcoming 后，空窗口表现为两组分别 "(none)"
+    assert "past_macro_events_last_14d: (none)" in user_prompt
+    assert "upcoming_macro_events_next_14d: (none)" in user_prompt

--- a/services/research/tests/test_debate.py
+++ b/services/research/tests/test_debate.py
@@ -1,0 +1,233 @@
+"""辩论协调器单测 —— 不打外部网络，用 FakeLLMClient 跑 Bull/Bear 轮换。"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from inalpha_research.debate import run_debate
+from inalpha_research.llm.client import FakeLLMClient
+from inalpha_research.researchers import BearResearcher, BullResearcher
+from inalpha_research.schemas import AnalystBrief
+
+
+def _as_of() -> datetime:
+    return datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _brief(analyst: str, stance: str = "neutral") -> AnalystBrief:
+    return AnalystBrief(
+        analyst=analyst,  # type: ignore[arg-type]
+        stance=stance,  # type: ignore[arg-type]
+        confidence=0.5,
+        summary=f"{analyst} brief",
+        key_points=[f"{analyst} kp1"],
+    )
+
+
+def _bull_bear_llm() -> FakeLLMClient:
+    return FakeLLMClient(
+        {
+            "you are a bull analyst": {"argument": "Bull says up"},
+            "you are a bear analyst": {"argument": "Bear says down"},
+        }
+    )
+
+
+async def test_run_debate_zero_rounds_returns_empty() -> None:
+    """``max_rounds=0`` 时不调 LLM，直接返空 log（runner 旁路场景）。"""
+    llm = _bull_bear_llm()
+    bull = BullResearcher(llm=llm)
+    bear = BearResearcher(llm=llm)
+
+    log = await run_debate(
+        bull=bull,
+        bear=bear,
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical", "bullish")],
+        max_rounds=0,
+    )
+
+    assert log == []
+    assert llm.calls == []
+
+
+async def test_run_debate_one_round_alternates_bull_then_bear() -> None:
+    llm = _bull_bear_llm()
+    bull = BullResearcher(llm=llm)
+    bear = BearResearcher(llm=llm)
+
+    log = await run_debate(
+        bull=bull,
+        bear=bear,
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical", "bullish"), _brief("risk", "neutral")],
+        max_rounds=1,
+    )
+
+    assert len(log) == 2
+    assert log[0].role == "bull"
+    assert log[0].round == 1
+    assert log[0].content == "Bull says up"
+    assert log[1].role == "bear"
+    assert log[1].round == 1
+    assert log[1].content == "Bear says down"
+
+    # Bull 第一轮 user prompt 不应含"opponent_last_turn"（第一发言）
+    bull_call = next(c for c in llm.calls if "bull analyst" in c["system"].lower())
+    assert "opponent_last_turn" not in bull_call["user"]
+
+    # Bear 这次应该看到 Bull 上一轮（rebut）
+    bear_call = next(c for c in llm.calls if "bear analyst" in c["system"].lower())
+    assert "opponent_last_turn" in bear_call["user"]
+    assert "Bull says up" in bear_call["user"]
+
+
+async def test_run_debate_multi_round_grows_history() -> None:
+    """2 轮 = 4 turns，且第 2 轮 Bull 应看到 Round1 Bear。"""
+    llm = _bull_bear_llm()
+    bull = BullResearcher(llm=llm)
+    bear = BearResearcher(llm=llm)
+
+    log = await run_debate(
+        bull=bull,
+        bear=bear,
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        max_rounds=2,
+    )
+
+    assert [(t.role, t.round) for t in log] == [
+        ("bull", 1),
+        ("bear", 1),
+        ("bull", 2),
+        ("bear", 2),
+    ]
+
+    # 4 次 LLM 调用
+    assert len(llm.calls) == 4
+    # 第 3 次（Round 2 Bull）应该看到 Round 1 Bear 的发言
+    bull_round2 = llm.calls[2]
+    assert "bull analyst" in bull_round2["system"].lower()
+    assert "Bear says down" in bull_round2["user"]
+    assert "Round 1 BEAR" in bull_round2["user"]
+
+
+async def test_run_debate_swallows_researcher_failure() -> None:
+    """LLM 抛错时辩论不中断，落"(researcher failed)"占位继续。"""
+    llm = FakeLLMClient(
+        {
+            "you are a bull analyst": {"argument": "Bull ok"},
+            # 没给 Bear 预设 → FakeLLMClient 抛 LLMError
+        }
+    )
+    bull = BullResearcher(llm=llm)
+    bear = BearResearcher(llm=llm)
+
+    log = await run_debate(
+        bull=bull,
+        bear=bear,
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        max_rounds=1,
+    )
+
+    assert len(log) == 2
+    assert log[0].content == "Bull ok"
+    assert "(researcher failed:" in log[1].content
+    assert "LLM_FAKE_NO_MATCH" in log[1].content or "LLMError" in log[1].content
+
+
+async def test_researcher_speak_empty_argument_falls_back() -> None:
+    """LLM 返空 argument 字段时不应让 ResearcherTurn.content 校验炸（min_length=1）。"""
+    llm = FakeLLMClient({"you are a bull analyst": {"argument": ""}})
+    bull = BullResearcher(llm=llm)
+
+    text = await bull.speak(
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        history=[],
+        round_no=1,
+    )
+    assert text == "(empty argument from LLM)"
+
+
+async def test_researcher_speak_handles_missing_response_key() -> None:
+    """LLM 返没有 argument key 的 JSON 时也兜底为占位文本。"""
+    llm = FakeLLMClient({"you are a bear analyst": {"foo": "bar"}})
+    bear = BearResearcher(llm=llm)
+
+    text = await bear.speak(
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        history=[],
+        round_no=1,
+    )
+    assert text == "(empty argument from LLM)"
+
+
+def test_bull_system_prompt_adjusts_for_crypto_vs_stock() -> None:
+    """Bull system prompt 在 5 类资产下文案不同（fundamental_note 切换）。"""
+    bull = BullResearcher(llm=FakeLLMClient())
+    crypto_prompt = bull.system_prompt(asset_type="crypto")
+    us_prompt = bull.system_prompt(asset_type="us_stock")
+    cn_prompt = bull.system_prompt(asset_type="cn_stock")
+    hk_prompt = bull.system_prompt(asset_type="hk_stock")
+
+    # crypto 谈 on-chain / halving，不谈 10-K / 年报
+    assert "on-chain" in crypto_prompt or "halving" in crypto_prompt
+    assert "10-K" not in crypto_prompt and "年报" not in crypto_prompt
+
+    # 美股谈 10-K / EPS
+    assert "10-K" in us_prompt or "EPS" in us_prompt
+    assert "halving" not in us_prompt
+
+    # A 股谈年报 / 北向
+    assert "年报" in cn_prompt or "北向" in cn_prompt
+    assert "halving" not in cn_prompt
+
+    # 港股谈 Southbound / 互联互通
+    assert "Southbound" in hk_prompt or "HKMA" in hk_prompt
+
+
+def test_infer_asset_type_classifies_all_venues() -> None:
+    """覆盖 5 类资产的 venue+symbol 路由。"""
+    from inalpha_research.researchers.base import infer_asset_type
+
+    # crypto
+    assert infer_asset_type(venue="binance", symbol="BTC/USDT") == "crypto"
+    assert infer_asset_type(venue="okx", symbol="ETH/USDT") == "crypto"
+    # 美股
+    assert infer_asset_type(venue="alpaca", symbol="AAPL") == "us_stock"
+    assert infer_asset_type(venue="yfinance", symbol="AAPL") == "us_stock"
+    assert infer_asset_type(venue="yfinance", symbol="SPY") == "us_stock"
+    # A 股
+    assert infer_asset_type(venue="akshare", symbol="sh.600519") == "cn_stock"
+    assert infer_asset_type(venue="akshare", symbol="sz.000001") == "cn_stock"
+    # 港股
+    assert infer_asset_type(venue="akshare", symbol="hk.00700") == "hk_stock"
+    # 日 / 英 / 德（akshare 归 global_stock）
+    assert infer_asset_type(venue="akshare", symbol="jp.6758") == "global_stock"
+    assert infer_asset_type(venue="akshare", symbol="uk.BARC") == "global_stock"
+    # yfinance 后缀路由
+    assert infer_asset_type(venue="yfinance", symbol="005930.KS") == "global_stock"  # 韩
+    assert infer_asset_type(venue="yfinance", symbol="BHP.AX") == "global_stock"  # 澳
+    assert infer_asset_type(venue="yfinance", symbol="^N225") == "global_stock"  # 指数
+    # 未知 venue 兜底
+    assert infer_asset_type(venue="unknown", symbol="X") == "global_stock"

--- a/services/research/tests/test_llm_client.py
+++ b/services/research/tests/test_llm_client.py
@@ -1,9 +1,14 @@
 """LLM client 抽象层单测。"""
 from __future__ import annotations
 
+import asyncio
+import json
+from typing import Any
+
 import pytest
 
 from inalpha_research.llm.client import (
+    DeepSeekLLMClient,
     FakeLLMClient,
     LLMError,
     build_llm_client,
@@ -89,3 +94,158 @@ def test_build_deepseek_requires_api_key() -> None:
             model="deepseek-chat",
             timeout_seconds=1.0,
         )
+
+
+# ────────────────────────────────────────────────────────────────────
+# DeepSeekLLMClient 护栏（D-9）：semaphore 限流 + 退避重试
+# ────────────────────────────────────────────────────────────────────
+
+
+def _make_response(content: str = '{"ok": true}') -> Any:
+    """伪造一个 openai SDK 的 ChatCompletion 形状对象（鸭子类型）。"""
+    msg = type("M", (), {"content": content})()
+    choice = type("C", (), {"message": msg})()
+    return type("R", (), {"choices": [choice]})()
+
+
+def _make_client(
+    *,
+    max_concurrent: int = 5,
+    max_retries: int = 3,
+    retry_base_seconds: float = 0.01,
+) -> DeepSeekLLMClient:
+    """绕过 ``__init__`` 创建 client —— 跳过 openai SDK 真实构造。
+
+    Why: 单测不依赖 openai 网络栈；只验护栏（semaphore / retry / 异常分类）。
+    """
+    c = DeepSeekLLMClient.__new__(DeepSeekLLMClient)
+    c._client = None  # type: ignore[assignment]
+    c._model = "test-model"
+    c._semaphore = asyncio.Semaphore(max_concurrent)
+    c._max_retries = max_retries
+    c._retry_base_seconds = retry_base_seconds
+    return c
+
+
+class _FakeChat:
+    """模拟 ``client.chat.completions.create`` —— 可控行为。"""
+
+    def __init__(
+        self,
+        *,
+        response_content: str = '{"ok": true}',
+        raise_seq: list[Exception] | None = None,
+        track_in_flight: bool = False,
+    ) -> None:
+        self._response_content = response_content
+        self._raise_seq = list(raise_seq or [])
+        self.call_count = 0
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self._track = track_in_flight
+        # mock self.chat.completions.create 链路
+        self.completions = self
+        self.chat = self
+
+    async def create(self, **_kwargs: Any) -> Any:
+        self.call_count += 1
+        if self._track:
+            self.in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self.in_flight)
+            await asyncio.sleep(0.05)
+            self.in_flight -= 1
+        if self._raise_seq:
+            err = self._raise_seq.pop(0)
+            if err is not None:
+                raise err
+        return _make_response(self._response_content)
+
+
+async def test_semaphore_limits_concurrent_calls() -> None:
+    """max_concurrent=2 + 10 个并发调用 → 同时 in-flight 数 ≤ 2。"""
+    c = _make_client(max_concurrent=2, max_retries=0)
+    fake = _FakeChat(track_in_flight=True)
+    c._client = fake  # type: ignore[assignment]
+
+    coros = [c.complete_json(system="s", user="u") for _ in range(10)]
+    results = await asyncio.gather(*coros)
+
+    assert len(results) == 10
+    assert all(r == {"ok": True} for r in results)
+    assert fake.call_count == 10
+    assert fake.max_in_flight <= 2, f"max_in_flight={fake.max_in_flight}, expected ≤ 2"
+
+
+async def test_retriable_error_retries_until_success() -> None:
+    """前 2 次抛 RateLimitError，第 3 次成功 → 总共 3 次调用、最终成功。"""
+    from openai import RateLimitError
+
+    err1 = RateLimitError.__new__(RateLimitError)
+    err2 = RateLimitError.__new__(RateLimitError)
+
+    c = _make_client(max_retries=3, retry_base_seconds=0.01)
+    fake = _FakeChat(raise_seq=[err1, err2, None])  # None = 不抛、返成功
+    c._client = fake  # type: ignore[assignment]
+
+    out = await c.complete_json(system="s", user="u")
+    assert out == {"ok": True}
+    assert fake.call_count == 3
+
+
+async def test_retriable_error_exhausts_retries_then_raises_llm_error() -> None:
+    """所有重试都失败 → 抛 LLMError（包装原异常）、不裸传原 openai 异常。"""
+    from openai import RateLimitError
+
+    errs = [RateLimitError.__new__(RateLimitError) for _ in range(5)]
+    c = _make_client(max_retries=2, retry_base_seconds=0.01)
+    fake = _FakeChat(raise_seq=errs)
+    c._client = fake  # type: ignore[assignment]
+
+    with pytest.raises(LLMError) as ei:
+        await c.complete_json(system="s", user="u")
+    assert ei.value.code == "LLM_PROVIDER_ERROR"
+    # max_retries=2 → 总共 1 + 2 = 3 次调用
+    assert fake.call_count == 3
+
+
+async def test_non_retriable_error_raises_immediately() -> None:
+    """非可重试异常（如 ValueError）→ 不重试、直接包成 LLMError 抛。"""
+    c = _make_client(max_retries=3, retry_base_seconds=0.01)
+    fake = _FakeChat(raise_seq=[ValueError("bad request")])
+    c._client = fake  # type: ignore[assignment]
+
+    with pytest.raises(LLMError) as ei:
+        await c.complete_json(system="s", user="u")
+    assert ei.value.code == "LLM_PROVIDER_ERROR"
+    assert fake.call_count == 1, "non-retriable error must not trigger retries"
+
+
+async def test_invalid_json_raises_llm_invalid_json() -> None:
+    """SDK 成功返回但 content 不是 JSON → 抛 LLM_INVALID_JSON。"""
+    c = _make_client(max_retries=0)
+    fake = _FakeChat(response_content="not json at all")
+    c._client = fake  # type: ignore[assignment]
+
+    with pytest.raises(LLMError) as ei:
+        await c.complete_json(system="s", user="u")
+    assert ei.value.code == "LLM_INVALID_JSON"
+
+
+async def test_max_retries_zero_means_one_attempt_only() -> None:
+    """max_retries=0 → 只跑 1 次、可重试错误不重试。"""
+    from openai import APITimeoutError
+
+    err = APITimeoutError.__new__(APITimeoutError)
+    c = _make_client(max_retries=0, retry_base_seconds=0.01)
+    fake = _FakeChat(raise_seq=[err])
+    c._client = fake  # type: ignore[assignment]
+
+    with pytest.raises(LLMError):
+        await c.complete_json(system="s", user="u")
+    assert fake.call_count == 1
+
+
+# ────────────────────────────────────────────────────────────────────
+# 防 unused import lint
+# ────────────────────────────────────────────────────────────────────
+_ = json  # keep import used (helps type checkers / linters)

--- a/services/research/tests/test_multi_market.py
+++ b/services/research/tests/test_multi_market.py
@@ -1,0 +1,209 @@
+"""5 类 analyst 的 multi-market 感知测试（D-9 升级）。
+
+覆盖：
+
+- 每个 analyst 的 user prompt 都含 ``market_type`` 字段
+- sentiment 在非 crypto 不调 ``alternative.me/fng/``（走 LLM-only）
+- risk system prompt 含 5 类 vol band 表
+- macro system prompt 含传导表
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import respx
+from httpx import Response
+
+from inalpha_research.analysts.macro import MacroAnalyst
+from inalpha_research.analysts.risk import RiskAnalyst
+from inalpha_research.analysts.sentiment import SentimentAnalyst
+from inalpha_research.analysts.technical import TechnicalAnalyst
+from inalpha_research.data_client import DataClient
+from inalpha_research.llm.client import FakeLLMClient
+
+from .conftest import make_bar_row
+
+
+def _as_of() -> datetime:
+    return datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+def _stock_brief() -> dict[str, Any]:
+    return {
+        "stance": "neutral",
+        "confidence": 0.5,
+        "summary": "stock multi-market test",
+        "key_points": ["kp"],
+    }
+
+
+# ────────────────────────────────────────────────────────────────────
+# 1) 4 个 analyst 都把 market_type 塞 user prompt
+# ────────────────────────────────────────────────────────────────────
+
+
+@respx.mock
+async def test_technical_user_prompt_has_market_type() -> None:
+    bars = [make_bar_row((_as_of() - timedelta(hours=20 - i)).isoformat(), close=100 + i)
+            for i in range(20)]
+    respx.get("http://data-mock.test/bars").mock(return_value=Response(200, json=bars))
+
+    llm = FakeLLMClient({"you are a technical analyst": _stock_brief()})
+    async with DataClient("http://data-mock.test", "t") as data:
+        analyst = TechnicalAnalyst(llm=llm, data=data)
+        await analyst.run(
+            venue="alpaca",
+            symbol="AAPL",
+            timeframe="1h",
+            as_of=_as_of(),
+            lookback_days=2,
+        )
+
+    user_prompt = llm.calls[0]["user"]
+    assert "market_type: us_stock" in user_prompt
+    assert "AAPL @ alpaca" in user_prompt
+
+
+@respx.mock
+async def test_risk_user_prompt_has_market_type() -> None:
+    bars = [make_bar_row((_as_of() - timedelta(hours=120 - i)).isoformat(), close=100 + i * 0.1)
+            for i in range(120)]
+    respx.get("http://data-mock.test/bars").mock(return_value=Response(200, json=bars))
+
+    llm = FakeLLMClient({"you are a risk analyst": _stock_brief()})
+    async with DataClient("http://data-mock.test", "t") as data:
+        analyst = RiskAnalyst(llm=llm, data=data)
+        await analyst.run(
+            venue="akshare",
+            symbol="sh.600519",
+            timeframe="1d",
+            as_of=_as_of(),
+            lookback_days=180,
+        )
+
+    user_prompt = llm.calls[0]["user"]
+    assert "market_type: cn_stock" in user_prompt
+
+
+async def test_macro_user_prompt_has_market_type() -> None:
+    """macro analyst 不打 K 线接口，直接调即可。"""
+    llm = FakeLLMClient({"you are a macro analyst": _stock_brief()})
+    # data_client 不会被 macro 用到，传一个 placeholder
+    async with DataClient("http://data-mock.test", "t") as data:
+        analyst = MacroAnalyst(llm=llm, data=data)
+        await analyst.run(
+            venue="yfinance",
+            symbol="^N225",
+            timeframe="1d",
+            as_of=_as_of(),
+            lookback_days=14,
+        )
+
+    user_prompt = llm.calls[0]["user"]
+    # ^N225 是 yfinance 指数 → global_stock
+    assert "market_type: global_stock" in user_prompt
+
+
+# ────────────────────────────────────────────────────────────────────
+# 2) sentiment 在非 crypto 跳过 FNG，走 LLM-only
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_sentiment_skips_fng_for_non_crypto() -> None:
+    """venue=alpaca 时 sentiment 不应调 alternative.me。"""
+    llm = FakeLLMClient(
+        {
+            "you are a sentiment analyst": {
+                "stance": "neutral",
+                "confidence": 0.4,
+                "summary": "LLM-only stock sentiment",
+                "key_points": ["regime unclear"],
+            }
+        }
+    )
+
+    # 故意不 respx.mock alternative.me —— 如果 analyst 调它会抛
+    async with DataClient("http://data-mock.test", "t") as data:
+        analyst = SentimentAnalyst(llm=llm, data=data)
+        brief = await analyst.run(
+            venue="alpaca",
+            symbol="AAPL",
+            timeframe="1h",
+            as_of=_as_of(),
+            lookback_days=7,
+        )
+
+    assert brief.stance == "neutral"
+    user_prompt = llm.calls[0]["user"]
+    assert "market_type: us_stock" in user_prompt
+    assert "non-crypto" in user_prompt
+    # crypto_fng 区段应是 LLM-only fallback 提示
+    # D-9 L3：非 crypto sentiment 现在拉 yfinance news（拉不到时清晰标注）
+    assert "no Fear & Greed" in user_prompt
+    assert "live_news" in user_prompt
+
+
+@respx.mock
+async def test_sentiment_still_uses_fng_for_crypto() -> None:
+    """venue=binance 时 sentiment 仍走 FNG 路径（向后兼容）。"""
+    respx.get("https://api.alternative.me/fng/").mock(
+        return_value=Response(
+            200,
+            json={
+                "data": [
+                    {"value": "30", "value_classification": "Fear", "timestamp": "1716163200"},
+                    *[
+                        {"value": "35", "value_classification": "Fear", "timestamp": str(1716163200 - i * 86400)}
+                        for i in range(1, 30)
+                    ],
+                ]
+            },
+        )
+    )
+    llm = FakeLLMClient(
+        {
+            "you are a sentiment analyst": {
+                "stance": "neutral",
+                "confidence": 0.5,
+                "summary": "crypto fng neutral",
+            }
+        }
+    )
+
+    async with DataClient("http://data-mock.test", "t") as data:
+        analyst = SentimentAnalyst(llm=llm, data=data)
+        await analyst.run(
+            venue="binance",
+            symbol="BTC/USDT",
+            timeframe="1h",
+            as_of=_as_of(),
+            lookback_days=7,
+        )
+
+    user_prompt = llm.calls[0]["user"]
+    assert "market_type: crypto" in user_prompt
+    assert "latest_value: 30" in user_prompt
+
+
+# ────────────────────────────────────────────────────────────────────
+# 3) risk / macro system prompt 含 multi-market 表
+# ────────────────────────────────────────────────────────────────────
+
+
+def test_risk_system_prompt_contains_all_market_bands() -> None:
+    sys = RiskAnalyst.system_prompt(RiskAnalyst.__new__(RiskAnalyst))
+    for mt in ("crypto", "us_stock", "cn_stock", "hk_stock", "global_stock"):
+        assert mt in sys
+    # 阈值表关键字段
+    assert "low vol" in sys
+    assert "high vol" in sys
+
+
+def test_macro_system_prompt_contains_transmission_table() -> None:
+    sys = MacroAnalyst.system_prompt(MacroAnalyst.__new__(MacroAnalyst))
+    for mt in ("crypto", "us_stock", "cn_stock", "hk_stock", "global_stock"):
+        assert mt in sys
+    # 传导表关键字
+    assert "Transmission" in sys or "transmission" in sys
+    assert "USD-peg" in sys  # 港股专属


### PR DESCRIPTION
## Summary

- **D-9 主特性（01985af）**：Bull/Bear researcher 辩论 + swarm 多候选回测 grid（Pareto 前沿 + topK + buy_and_hold baseline 自动对照）
- **D-9 配套修复**：
  - macro events 按 as_of 拆 past/upcoming，CLAUDE.md §3.2 金融时效性硬约束（6dc472a）
  - grid 与模拟盘 schema 解除 crypto-only 硬限制，支持美股/A股/港股/全球指数（97596c7）
- **并行运行时护栏 P0+P1（8fdc43c）**：
  - **P0** ProcessPool worker 启动时 setdefault `OMP/MKL/OPENBLAS/NUMEXPR/VECLIB` 五个 BLAS 线程数为 `"1"`，避免 N worker × M thread 超额抢核
  - **P1** `DeepSeekLLMClient` 加 `asyncio.Semaphore` + 指数退避重试（对 `RateLimitError/APITimeoutError/InternalServerError`），闭掉 D-9 swarm grid×N 同时打 LLM 撞 429 的整链 fail 隐患
  - 新增 `LLM_MAX_CONCURRENT / LLM_MAX_RETRIES / LLM_RETRY_BASE_SECONDS` settings 透传
- **CI（e3a7e83）**：claude-code-action 升级 v0.x beta → v1 + Max 订阅 OAuth 鉴权

## Stats

- 26 files changed, +1681 / -140
- 新增 5 个测试文件（debate / multi-market / llm-client / researchers / pool BLAS）

## Test plan

- [x] `services/research`: ruff + pytest 全套 65/65 通过（含 14 个 llm_client 测试）
- [x] `services/paper`: ruff 通过；test_pool 13/13 通过（含 2 个新 BLAS env 单测）
- [x] 全套 paper pytest: 487 pass / 2 fail（`test_risk_reconciler` 是预存在的 DB 集成依赖问题，与本 PR 改动无关）
- [ ] 端到端验证：本地 `bash scripts/dev.sh` 起服务，跑一次小 grid 回测确认 worker env vars 和 LLM 调用节奏

🤖 Generated with [Claude Code](https://claude.com/claude-code)