### PR TITLE
feat(orchestration): D-9.1b 收尾打磨 · ADR-0018 修订 + telemetry + risk.* 自检

### DIFF
--- a/packages/orchestration/src/hooks/with-hooks.ts
+++ b/packages/orchestration/src/hooks/with-hooks.ts
@@ -66,6 +66,10 @@ type GenericTool = {
  *
  * 这样 askCache 跨 turn 也能命中，audit-log 也能按 thread 聚合。
  */
+/** Module-level flag：进程内仅 warn 一次 runId fallback / 完全失败，避免每次 tool 调用刷屏。 */
+let _warnedRunIdFallback = false;
+let _warnedNoSessionId = false;
+
 export function defaultGetSessionId(ctx: unknown): string | undefined {
   if (!ctx || typeof ctx !== "object") return undefined;
   const c = ctx as Record<string, unknown>;
@@ -93,7 +97,23 @@ export function defaultGetSessionId(ctx: unknown): string | undefined {
 
   // 最后 fallback：runId —— turn-level 不稳定，会让 askCache 跨 turn miss
   const runId = pickString(c.runId);
-  if (runId) return runId;
+  if (runId) {
+    if (!_warnedRunIdFallback) {
+      _warnedRunIdFallback = true;
+      console.warn(
+        "[with-hooks] defaultGetSessionId falling back to ctx.runId — runId changes per user-turn, " +
+          "askCache will miss across turns. Check if ctx.agent.threadId/resourceId is populated by Mastra runtime.",
+      );
+    }
+    return runId;
+  }
+  if (!_warnedNoSessionId) {
+    _warnedNoSessionId = true;
+    console.warn(
+      "[with-hooks] defaultGetSessionId could not extract any stable id from ctx; " +
+        "ask-path will fall back to __global__ cache key (multi-user unsafe).",
+    );
+  }
   return undefined;
 }
 

--- a/packages/orchestration/src/mastra/agents/orchestrator.ts
+++ b/packages/orchestration/src/mastra/agents/orchestrator.ts
@@ -60,7 +60,8 @@ const INSTRUCTIONS = `
 - paper.get_candidate —— 按 ID 取完整候选（含源码 + 最近 metrics + fitness）
 - paper.promote_candidate —— 把候选从 'candidate' 切到 'promoted'（D-9.1b 起 permission='ask'，
   返 requiresApproval=true——需要你在 chat 里向用户清楚说明候选信息 +
-  等用户明确回复"允许 / 同意 / yes" 后**重调本 tool**；用户拒绝 / 含糊不要重试）；
+  等用户明确回复"允许 / 同意 / yes" 后**重调本 tool**；用户**明确拒绝**告诉用户已取消 +
+  不重试；用户**含糊 / 犹豫 / 跳话题**也不要重调，主动追问明确再决定，**沉默不是同意**）；
   promote 后**仅状态切换**，live trading runner 仍在 E2 / D-7
 
 **下单流（Plan/Exec 三件套）**：
@@ -91,6 +92,20 @@ const INSTRUCTIONS = `
 - sandbox.run_code —— 跑 python / node 小段代码做一次性计算（默认 30s 超时，60s 内 allow，更长 ask）
   - 何时用：用户给的数学公式 / 临时算法验证 / 算指标
   - 何时不用：需要数据库 / 外部 API / 跑回测 → 用专用 tool；沙盒 env 是最小化的拿不到 secret
+
+**风控自检（D-9.1b · ADR-0006 §D6）**：
+- risk.describe_rules —— 列出当前加载的 RiskRule 配置（含 short_desc）
+  · 何时用：用户问"现在有哪些风控规则"/"为什么订单被拒"；下单前自检"哪些 rule 可能拦我"
+  · 何时不用：想看 active 锁状态 → 用 risk.list_locks；想改规则 → 不行，必须改 configs/risk_rules.toml 重启
+- risk.list_locks —— 列当前 active 的风控锁（命中后写入 risk_locks 表的行）
+  · 何时用：撞到 409 RISK_REJECTED 后立刻调，告诉用户"被什么 rule 锁了 / 锁到何时 / 锁的范围"
+  · 过滤参数：scope='global'/'market'/'symbol'；market='binance'；symbol='BTC/USDT@binance'
+  · 何时不用：想自动解锁 → **不行**，risk.unlock 是人工 UI 触发（modelInvocable=false 你也看不见）
+- **撞 RiskGuard 拒绝时的标准动作**（用户体感很关键）：
+  1. paper 端返 409 RISK_REJECTED → **立刻**调 risk.list_locks（带相关 symbol/market）拿原因
+  2. 把 rule 名 / 命中范围 / 解锁时间用人话告诉用户（"目前 BTC/USDT 在 binance 触发了 max_drawdown 锁，到 18:00 自动解除"），
+     不要只说"被拒了"
+  3. 用户若要立刻解锁 → 告诉用户"这要人工 admin 操作，我只能列锁不能解"，不要试图调 risk.unlock
 
 ## 研究驱动决策链路（D-8c 标准 4 步流程）
 
@@ -380,12 +395,21 @@ Inalpha 的内置策略 sma_cross / mean_reversion / buy_and_hold 三个都是
        行 / 可以 / 干 / 来吧 / 加 / 加进去 / 转正 / 上线"。**只要用户在前文已经
        提过想 promote 且这一轮没明确反对**，他给个简短肯定就是允许，不要让用户
        重复说第二遍
-    3. 用户拒绝 / 明确反对（"算了 / 不要 / 取消 / no / 等等"）→ 告诉用户已取消，
-       不要重试
-    4. 重调若仍返 requiresApproval → **最可能是你（LLM）第二次调用时改了 input**
+    3. 用户拒绝 / 明确反对（"算了 / 不要 / 取消 / no / 等等 / 别 / 先别 / 不要这个"）
+       → 告诉用户已取消该操作，并主动汇报现在的状态（"这个候选仍在 candidate
+       状态，没有进入正式策略池"）。**不要重试**。也不要保留"将来还 promote"
+       的悬念——用户拒绝就是终止本轮，下次如果想做要重新发起
+    4. 用户**含糊 / 犹豫 / 跳话题**（"再想想 / 让我看看 / 先看看 / 等下 / 嗯 /
+       哦 / 不确定" / 用户突然问别的不回答 promote）→ **不要重调**也不要假设同意。
+       明确问一句"是要现在加入正式策略池吗，还是先看看其他指标 / 跑别的回测"，
+       让用户做明确决定再继续。**沉默不是同意**
+    5. 重调若仍返 requiresApproval → **最可能是你（LLM）第二次调用时改了 input**
        （比如 candidateId 后缀、reason 文案、字段大小写、键序变化）。检查上一次
        的 toolInput 跟现在的，确保**完全一致**再重调；input 已经一致还撞 → 才是
        系统问题，直接告诉用户"内部问题，我重试中"，再调一次通常就过
+    6. **会话驱动里不存在"系统超时"**：requiresApproval 不会自动失效翻成 deny，
+       也不会自动放行——它就是个"需要用户口头同意"的信号。用户没回 / 跳话题
+       时**不要**说"等了太久所以取消了"，按上面 case 4 主动澄清
 - promote 成功后**必须明确告诉用户**：候选已加入正式策略池，**但自动按行情运行
   的能力（live trading runner）还没实现**（E2 / D-7 范围）。当前"正式"仅指
   "可以走 trade.create_plan 链路手动下单"，不是"已经自动开始交易"

--- a/packages/orchestration/src/permissions/ask-cache.ts
+++ b/packages/orchestration/src/permissions/ask-cache.ts
@@ -31,6 +31,16 @@ interface AskCacheEntry {
 const DEFAULT_TTL_MS = 60_000;
 
 /**
+ * Telemetry sink —— 默认 ``console.log(JSON.stringify(record))``，与 ``audit-log.ts``
+ * 同款 stdout-friendly 格式。测试可注入自定义 sink。
+ */
+export type AskCacheTelemetrySink = (record: Record<string, unknown>) => void;
+
+const defaultTelemetrySink: AskCacheTelemetrySink = (r) => {
+  console.log(JSON.stringify(r));
+};
+
+/**
  * **稳定** JSON stringify —— object keys 按字典序，避免 ``{a,b}`` vs ``{b,a}`` 撞不上。
  *
  * 必须用 stable 形式：DeepSeek / GPT 生成 tool call JSON 时 key 顺序在两次调用之间
@@ -48,10 +58,14 @@ function stableStringify(value: unknown): string {
 export class AskApprovalCache {
   private readonly entries = new Map<string, AskCacheEntry>();
   private readonly ttlMs: number;
+  private readonly telemetry: AskCacheTelemetrySink;
+  /** 记录已打过 __global__ fallback warning，避免每次 mark/consume 都刷屏。 */
+  private warnedGlobalFallback = false;
 
-  constructor(ttlMs: number = DEFAULT_TTL_MS) {
+  constructor(ttlMs: number = DEFAULT_TTL_MS, telemetry?: AskCacheTelemetrySink) {
     if (ttlMs <= 0) throw new Error(`ttlMs must be positive, got ${ttlMs}`);
     this.ttlMs = ttlMs;
+    this.telemetry = telemetry ?? defaultTelemetrySink;
   }
 
   /** 拼 cache key。无 sessionId 时回退到 ``"__global__"`` —— 单进程 dev 环境够用。 */
@@ -64,18 +78,47 @@ export class AskApprovalCache {
     return `${sid}::${toolName}::${stableStringify(input)}`;
   }
 
+  /** 进程内仅 warn 一次 sessionId 缺失：多用户场景下不同用户的 ask 会撞同一个 __global__ entry。 */
+  private maybeWarnGlobalFallback(
+    sessionId: string | undefined,
+    op: string,
+    toolName: string,
+  ): void {
+    if (this.warnedGlobalFallback) return;
+    if (sessionId && sessionId.length > 0) return;
+    this.warnedGlobalFallback = true;
+    console.warn(
+      `[ask-cache] sessionId missing for ${op}("${toolName}"); falling back to "__global__". ` +
+        "Multi-user safety degraded. Check defaultGetSessionId in with-hooks.ts.",
+    );
+  }
+
   /**
    * 标记 (sessionId, toolName, input) 已被 ask 过；TTL 后自动失效。
    * 若已存在条目，重置 TTL（连续多次 ask 同一动作不需要重启计时）。
    */
   mark(sessionId: string | undefined, toolName: string, input: unknown): void {
+    this.maybeWarnGlobalFallback(sessionId, "mark", toolName);
     const key = AskApprovalCache.keyFor(sessionId, toolName, input);
     const existing = this.entries.get(key);
     if (existing) clearTimeout(existing.timer);
     const timer = setTimeout(() => {
       this.entries.delete(key);
+      this.telemetry({
+        event: "ask_cache_expired",
+        toolName,
+        sessionId: sessionId ?? null,
+        ttlMs: this.ttlMs,
+        ts: new Date().toISOString(),
+      });
     }, this.ttlMs);
     this.entries.set(key, { markedAt: Date.now(), timer });
+    this.telemetry({
+      event: "ask_marked",
+      toolName,
+      sessionId: sessionId ?? null,
+      ts: new Date().toISOString(),
+    });
   }
 
   /**
@@ -92,21 +135,45 @@ export class AskApprovalCache {
     input: unknown,
     debugSink?: (msg: string) => void,
   ): boolean {
+    this.maybeWarnGlobalFallback(sessionId, "consume", toolName);
     const key = AskApprovalCache.keyFor(sessionId, toolName, input);
     const entry = this.entries.get(key);
     if (!entry) {
       if (debugSink) this.debugWhyMiss(sessionId, toolName, input, debugSink);
+      this.telemetry({
+        event: "ask_consume_miss",
+        toolName,
+        sessionId: sessionId ?? null,
+        reason: "no_entry",
+        ts: new Date().toISOString(),
+      });
       return false;
     }
+    const latency_ms = Date.now() - entry.markedAt;
     // 双保险：即便 setTimeout 未触发，超时仍按未命中处理
-    if (Date.now() - entry.markedAt > this.ttlMs) {
+    if (latency_ms > this.ttlMs) {
       clearTimeout(entry.timer);
       this.entries.delete(key);
       if (debugSink) debugSink(`AskCache: entry expired for ${toolName} (sid=${sessionId})`);
+      this.telemetry({
+        event: "ask_consume_miss",
+        toolName,
+        sessionId: sessionId ?? null,
+        reason: "expired_double_check",
+        latency_ms,
+        ts: new Date().toISOString(),
+      });
       return false;
     }
     clearTimeout(entry.timer);
     this.entries.delete(key);
+    this.telemetry({
+      event: "ask_consumed",
+      toolName,
+      sessionId: sessionId ?? null,
+      latency_ms,
+      ts: new Date().toISOString(),
+    });
     return true;
   }
 

--- a/packages/orchestration/src/permissions/pending.ts
+++ b/packages/orchestration/src/permissions/pending.ts
@@ -54,10 +54,25 @@ export interface PendingRequestResult {
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
+ * Telemetry sink —— 默认 ``console.log(JSON.stringify(record))``，与 ``audit-log.ts``
+ * + ``ask-cache.ts`` 同款 stdout-friendly 格式。测试可注入自定义 sink。
+ */
+export type PendingTelemetrySink = (record: Record<string, unknown>) => void;
+
+const defaultPendingTelemetrySink: PendingTelemetrySink = (r) => {
+  console.log(JSON.stringify(r));
+};
+
+/**
  * 进程内挂起池。``mastra/index.ts`` 在 runtime 启动时共享单例；测试可 new 独立实例。
  */
 export class PendingApprovalsStore {
   private readonly pending = new Map<string, PendingApprovalRecord>();
+  private readonly telemetry: PendingTelemetrySink;
+
+  constructor(telemetry?: PendingTelemetrySink) {
+    this.telemetry = telemetry ?? defaultPendingTelemetrySink;
+  }
 
   /**
    * 注册一个挂起审批，返 promise 等用户决策。
@@ -70,11 +85,30 @@ export class PendingApprovalsStore {
     const createdAt = new Date();
     const deadline = new Date(createdAt.getTime() + timeoutMs);
 
+    this.telemetry({
+      event: "ask_pending_requested",
+      requestId,
+      toolName: args.toolName,
+      sessionId: args.sessionId ?? null,
+      timeoutMs,
+      ts: createdAt.toISOString(),
+    });
+
     return new Promise<PendingRequestResult>((resolve) => {
       const timer = setTimeout(() => {
         const record = this.pending.get(requestId);
         if (record) {
           this.pending.delete(requestId);
+          this.telemetry({
+            event: "ask_pending_resolved",
+            requestId,
+            toolName: args.toolName,
+            sessionId: args.sessionId ?? null,
+            decision: "deny",
+            via: "timeout",
+            latency_ms: timeoutMs,
+            ts: new Date().toISOString(),
+          });
           resolve({ decision: "deny", requestId, via: "timeout" });
         }
       }, timeoutMs);
@@ -90,6 +124,16 @@ export class PendingApprovalsStore {
         resolve: (decision) => {
           clearTimeout(timer);
           this.pending.delete(requestId);
+          this.telemetry({
+            event: "ask_pending_resolved",
+            requestId,
+            toolName: args.toolName,
+            sessionId: args.sessionId ?? null,
+            decision,
+            via: "user",
+            latency_ms: Date.now() - createdAt.getTime(),
+            ts: new Date().toISOString(),
+          });
           resolve({ decision, requestId, via: "user" });
         },
       };
@@ -114,29 +158,6 @@ export class PendingApprovalsStore {
     const record = this.pending.get(requestId);
     if (!record) return false;
     record.resolve(decision);
-    return true;
-  }
-
-  /**
-   * 尝试用 ``requestId`` token 消费一个挂起项（D-9.1b token threading 模式）。
-   *
-   * 与 ``respond`` 区别：``respond`` 是外部按钮 / curl 主动决策；本方法是
-   * **检查"用户口头同意"后，agent 重调原 tool 时携带 token 走的快速放行通道**。
-   *
-   * 安全约束：必须 toolName + toolInput 完全匹配创建时的快照，防止 agent 拿一个
-   * tool 的 token 去激活另一个 tool。
-   *
-   * 命中返 ``true``：从池中删除该挂起项并解为 ``"allow"``。
-   * 未命中（id 不存在 / 已超时 / toolName/Input 不匹配）返 ``false``。
-   */
-  tryConsume(requestId: string, toolName: string, toolInput: unknown): boolean {
-    const record = this.pending.get(requestId);
-    if (!record) return false;
-    if (record.toolName !== toolName) return false;
-    // JSON 字符串化比较——对纯 JSON 对象 / 数组 / 标量足够；对含 Date/Function
-    // 的复杂结构不可靠，但 tool input 通过 zod schema 校验，基本都是 JSON 安全的
-    if (JSON.stringify(record.toolInput) !== JSON.stringify(toolInput)) return false;
-    record.resolve("allow"); // 内部会 clearTimeout + delete from map
     return true;
   }
 

--- a/packages/orchestration/src/tools/index.ts
+++ b/packages/orchestration/src/tools/index.ts
@@ -182,6 +182,9 @@ export const orchestratorToolList = [
   schedulerListRunsTool,
   // D-9 spike：沙盒（ADR-0020 第二道运行隔离）
   sandboxRunCodeTool,
+  // D-9.1b · ADR-0006 §D6：agent 自检 + 解释风控（unlock 不挂，admin UI 用 allTools 走）
+  riskDescribeRulesTool,
+  riskListLocksTool,
 ] as const;
 
 /** 名字 → tool 索引，给 framework 路由用。 */

--- a/packages/orchestration/src/tools/risk.ts
+++ b/packages/orchestration/src/tools/risk.ts
@@ -10,8 +10,9 @@
  * `risk.unlock` 走 [ADR-0018 askUserChoice](../../../../docs/miro/decisions/0018-ask-user-question-as-tool.md)
  * 的等价 UI 人工确认。LLM 不应直接调，但 client 层一致暴露，权限隔离在 tool 层。
  *
- * **未接入 wired-tools / index.ts** —— 用户 review 后手动接入（避免与 D-9 并行
- * 工作的 untracked 改动冲突）。
+ * **D-9.1b 接入清单**（`tools/index.ts:orchestratorToolList`）：
+ * - `riskDescribeRulesTool` + `riskListLocksTool` ✅ 挂到 orchestrator
+ * - `riskUnlockTool` ❌ 不挂（`modelInvocable: false`，仅 admin UI / CLI 走 allTools 通路）
  */
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";

--- a/packages/orchestration/tests/ask-path-e2e.test.ts
+++ b/packages/orchestration/tests/ask-path-e2e.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Ask-path 集成测试（ADR-0018 D-9.1b 修订）。
+ *
+ * 与 `hooks.test.ts` 的单元拆分不同——本文件用**完整组合**（真 withHooks + 真
+ * AskApprovalCache + 真 PendingApprovalsStore + 注入 telemetry sink）覆盖一次
+ * ask 流程的所有可观察事件 + 跨 session 隔离 + TTL 自然过期。
+ *
+ * 覆盖的事件序列（events emitted to telemetry sink）：
+ *
+ * - 第一次 ask 拦截：``ask_marked``（cache.mark）+ ``ask_pending_requested``（store.request）
+ * - 第二次 ask 重调（cache hit）：``ask_consumed``
+ * - 用户拒绝 / cache 自然过期：``ask_cache_expired``
+ * - store.request 30s timeout fire-and-forget：``ask_pending_resolved` via=timeout
+ * - 跨 sessionId 不复用
+ *
+ * 不覆盖（已在 hooks.test.ts / permissions-pending.test.ts 单测）：
+ * - matcher / runner 自身逻辑
+ * - HTTP API endpoint（permissions-pending.test.ts §permissionsApiRoutes）
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { HookRunner, withHooks } from "../src/hooks/index.js";
+import { AskApprovalCache } from "../src/permissions/ask-cache.js";
+import { PendingApprovalsStore } from "../src/permissions/pending.js";
+
+function makeEnv(opts: { cacheTtlMs?: number } = {}) {
+  const events: Array<Record<string, unknown>> = [];
+  const sink = (r: Record<string, unknown>) => {
+    events.push(r);
+  };
+  const cache = new AskApprovalCache(opts.cacheTtlMs ?? 60_000, sink);
+  const store = new PendingApprovalsStore(sink);
+  const runner = new HookRunner();
+  return { events, cache, store, runner };
+}
+
+function eventsOf(
+  events: Array<Record<string, unknown>>,
+  name: string,
+): Array<Record<string, unknown>> {
+  return events.filter((e) => e.event === name);
+}
+
+describe("ask-path e2e · 完整 happy path + telemetry 事件序列", () => {
+  it("第一次 ask 触发 mark + pending_requested；第二次重调 cache hit + consumed → execute", async () => {
+    const { events, cache, store, runner } = makeEnv();
+    const exec = vi.fn().mockResolvedValue({ candidateId: "c-42", status: "promoted" });
+    const tool = { id: "paper.promote_candidate", description: "", execute: exec };
+    const wrapped = withHooks(tool, {
+      runner,
+      permissionResolver: () => "ask",
+      askCache: cache,
+      pendingApprovals: store,
+      getSessionId: () => "thread-A",
+    });
+
+    // 第一次：被拦
+    const first = (await wrapped.execute!({ candidateId: "c-42" })) as {
+      isError: boolean;
+      requiresApproval: boolean;
+    };
+    expect(first.isError).toBe(true);
+    expect(first.requiresApproval).toBe(true);
+    expect(exec).not.toHaveBeenCalled();
+
+    // 第一次的 telemetry：先 mark 再 pending_requested（顺序由 with-hooks 决定）
+    expect(eventsOf(events, "ask_marked")).toHaveLength(1);
+    expect(eventsOf(events, "ask_pending_requested")).toHaveLength(1);
+    const marked = eventsOf(events, "ask_marked")[0];
+    expect(marked).toMatchObject({
+      toolName: "paper.promote_candidate",
+      sessionId: "thread-A",
+    });
+
+    // 第二次：同 input → cache hit → 真 execute
+    const second = await wrapped.execute!({ candidateId: "c-42" });
+    expect(exec).toHaveBeenCalledOnce();
+    expect(second).toEqual({ candidateId: "c-42", status: "promoted" });
+
+    // 第二次的 telemetry：ask_consumed
+    expect(eventsOf(events, "ask_consumed")).toHaveLength(1);
+    const consumed = eventsOf(events, "ask_consumed")[0];
+    expect(consumed).toMatchObject({
+      toolName: "paper.promote_candidate",
+      sessionId: "thread-A",
+    });
+    expect(typeof consumed.latency_ms).toBe("number");
+
+    // 副作用 cleanup：cache 一次性消费
+    expect(cache.size()).toBe(0);
+    store.clearAll();
+  });
+});
+
+describe("ask-path e2e · 跨 sessionId 不复用", () => {
+  it("A 用户 mark 不被 B 用户 consume；两条独立 entry", async () => {
+    const { events, cache, store, runner } = makeEnv();
+    const exec = vi.fn();
+    const tool = { id: "paper.promote_candidate", description: "", execute: exec };
+
+    // sessionId 由 ctx 提供，每次 invoke 时 ctx.agent.threadId 不同
+    const wrapped = withHooks(tool, {
+      runner,
+      permissionResolver: () => "ask",
+      askCache: cache,
+      pendingApprovals: store,
+    });
+
+    // A 用户拦一次
+    await wrapped.execute!({ candidateId: "c-42" }, { agent: { threadId: "thread-A" } });
+    expect(cache.size()).toBe(1);
+
+    // B 用户**同 input** 重调 → cache 不命中（不同 sessionId）→ 也被拦
+    const bOut = (await wrapped.execute!(
+      { candidateId: "c-42" },
+      { agent: { threadId: "thread-B" } },
+    )) as { isError: boolean; requiresApproval: boolean };
+    expect(bOut.requiresApproval).toBe(true);
+    expect(exec).not.toHaveBeenCalled();
+    // 两条独立 entry：A + B 各一
+    expect(cache.size()).toBe(2);
+
+    // telemetry：两次 ask_marked，sessionId 不同
+    const marks = eventsOf(events, "ask_marked");
+    expect(marks).toHaveLength(2);
+    const sids = new Set(marks.map((e) => e.sessionId));
+    expect(sids).toEqual(new Set(["thread-A", "thread-B"]));
+
+    store.clearAll();
+    cache.clear();
+  });
+});
+
+describe("ask-path e2e · cache TTL 自然过期", () => {
+  it("用户不重调时 cache TTL 到期触发 expired 事件", async () => {
+    const { events, cache, store, runner } = makeEnv({ cacheTtlMs: 50 });
+    const exec = vi.fn();
+    const tool = { id: "paper.promote_candidate", description: "", execute: exec };
+    const wrapped = withHooks(tool, {
+      runner,
+      permissionResolver: () => "ask",
+      askCache: cache,
+      pendingApprovals: store,
+      getSessionId: () => "thread-A",
+    });
+
+    await wrapped.execute!({ candidateId: "c-42" });
+    expect(cache.size()).toBe(1);
+    expect(eventsOf(events, "ask_marked")).toHaveLength(1);
+
+    // 等 TTL 过期（用真 setTimeout，与项目其他测试一致）
+    await new Promise((r) => setTimeout(r, 80));
+
+    // cache 已被自动清理
+    expect(cache.size()).toBe(0);
+    // telemetry：收到 ask_cache_expired
+    expect(eventsOf(events, "ask_cache_expired")).toHaveLength(1);
+    expect(eventsOf(events, "ask_cache_expired")[0]).toMatchObject({
+      toolName: "paper.promote_candidate",
+      sessionId: "thread-A",
+    });
+
+    store.clearAll();
+  });
+});
+
+describe("ask-path e2e · store.request fire-and-forget timeout", () => {
+  it("第一次 ask 后 30s timeout 触发 pending_resolved via=timeout（不影响 cache）", async () => {
+    const { events, cache, store, runner } = makeEnv();
+    const exec = vi.fn();
+    const tool = { id: "paper.promote_candidate", description: "", execute: exec };
+    const wrapped = withHooks(tool, {
+      runner,
+      permissionResolver: () => "ask",
+      askCache: cache,
+      pendingApprovals: store,
+      askTimeoutMs: 30, // 用小超时让测试快
+      getSessionId: () => "thread-A",
+    });
+
+    await wrapped.execute!({ candidateId: "c-42" });
+    expect(eventsOf(events, "ask_pending_requested")).toHaveLength(1);
+
+    // 等 store timeout 触发（与 cache TTL 独立）
+    await new Promise((r) => setTimeout(r, 60));
+
+    const resolved = eventsOf(events, "ask_pending_resolved");
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({
+      toolName: "paper.promote_candidate",
+      sessionId: "thread-A",
+      decision: "deny",
+      via: "timeout",
+    });
+    // cache 仍存活（60s TTL 默认未到）—— 印证 store timeout 不影响 cache 路径
+    expect(cache.size()).toBe(1);
+
+    cache.clear();
+  });
+});
+
+describe("ask-path e2e · 用户拒绝路径", () => {
+  it("agent 不重调 + cache 60s TTL 过期 → 后续相同 input 重新触发 ask（不复用旧 mark）", async () => {
+    const { events, cache, store, runner } = makeEnv({ cacheTtlMs: 50 });
+    const exec = vi.fn();
+    const tool = { id: "paper.promote_candidate", description: "", execute: exec };
+    const wrapped = withHooks(tool, {
+      runner,
+      permissionResolver: () => "ask",
+      askCache: cache,
+      pendingApprovals: store,
+      getSessionId: () => "thread-A",
+    });
+
+    // 第一次 ask
+    await wrapped.execute!({ candidateId: "c-42" });
+    expect(eventsOf(events, "ask_marked")).toHaveLength(1);
+
+    // 模拟"用户拒绝 → agent 不重调" —— 啥都不做，等 cache 过期
+    await new Promise((r) => setTimeout(r, 80));
+    expect(eventsOf(events, "ask_cache_expired")).toHaveLength(1);
+    expect(cache.size()).toBe(0);
+
+    // 用户改变主意，agent 重新发起同样 tool 调用 → 应再走一遍 ask（不复用旧 mark）
+    await wrapped.execute!({ candidateId: "c-42" });
+    expect(eventsOf(events, "ask_marked")).toHaveLength(2); // 新一轮 mark
+    expect(exec).not.toHaveBeenCalled();
+
+    store.clearAll();
+    cache.clear();
+  });
+});


### PR DESCRIPTION
## Summary

D-9.1b 会话驱动 ask 路径主线已通过 PR #19 合入，本 PR 是实测后的收尾打磨，三件事：

1. **Telemetry 落地**（ADR-0018 §关键约定 4）—— `AskApprovalCache` + `PendingApprovalsStore` 各加结构化事件 emit（含 latency_ms / via / sessionId / toolName）
2. **`risk.*` 自检 tool 挂 orchestrator**（ADR-0006 §D6）—— `riskDescribeRulesTool` + `riskListLocksTool` 加进 `orchestratorToolList`；prompt 加"撞 RiskGuard 拒绝时三步"
3. **Prompt 加固 + e2e 测试** —— promote 流程 prompt 从 3-step 扩成 6-step（拒绝/含糊/超时不存在 全覆盖）；新建 `tests/ask-path-e2e.test.ts` 5 个集成场景

## 改动文件

| 文件 | 改动 |
|---|---|
| `packages/orchestration/src/permissions/ask-cache.ts` | + 4 个 telemetry 事件 + `TelemetrySink` 类型 + sessionId fallback warn-once |
| `packages/orchestration/src/permissions/pending.ts` | + 3 个 telemetry 事件 + `TelemetrySink` + **删除 `tryConsume()` 死代码** |
| `packages/orchestration/src/hooks/with-hooks.ts` | + `defaultGetSessionId` runId/无 id 两路径 warn-once |
| `packages/orchestration/src/mastra/agents/orchestrator.ts` | + 风控自检段 + 6-step promote 流程（case 3/4/5/6 新增） |
| `packages/orchestration/src/tools/index.ts` | + `riskDescribeRulesTool` / `riskListLocksTool` 进 orchestratorToolList |
| `packages/orchestration/src/tools/risk.ts` | 文件头注释更新（接入清单） |
| `packages/orchestration/tests/ask-path-e2e.test.ts` | **新建** 5 个 e2e 场景 |

## 关联资源

- 关闭 [issue #2](https://github.com/mirror29/inalpha/issues/2)（askUserChoice 前端接入 → 决议变更为会话驱动，本 PR 完成 telemetry + risk.* + e2e 收尾）
- 配套 [PR #20](https://github.com/mirror29/inalpha/pull/20)（D-9.1a · RiskGuardFactory per-account 隔离 + MarketHoursRule 真日历）独立 review

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm test` 279/279 ✅（新增 5 个 e2e 测试，无 regression）
- [x] `bash scripts/check-consistency.sh` 3 通过 / 2 历史警告 / 0 失败 ✅
- [ ] reviewer 跑 `bash scripts/dev.sh` 验证：触发 promote → 看 console 输出 telemetry JSON 行序列符合预期（ask_marked → ask_pending_requested → ask_consumed）

## 不在本 PR 范围

- ADR-0018 文件本身（gitignored 内部决策文档，与代码改动语义同步但不进仓库）
- `apps/web/*` 工作（独立 in-progress，未 staged）
- delegation hop（ADR-0012 补丁 / issue #5）→ D-10 评估
- 多实例 `PendingApprovalsStore` Redis 化 → D-10+

🤖 Generated with [Claude Code](https://claude.com/claude-code)