### PR TITLE
chore(gitignore): 忽略 pnpm 自动生成的 pnpm-workspace.yaml 占位

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ out/
 coverage/
 *.log
 .pnpm-store/
+# pnpm auto-generates a placeholder here, but Inalpha is not a monorepo (sub-packages each manage their own pnpm-lock)
+pnpm-workspace.yaml
 
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary

\`pnpm-workspace.yaml\` 会在某些场景下被 pnpm 自动生成在仓库根（内容只有 \`allowBuilds: esbuild: set this to true or false\` 这种 hint placeholder），但 Inalpha **不是 pnpm monorepo**：

- 仓库根没有 \`package.json\`
- \`apps/web\` 与 \`packages/orchestration\` 各自独立 \`pnpm-lock.yaml\`
- CI 各 job 也是分别 \`pnpm install --frozen-lockfile\` 在子目录

这个占位文件没有实际用途，但会反复出现让 \`git status\` 一直 dirty。

把它加进 \`.gitignore\`（Node 段），一行注释说明原因，方便未来真要转 pnpm monorepo 时知道为什么 ignore。

## Test plan

- [x] 删除本地副本后 \`git status\` 干净
- [x] 改动只一个文件、+2 行
- [ ] CI 全过（应该秒过——没动业务代码）

🤖 Generated with [Claude Code](https://claude.com/claude-code)