### PR TITLE
feat(web): landing page 大改 · Hero 日志流 / Problem split-screen / Harness 终端化

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -30,29 +30,24 @@
   },
   "problem": {
     "eyebrow": "01 / Problem",
-    "title": "You're not doing quant.",
-    "titleAlt": "You're trusting a black box.",
-    "sub": "Most LLM trading stacks return a single score and a paragraph. You can't replay it, you can't audit it, and you can't disagree with it. Inalpha treats every factor, plan, and order as a versioned record — not a vibe.",
+    "title": "LLM-written strategies are easy.",
+    "titleAlt": "Signing every decision is engineering.",
+    "sub": "Most \"LLM + quant\" stacks today: prompt in, \"long BTC, conf 0.62\" out, broker SDK next door. Lost money — no way to find which prompt or which slice of data broke. Made money — no way to tell alpha from overfit. Inalpha brings the Claude Code engineering harness (hooks / permissions / plan-exec) to LLM quant — the LLM only writes code; every decision is signed, every backtest is replayable, and the order path is never reachable by the LLM directly.",
     "table": {
-      "header": {
-        "want": "What you want",
-        "blackbox": "Black-box LLM",
-        "inalpha": "Inalpha"
-      },
-      "signal": {
-        "want": "Signal",
-        "blackbox": "One score",
-        "inalpha": "Plan with rationale + opposing analysts"
-      },
-      "reason": {
-        "want": "Reasoning",
-        "blackbox": "\"trust me\"",
-        "inalpha": "Hooks-enforced decision record"
+      "lineage": {
+        "want": "lineage",
+        "blackbox": "\"long BTC, conf 0.62\" — source data, prompt, model version: nowhere on record. Nothing to attribute when it loses",
+        "inalpha": "research_id → backtest_run_id → plan_id, every decision traceable back through its full UUID chain"
       },
       "replay": {
-        "want": "Replay",
-        "blackbox": "Not reproducible",
-        "inalpha": "JSONL on disk + token-signed audit trail"
+        "want": "replay",
+        "blackbox": "How was last week's sharpe 2.14 computed? Params forgotten, data slice forgotten — recompute from memory",
+        "inalpha": "strategy_id + params_hash + as_of as a fingerprint. Same numbers any day, any week"
+      },
+      "guardrail": {
+        "want": "guardrail",
+        "blackbox": "The LLM holds the broker SDK directly. One jailbreak prompt, one hallucination = real money out",
+        "inalpha": "permissions.yaml deny + plan/exec one-shot TTL token. The order path is unreachable by the LLM, ever"
       }
     }
   },
@@ -173,22 +168,38 @@
     "title": "Inspired by Claude Code.",
     "titleAlt": "Adapted for trading.",
     "sub": "Declarative configs decide what each agent can call. Plan → approve → execute is enforced by a one-shot, TTL-bound token — the LLM never reaches the order path unsupervised. Subagents isolate risk. MCP plugs in tools without hand-rolled glue.",
-    "configSample": "research:\n  allow:\n    - data.get_bars\n    - data.get_news\n  deny:\n    - paper.place_order\n\nrisk:\n  allow: [\"*\"]\n  require_human: [\"place_order > 0.5\"]",
+    "hint": "── Click a mechanism on the right to inspect real source",
     "chips": {
-      "hooks": "hooks",
       "permissions": "permissions",
+      "hooks": "hooks",
       "plan-exec": "plan-exec",
       "subagent": "subagent",
       "mcp": "MCP",
       "swarm": "Swarm"
     },
     "chipDescs": {
-      "hooks": "Middleware runs on every tool call.",
       "permissions": "Tool access scoped per agent role.",
+      "hooks": "Middleware runs on every tool call.",
       "plan-exec": "Plan first, execute once, no runaway loops.",
       "subagent": "Risk and review live in isolated subagents.",
       "mcp": "Model Context Protocol native, no glue code.",
       "swarm": "Parallel workers run grid backtests."
+    },
+    "captions": {
+      "permissions": "config/permissions.default.yaml",
+      "hooks": "hooks/handlers/audit-log.ts · PostToolUse",
+      "plan-exec": "tools/trade-plan.ts · 3-step · ADR-0012",
+      "subagent": "agents/orchestrator.ts · D-8a → D-8a'",
+      "mcp": "scripts/smoke-coingecko-mcp.ts · spike",
+      "swarm": "tools/swarm.ts × workflows/backtest-grid"
+    },
+    "samples": {
+      "permissions": "defaultMode: ask           # fail-closed\n\nallow:\n  - \"data.*\"               # quotes / news / macro (read)\n  - \"paper.run_backtest\"\n  - \"research.*\"\n  - \"trade.create_plan\"    # proposing is fine\n  - \"trade.approve_plan\"\n  - \"trade.execute_plan\"\n\ndeny:                        # the LLM cannot bypass these\n  - \"paper.submit_order\"   # legacy direct-order path\n  - \"live.submit_order(notional>=10000)\"\n  - \"live.emergency_stop_all\"",
+      "hooks": "// PostToolUse · audits every business tool\n// matcher: paper.* | live.* | factor.* | research.*\nexport const auditLog: HookHandler = async (ctx) => {\n  await jsonl.append(`audit/${today()}.jsonl`, {\n    ts:        nowIso(),\n    tool:      ctx.toolName,\n    sessionId: ctx.sessionId,\n    isError:   ctx.isError,\n    input:     redact(ctx.toolInput),   // apiKey / approvalToken\n    output:    redact(ctx.toolOutput),  // wallet / ssn / cvv → [REDACTED]\n  });\n  // blocking: false — audit is a side effect, never gates business path\n};",
+      "plan-exec": "$ trade.create_plan\n    intent=open_long   symbol=BTCUSDT   side=buy   qty=0.05\n    rationale=\"4h breakout · bull thesis holds\"\n    researchId=rs_8f3a   backtestRunId=bt_91c2     # ← lineage\n→ planId=pln_7c91   status=pending   expireAt=+300s\n\n$ trade.approve_plan { planId, reason=\"risk gate pass\" }\n→ approvalToken=tk_…   one-shot · 60s TTL\n\n$ trade.execute_plan { planId, approvalToken }\n→ ok · orderId=ord_4d2a   token consumed",
+      "subagent": "// D-8a:  trader / risk subagents nested (4-hop LLM · ~15s)\n// D-8a': flatten everything to tools on orchestrator — 4× faster\n//        Permission boundary moves to permissions.yaml deny rules\n\n// Subagents kept for long-context, isolatable subtasks:\nconst reflect = await orch.subagent(\"backtest-reflect\", {\n  prompt: `Attribute ${runId} · find lookahead-bias segments`,\n  tools:  [\"paper.reflect_backtest\", \"data.get_news\"],  // scoped\n  contextBudget: 8_000,                                  // isolated\n});",
+      "mcp": "// scripts/smoke-coingecko-mcp.ts — D-9 spike\nimport { Client } from \"@modelcontextprotocol/sdk/client\";\nimport { StreamableHTTPClientTransport }\n  from \"@modelcontextprotocol/sdk/client/streamableHttp\";\n\nconst t = new StreamableHTTPClientTransport(\n  new URL(\"https://mcp.api.coingecko.com/mcp\"),  // official public endpoint\n);\nconst client = new Client({ name: \"inalpha\", version: \"0.9\" });\nawait client.connect(t);\nconst tools = await client.listTools();\n// → 32 CoinGecko tools land on the orchestrator · zero glue code",
+      "swarm": "$ swarm.run_backtest_grid\n    candidateIds: [c_3a1, c_7c9, c_5e2]   # D-9 LLM-authored\n    symbols:      [BTCUSDT, ETHUSDT, SOLUSDT]\n    venue: binance   timeframe: 1h\n    from: 2025-01-01    to: 2026-05-26\n\n→ grid:     3 × 3 = 9 runs    (cap ≤ 20 by grid-size-cap hook)\n→ workers:  6   wall: 4.2s    ok: 9 / errored: 0\n→ pareto:   3 points (Sharpe ↑  · maxDD ↓)\n→ top1:     c_3a1 on ETHUSDT   fitness=1.84\n            baseline(buy_and_hold)=0.92  ·  alpha ✓"
     }
   },
   "coverage": {
@@ -218,7 +229,7 @@
       "starsSuffix": "stars",
       "contributorsSuffix": "contributors",
       "commitsSuffix": "commits",
-      "qualityLabel": "alpha quality"
+      "qualityLabel": "not for live capital"
     },
     "currentState": {
       "title": "Where we are honest with you",
@@ -233,13 +244,8 @@
     "eyebrow": "07 / Get started",
     "title": "Star it. Read it. Tear it apart.",
     "sub": "Inalpha is alpha-stage and AGPL-3.0. No real money yet — every line is on GitHub.",
-    "tabs": {
-      "git": "git clone",
-      "pip": "pip install"
-    },
     "commands": {
-      "git": "git clone https://github.com/mirror29/inalpha",
-      "pip": "pip install inalpha"
+      "git": "git clone https://github.com/mirror29/inalpha"
     },
     "copy": "Copy",
     "copied": "Copied",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -30,29 +30,24 @@
   },
   "problem": {
     "eyebrow": "01 / 问题",
-    "title": "你以为在做量化研究，",
-    "titleAlt": "实则在仰仗一个黑盒。",
-    "sub": "大多数 LLM 量化框架，只给你一个分值加一段散文。无法回放、无法审计，也无从质疑。Inalpha 把每一个因子、计划、订单都当作有版本的记录看待——不是凭感觉的猜测。",
+    "title": "LLM 把策略写出来，很容易。",
+    "titleAlt": "替它的每个决策签名，才是工程。",
+    "sub": "现在大部分「LLM + 量化」长这样：prompt 进去，「做多 BTC 0.62」出来，broker SDK 就在隔壁。亏了找不到是哪段 prompt、哪份数据出的错；赚了也分不清是 alpha 还是过拟合。Inalpha 把 Claude Code 那套工程绑带（hooks / permissions / plan-exec）搬到 LLM 量化——LLM 只负责写代码，每个决策有签名、每次回测可重放、订单路径走不到 LLM 嘴边。",
     "table": {
-      "header": {
-        "want": "你想要的",
-        "blackbox": "黑盒 LLM 给的",
-        "inalpha": "Inalpha 给的"
-      },
-      "signal": {
-        "want": "信号",
-        "blackbox": "一个分值",
-        "inalpha": "带 rationale 的 plan + 对立分析师"
-      },
-      "reason": {
-        "want": "依据",
-        "blackbox": "「相信我」",
-        "inalpha": "Hooks 强制的决策记录"
+      "lineage": {
+        "want": "lineage · 血缘",
+        "blackbox": "「建议做多 BTC 0.62」——源数据、prompt、模型版本一概不留痕，亏了无从复盘",
+        "inalpha": "research_id → backtest_run_id → plan_id 全链 UUID 串联，每个决策可反查上游"
       },
       "replay": {
-        "want": "回放",
-        "blackbox": "无法复现",
-        "inalpha": "JSONL 落盘 + token 签名审计链"
+        "want": "replay · 重放",
+        "blackbox": "上次的 sharpe 2.14 是怎么跑出来的？参数和数据切片忘了，凭印象再算一次",
+        "inalpha": "strategy_id + params_hash + as_of 三联做指纹，任意时间点重放数字一致"
+      },
+      "guardrail": {
+        "want": "guardrail · 护栏",
+        "blackbox": "LLM 直接握着 broker SDK：一次 prompt 越狱、一句模型幻觉 = 一笔真亏钱",
+        "inalpha": "permissions.yaml deny + plan/exec 一次性 TTL token，订单路径 LLM 永远绕不过"
       }
     }
   },
@@ -173,22 +168,38 @@
     "title": "Claude Code 的工程哲学，",
     "titleAlt": "应用于量化交易。",
     "sub": "声明式配置规定每个 agent 的工具调用权限。Plan → approve → execute 由一次性、短 TTL 的 token 强制——LLM 永远不会绕过审批触达订单路径。subagent 隔离风险与复盘。MCP 协议接入工具，免去胶水代码。",
-    "configSample": "research:\n  allow:\n    - data.get_bars\n    - data.get_news\n  deny:\n    - paper.place_order\n\nrisk:\n  allow: [\"*\"]\n  require_human: [\"place_order > 0.5\"]",
+    "hint": "── 点击右侧机制查看真实代码片段",
     "chips": {
-      "hooks": "hooks",
       "permissions": "permissions",
+      "hooks": "hooks",
       "plan-exec": "plan-exec",
       "subagent": "subagent",
       "mcp": "MCP",
       "swarm": "Swarm"
     },
     "chipDescs": {
-      "hooks": "每个 tool call 都走中间件。",
       "permissions": "工具权限按角色 scope。",
+      "hooks": "每个 tool call 都走中间件。",
       "plan-exec": "先 plan 后 exec，one-shot token。",
       "subagent": "风险与复盘住在独立子 agent。",
       "mcp": "原生支持 Model Context Protocol。",
       "swarm": "并行 worker 跑参数网格回测。"
+    },
+    "captions": {
+      "permissions": "config/permissions.default.yaml",
+      "hooks": "hooks/handlers/audit-log.ts · PostToolUse",
+      "plan-exec": "tools/trade-plan.ts · 3-step · ADR-0012",
+      "subagent": "agents/orchestrator.ts · D-8a → D-8a'",
+      "mcp": "scripts/smoke-coingecko-mcp.ts · spike",
+      "swarm": "tools/swarm.ts × workflows/backtest-grid"
+    },
+    "samples": {
+      "permissions": "defaultMode: ask           # fail-closed\n\nallow:\n  - \"data.*\"               # 只读行情 / 新闻 / 宏观\n  - \"paper.run_backtest\"\n  - \"research.*\"\n  - \"trade.create_plan\"    # 提案可以写\n  - \"trade.approve_plan\"\n  - \"trade.execute_plan\"\n\ndeny:                        # 这条 LLM 永远绕不过\n  - \"paper.submit_order\"   # 旧直下单路径\n  - \"live.submit_order(notional>=10000)\"\n  - \"live.emergency_stop_all\"",
+      "hooks": "// PostToolUse · 业务 tool 全量审计\n// matcher: paper.* | live.* | factor.* | research.*\nexport const auditLog: HookHandler = async (ctx) => {\n  await jsonl.append(`audit/${today()}.jsonl`, {\n    ts:        nowIso(),\n    tool:      ctx.toolName,\n    sessionId: ctx.sessionId,\n    isError:   ctx.isError,\n    input:     redact(ctx.toolInput),   // apiKey / approvalToken\n    output:    redact(ctx.toolOutput),  // wallet / ssn / cvv → [REDACTED]\n  });\n  // blocking: false —— 审计是副作用，绝不卡业务路径\n};",
+      "plan-exec": "$ trade.create_plan\n    intent=open_long   symbol=BTCUSDT   side=buy   qty=0.05\n    rationale=\"4h breakout · bull 论据成立\"\n    researchId=rs_8f3a   backtestRunId=bt_91c2     # ← 血缘链\n→ planId=pln_7c91   status=pending   expireAt=+300s\n\n$ trade.approve_plan { planId, reason=\"risk gate pass\" }\n→ approvalToken=tk_…   one-shot · 60s TTL\n\n$ trade.execute_plan { planId, approvalToken }\n→ ok · orderId=ord_4d2a   token consumed",
+      "subagent": "// D-8a：trader / risk subagent 嵌套（4 跳 LLM call · ~15s）\n// D-8a'：拆掉嵌套，全部 tool 直挂 orchestrator —— 性能 ×4\n//        权限边界改由 permissions.yaml 的 deny 强约束\n\n// subagent 仍保留给\"长上下文、可隔离\"的子任务：\nconst reflect = await orch.subagent(\"backtest-reflect\", {\n  prompt: `分析 ${runId} 归因 + 找 lookahead bias 段`,\n  tools:  [\"paper.reflect_backtest\", \"data.get_news\"],  // scoped\n  contextBudget: 8_000,                                  // 不污染主对话\n});",
+      "mcp": "// scripts/smoke-coingecko-mcp.ts —— D-9 spike\nimport { Client } from \"@modelcontextprotocol/sdk/client\";\nimport { StreamableHTTPClientTransport }\n  from \"@modelcontextprotocol/sdk/client/streamableHttp\";\n\nconst t = new StreamableHTTPClientTransport(\n  new URL(\"https://mcp.api.coingecko.com/mcp\"),  // 官方公开端点\n);\nconst client = new Client({ name: \"inalpha\", version: \"0.9\" });\nawait client.connect(t);\nconst tools = await client.listTools();\n// → CoinGecko 32 个 tool 直接挂进 orchestrator · 零胶水",
+      "swarm": "$ swarm.run_backtest_grid\n    candidateIds: [c_3a1, c_7c9, c_5e2]   # D-9 LLM 自创策略\n    symbols:      [BTCUSDT, ETHUSDT, SOLUSDT]\n    venue: binance   timeframe: 1h\n    from: 2025-01-01    to: 2026-05-26\n\n→ grid:     3 × 3 = 9 runs    (cap ≤ 20 by grid-size-cap hook)\n→ workers:  6   wall: 4.2s    ok: 9 / errored: 0\n→ pareto:   3 points (Sharpe ↑  · maxDD ↓)\n→ top1:     c_3a1 on ETHUSDT   fitness=1.84\n            baseline(buy_and_hold)=0.92  ·  alpha ✓"
     }
   },
   "coverage": {
@@ -218,7 +229,7 @@
       "starsSuffix": "stars",
       "contributorsSuffix": "贡献者",
       "commitsSuffix": "提交",
-      "qualityLabel": "alpha 阶段"
+      "qualityLabel": "暂不用于真金"
     },
     "currentState": {
       "title": "诚实告知 ——",
@@ -233,13 +244,8 @@
     "eyebrow": "07 / 开始",
     "title": "Star 它。读它。彻底拆解它。",
     "sub": "Inalpha 仍在 alpha 阶段，AGPL-3.0 协议。请暂缓真金部署——但每一行代码都在 GitHub 公开。",
-    "tabs": {
-      "git": "git clone",
-      "pip": "pip install"
-    },
     "commands": {
-      "git": "git clone https://github.com/mirror29/inalpha",
-      "pip": "pip install inalpha"
+      "git": "git clone https://github.com/mirror29/inalpha"
     },
     "copy": "复制",
     "copied": "已复制",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,9 +10,9 @@
     "node": ">=20"
   },
   "scripts": {
-    "dev": "next dev --port 3000",
+    "dev": "next dev",
     "build": "next build",
-    "start": "next start --port 3000",
+    "start": "next start",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -9,6 +9,9 @@ import { Hero } from "@/components/sections/Hero";
 import { SystemSchematic } from "@/components/sections/SystemSchematic";
 import { UnifiedKernel } from "@/components/sections/UnifiedKernel";
 import { TickerStrip } from "@/components/primitives/TickerStrip";
+import { getGithubStats } from "@/lib/github";
+import { REPO_COORDS } from "@/lib/links";
+import { RELEASE } from "@/lib/release-meta";
 
 export default async function HomePage({
   params,
@@ -18,12 +21,18 @@ export default async function HomePage({
   const { locale } = await params;
   setRequestLocale(locale);
 
+  // server-side fetch；1h ISR；失败时 GlobalCoverage 自己走兜底
+  const githubStats = await getGithubStats({
+    owner: REPO_COORDS.owner,
+    repo: REPO_COORDS.name,
+  });
+
   const tickerItems = [
     "INALPHA",
     "OPEN-SOURCE QUANT AGENT FRAMEWORK",
-    "D-9",
-    "REV 0.9",
-    "2026.05.26",
+    RELEASE.phase,
+    `REV ${RELEASE.rev}`,
+    RELEASE.dateDot,
     "AUDIT-GRADE EVOLUTION",
     "FACTOR LAB · RISK ENGINE",
     "PLAN · APPROVE · EXECUTE",
@@ -45,7 +54,7 @@ export default async function HomePage({
         <SystemSchematic />
         <UnifiedKernel />
         <EngineeringHarness />
-        <GlobalCoverage />
+        <GlobalCoverage stats={githubStats} />
       </main>
 
       <CTAFooter />

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -126,4 +126,54 @@
   .caret-blink {
     animation: caret 1.06s steps(1, end) infinite;
   }
+
+  /* ── Hero backdrop ───────────────────────────────────────────
+     Decision-log stream: dot grid drifts slowly underneath while
+     half-transparent JSONL audit lines rise from the bottom edge,
+     fade in, drift past the title, fade out at the top. Mono only
+     — looks like a live audit trail playing behind the wordmark.
+     prefers-reduced-motion handled at the bottom of this file. */
+  @keyframes drift-dots {
+    0%   { background-position:   0px   0px; }
+    100% { background-position: 280px -280px; }
+  }
+  .drift-dots {
+    animation: drift-dots 70s linear infinite;
+  }
+
+  /* `top` animation (NOT transform) so the travel is relative to the
+     containing LogColumn (which has inset-y-0 → full hero height),
+     not the element's own ~16px line height. */
+  @keyframes log-rise {
+    0%   { top: 105%; opacity: 0;    }
+    8%   {            opacity: 0.85; }
+    55%  {            opacity: 0.85; }
+    92%  {            opacity: 0.45; }
+    100% { top: -8%;  opacity: 0;    }
+  }
+  .log-rise {
+    animation-name: log-rise;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    will-change: top, opacity;
+  }
+}
+
+/* Honor system-level motion preferences for animations that strobe /
+   flicker / fast-pan. log-rise is deliberately excluded — it's a slow,
+   linear drift used as the Hero's *content surface*; killing it leaves
+   the hero visually empty and harms vestibular users more than the
+   gentle drift itself. */
+@media (prefers-reduced-motion: reduce) {
+  .drift-dots,
+  .ticker-scroll,
+  .pulse-glow,
+  .caret-blink {
+    animation: none !important;
+  }
+  /* Slow log-rise way down rather than killing it, so motion-sensitive
+     users still see the audit-trail content but without a sense of speed. */
+  .log-rise {
+    animation-duration: 240s !important;
+  }
 }

--- a/apps/web/src/components/primitives/HeroBackdrop.tsx
+++ b/apps/web/src/components/primitives/HeroBackdrop.tsx
@@ -1,0 +1,118 @@
+/**
+ * Hero 背景 —— 右侧的决策日志流。
+ *
+ * 日志流贴 hero 右半部分上升漂浮，像角落里一块开着的 monitor。
+ * 标题占据左 / 中视觉重心，日志在右侧不抢戏，呼应 "agent + audit" 主题。
+ *
+ * 三层：
+ *   1. 慢速 pan 的 dot field 打底（70s · 中心向外渐隐）。
+ *   2. 右侧 LogStream：18 行独立 delay/duration，从底部漂到顶部。
+ *   3. 底部 → bg 渐隐，无缝衔接下方 BlackBoxProblem。
+ *
+ * 全部 CSS-only；prefers-reduced-motion 仅降速到 240s（保留内容可见性）。
+ */
+
+const LOG_LINES = [
+  '{ts:"08:01:12.441Z", agent:"bull",  action:"propose",      symbol:"BTCUSDT", confidence:0.62}',
+  '{ts:"08:01:09.118Z", agent:"risk",  action:"approve",      planId:"pln_7c91", ttl:60s}',
+  '{ts:"08:01:06.902Z", hook:"audit-log", tool:"trade.execute_plan", isError:false}',
+  '{ts:"08:01:03.774Z", agent:"bear",  action:"counter",      thesis:"vol regime shift"}',
+  '{ts:"08:00:58.215Z", tool:"swarm.run_backtest_grid", workers:6,  runs:9,  wall_ms:4218}',
+  '{ts:"08:00:54.030Z", tool:"data.get_bars",   venue:"binance", fresh:true,  bars:240}',
+  '{ts:"08:00:49.667Z", hook:"grid-size-cap",  decision:"allow", grid:9, cap:20}',
+  '{ts:"08:00:47.001Z", tool:"research.deep_dive", asOf:"2026-05-28T08:00Z", analysts:3}',
+  '{ts:"08:00:42.318Z", tool:"trade.create_plan", intent:"open_long", qty:0.05, expireAt:+300s}',
+  '{ts:"08:00:38.882Z", tool:"paper.run_backtest", strategy:"donchian(20)", sharpe:2.14}',
+  '{ts:"08:00:34.501Z", hook:"strategy-code-audit", verdict:"pass", lints:0}',
+  '{ts:"08:00:31.220Z", tool:"factor.compute", id:"f_mom_12_2", windowDays:12,  ic:0.18}',
+  '{ts:"08:00:27.064Z", agent:"orchestrator", route:"swarm.run_backtest_grid"}',
+  '{ts:"08:00:22.770Z", tool:"trade.approve_plan", approvalToken:"tk_[REDACTED]", oneShot:true}',
+  '{ts:"08:00:18.143Z", tool:"data.backfill_bars", venue:"yfinance", symbol:"^GSPC", days:365}',
+  '{ts:"08:00:14.301Z", hook:"inject-current-date", asOf:"2026-05-28", source:"runtime"}',
+  '{ts:"08:00:09.998Z", tool:"paper.compose_strategy", base:"donchian", mutation:"window+5"}',
+  '{ts:"08:00:05.221Z", agent:"orchestrator", maxSteps:15, step:7,  remaining:8}',
+];
+
+/**
+ * 渲染参数。
+ * - VISIBLE_LINES：同时上场的行数（小于 LOG_LINES.length，剩余作池子）
+ * - CYCLE_S：base 周期；所有行共享同一个公倍数周期，spacing = CYCLE_S / N
+ *   严格垂直等距 → 永不重叠
+ * - DUR_JITTER：duration 围绕 base 做 ±jitter 的三档循环，避免节奏死板
+ * - LEFT_BUCKETS：水平偏移按桶取，散开到 0-30% 让行不全从最左切入
+ */
+const VISIBLE_LINES = 12;
+const CYCLE_S = 72;
+const DUR_JITTER = [0, 6, -5] as const; // 三档：72 / 78 / 67
+const LEFT_BUCKETS = [0, 22, 8, 28, 4, 18, 12, 26, 2, 20, 10, 30] as const;
+
+/**
+ * 行级排布：严格等距 delay + 三档 duration + 桶状 left。
+ * 不用 Math.random，避免 SSR / 客户端 hydration mismatch。
+ */
+function lineProps(i: number) {
+  const duration = CYCLE_S + DUR_JITTER[i % DUR_JITTER.length];
+  // 关键：delay 严格等距 = -i × (CYCLE_S / N)，确保任意瞬间相邻两行垂直间距相同
+  const delay = -(i * (CYCLE_S / VISIBLE_LINES));
+  const left = LEFT_BUCKETS[i % LEFT_BUCKETS.length];
+  return { left, duration, delay };
+}
+
+export function HeroBackdrop() {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+    >
+      {/* Layer 1 · drifting dot grid（中心向外渐隐） */}
+      <div className="absolute inset-0 dot-grid drift-dots opacity-40 [mask-image:radial-gradient(ellipse_at_center,black_35%,transparent_82%)]" />
+
+      {/* Layer 2 · 右侧 LogStream（容器贴右半，避开标题占据的左 / 中区） */}
+      <div
+        className="absolute inset-y-0 right-0 w-[52%] overflow-hidden"
+        style={{
+          // 顶部 14% 透明避开 LocaleSwitcher (top-6 right-6) +
+          // ticker strip 余量；右边 fade 让长行温柔切掉
+          maskImage:
+            "linear-gradient(to bottom, transparent, black 14%, black 92%, transparent)",
+          WebkitMaskImage:
+            "linear-gradient(to bottom, transparent, black 14%, black 92%, transparent)",
+        }}
+      >
+        {/* 容器内右侧 fade，让长行边缘虚化（避免硬切观感） */}
+        <div
+          className="absolute inset-0"
+          style={{
+            maskImage:
+              "linear-gradient(to right, transparent, black 8%, black 88%, transparent)",
+            WebkitMaskImage:
+              "linear-gradient(to right, transparent, black 8%, black 88%, transparent)",
+          }}
+        >
+          {Array.from({ length: VISIBLE_LINES }).map((_, i) => {
+            // 从池子里循环取行，让 18 条文案 12 行轮换
+            const line = LOG_LINES[i % LOG_LINES.length];
+            const { left, duration, delay } = lineProps(i);
+            return (
+              <span
+                key={i}
+                className="log-rise absolute whitespace-nowrap font-mono text-[11.5px] font-light tracking-tight text-fg-muted/30"
+                style={{
+                  left: `${left}%`,
+                  right: 0,
+                  animationDuration: `${duration}s`,
+                  animationDelay: `${delay}s`,
+                }}
+              >
+                {line}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Bottom-edge fade —— 跟下方 BlackBoxProblem 无缝衔接 */}
+      <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-b from-transparent to-bg" />
+    </div>
+  );
+}

--- a/apps/web/src/components/primitives/TerminalBlock.tsx
+++ b/apps/web/src/components/primitives/TerminalBlock.tsx
@@ -1,88 +1,247 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useReducedMotion } from "motion/react";
 
 import { cn } from "@/lib/cn";
 import { TYPEWRITER_MS_PER_CHAR } from "@/lib/motion";
 
 interface TerminalBlockProps {
-  /** Shell prompt prefix. Defaults to `$ inalpha>`. */
+  /** 可选的全局 prompt 前缀（kit 页面用）。Engineering harness 留空，让样本自带 `$` / `→`。 */
   prompt?: string;
   /**
-   * Lines to render. Pass a string for one-liners, array for multi-line.
-   * Typewriter walks character-by-character across the entire flattened text.
+   * 渲染的内容。string 当一行；array 当多行。
+   * typewriter 模式逐字打完整段（按 \n 重排）。
    */
   content: string | string[];
-  /** Replay-able typewriter animation. Off by default. */
+  /** Replay-able typewriter animation. 默认 off。 */
   typewriter?: boolean;
-  /** Pin to the viewport while the parent section scrolls past. */
+  /** Pin to viewport while parent section scrolls past. */
   scrollPin?: boolean;
-  /** Optional caption above the chrome (e.g., file name). */
+  /** Caption above chrome（e.g. file name + ADR ref）。 */
   caption?: string;
+  /**
+   * 锁定最小行数高度。caller 切换不同 content 时传一个固定的 max 行数，
+   * 终端高度就不会随内容变化而跳动。默认按 content 自身行数算。
+   */
+  minLines?: number;
   className?: string;
 }
 
 /**
- * macOS-chrome terminal block. Used by EngineeringHarness §10.6 and
- * AgentDebateDemo §10.4. No syntax highlighting — pure mono.
+ * macOS-chrome 终端块。
  *
- * Typewriter respects `prefers-reduced-motion`: full text is shown immediately.
+ * 配色（D-9 终端化重写）：
+ *   - 背景：近黑 `#04060d` + cyan 细边框 + 上方 chrome 一段微凸起
+ *   - chrome 三色点保留品牌色（不学 macOS 灰）
+ *   - 右上角小指示器：typewriter 跑时是 `bull` 脉冲 + "EXEC"，跑完转 "IDLE"
+ *   - 行内 token 高亮：注释 muted、字符串 gold、数字 bull、状态词
+ *     (`ok/pass/approved` → bull / `deny/error/errored` → fox-red /
+ *     `[REDACTED]` → fox-red)、prefix `$` 与 `→` cyan
+ *
+ * 动画：
+ *   - typewriter 默认 off；开启后**每次 content 变化都重新打字**（HMR / chip
+ *     切换友好）；末尾常驻 caret 闪烁直到打完
+ *   - prefers-reduced-motion 时一次性显示完整文本（不打字、无 caret）
  */
 export function TerminalBlock({
-  prompt = "$ inalpha>",
+  prompt = "",
   content,
   typewriter = false,
   scrollPin = false,
   caption,
+  minLines,
   className,
 }: TerminalBlockProps) {
   const lines = Array.isArray(content) ? content : [content];
   const fullText = lines.join("\n");
   const reduced = useReducedMotion();
   const [shown, setShown] = useState(typewriter && !reduced ? "" : fullText);
-  const ranRef = useRef(false);
+  const intervalRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!typewriter || reduced || ranRef.current) return;
-    ranRef.current = true;
+    // 每次 content 切换：清理旧 interval 再重新打字
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    if (!typewriter || reduced) {
+      setShown(fullText);
+      return;
+    }
+    setShown("");
     let i = 0;
-    const id = window.setInterval(() => {
+    intervalRef.current = window.setInterval(() => {
       i += 1;
       setShown(fullText.slice(0, i));
-      if (i >= fullText.length) window.clearInterval(id);
+      if (i >= fullText.length && intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
     }, TYPEWRITER_MS_PER_CHAR);
-    return () => window.clearInterval(id);
+    return () => {
+      if (intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
   }, [typewriter, reduced, fullText]);
+
+  const isTyping = typewriter && !reduced && shown.length < fullText.length;
+  const shownLines = useMemo(() => shown.split("\n"), [shown]);
+  // 锁定 pre 最小高度。优先用 caller 传的 minLines（让多个不同 content
+  // 之间高度一致），否则按当前 content 行数。1.6em 是 leading-[1.6]。
+  const fullLineCount = useMemo(() => fullText.split("\n").length, [fullText]);
+  const heightLines = Math.max(fullLineCount, minLines ?? 0);
+  const preMinHeight = `${heightLines * 1.6}em`;
 
   return (
     <div
       className={cn(
-        "overflow-hidden rounded-lg border border-border-subtle bg-bg-deep font-mono text-sm",
+        "overflow-hidden rounded-lg border border-cyan/15 bg-[#04060d] font-mono text-sm shadow-[0_0_0_1px_rgba(95,179,255,0.05),0_24px_48px_-24px_rgba(95,179,255,0.18)]",
         scrollPin && "sticky top-24",
         className,
       )}
     >
-      {/* macOS chrome — three dots use brand tri-color, not the OS palette */}
-      <div className="flex items-center gap-2 border-b border-border-subtle px-4 py-2.5">
-        <span aria-hidden className="size-2.5 rounded-full bg-fox-red/70" />
-        <span aria-hidden className="size-2.5 rounded-full bg-gold/70" />
-        <span aria-hidden className="size-2.5 rounded-full bg-bull/70" />
+      {/* chrome bar */}
+      <div className="flex items-center gap-2 border-b border-cyan/12 bg-[#080c18] px-4 py-2.5">
+        <span aria-hidden className="size-2.5 rounded-full bg-fox-red/75" />
+        <span aria-hidden className="size-2.5 rounded-full bg-gold/75" />
+        <span aria-hidden className="size-2.5 rounded-full bg-bull/75" />
         {caption ? (
-          <span className="ml-3 font-mono text-[11px] text-fg-muted">{caption}</span>
+          <span className="ml-3 font-mono text-[11px] tracking-tight text-fg-muted/85">
+            {caption}
+          </span>
         ) : null}
+        <span className="ml-auto flex items-center gap-1.5 font-mono text-[9.5px] uppercase tracking-[0.22em]">
+          <span
+            aria-hidden
+            className={cn(
+              "size-1.5 rounded-full transition-colors",
+              isTyping ? "bg-bull animate-pulse" : "bg-fg-muted/30",
+            )}
+          />
+          <span className={isTyping ? "text-bull/80" : "text-fg-muted/45"}>
+            {isTyping ? "exec" : "idle"}
+          </span>
+        </span>
       </div>
-      <pre className="overflow-x-auto px-4 py-3 leading-relaxed text-fg-muted">
-        <code>
-          <span className="select-none text-cyan/70">{prompt}</span>{" "}
-          <span className="text-fg">{shown}</span>
-          {typewriter && !reduced && shown.length < fullText.length ? (
-            <span aria-hidden className="ml-0.5 inline-block w-2 animate-pulse bg-cyan">
-              &nbsp;
-            </span>
+
+      {/* body —— min-height 锁住，避免 typewriter 期间高度跳动 */}
+      <pre
+        className="overflow-x-auto px-4 py-3 leading-[1.6] text-fg/90"
+        style={{ minHeight: preMinHeight }}
+      >
+        <code className="block">
+          {prompt ? (
+            <>
+              <span className="select-none text-cyan/75">{prompt}</span>{" "}
+            </>
           ) : null}
+          {shownLines.map((line, idx) => (
+            <span key={idx} className="block">
+              {renderTokens(line)}
+              {isTyping && idx === shownLines.length - 1 ? (
+                <span
+                  aria-hidden
+                  className="ml-0.5 inline-block h-[1em] w-[0.6em] translate-y-[2px] bg-cyan/85 align-middle caret-blink"
+                />
+              ) : null}
+            </span>
+          ))}
         </code>
       </pre>
     </div>
   );
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Tokenizer —— 行级 + 行内组合
+// ───────────────────────────────────────────────────────────────────
+
+interface TokenSpan {
+  text: string;
+  cls?: string;
+}
+
+/** 整行 prefix 类型（`#` / `//` / `$` / `→`），剩余部分继续走 inline tokenizer。 */
+function renderTokens(line: string): ReactNode {
+  // 整行注释
+  if (/^\s*(\/\/|#)/.test(line)) {
+    return <span className="italic text-fg-muted/55">{line || " "}</span>;
+  }
+
+  // shell prompt
+  const dollarMatch = line.match(/^(\s*)\$\s?/);
+  if (dollarMatch) {
+    const indent = dollarMatch[1];
+    const rest = line.slice(dollarMatch[0].length);
+    return (
+      <>
+        {indent}
+        <span className="text-cyan/80">$</span>{" "}
+        <span className="text-fg">{inlineTokens(rest)}</span>
+      </>
+    );
+  }
+
+  // output arrow
+  const arrowMatch = line.match(/^(\s*)→\s?/);
+  if (arrowMatch) {
+    const indent = arrowMatch[1];
+    const rest = line.slice(arrowMatch[0].length);
+    return (
+      <>
+        {indent}
+        <span className="text-cyan/80">→</span>{" "}
+        <span className="text-fg/85">{inlineTokens(rest)}</span>
+      </>
+    );
+  }
+
+  // 空行保留高度
+  if (line === "") return " ";
+
+  return inlineTokens(line);
+}
+
+/**
+ * 行内 token 高亮：状态词 / 字符串字面量 / 数字 / [REDACTED]。
+ *
+ * 单 regex 取并集，按 group index 决定 className。其余文本走默认色（继承 pre 的 fg/90）。
+ */
+const INLINE_TOKEN_RE = new RegExp(
+  [
+    "(\\[REDACTED\\])", // 1: redacted
+    "(\\balpha\\s+✓|\\b(?:ok|pass|approved|true)\\b)", // 2: positive status
+    "(\\b(?:deny|denied|errored|failed?|reject(?:ed)?|false)\\b)", // 3: negative status
+    '("[^"\\n]*"|\'[^\'\\n]*\')', // 4: string literal
+    "(\\b\\d+(?:\\.\\d+)?(?:[smhd]|ms|s)?\\b)", // 5: number (optional time unit)
+  ].join("|"),
+  "g",
+);
+
+function inlineTokens(text: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  for (const m of text.matchAll(INLINE_TOKEN_RE)) {
+    const start = m.index!;
+    if (start > last) out.push(text.slice(last, start));
+    const matched = m[0];
+    let cls = "";
+    if (m[1]) cls = "text-fox-red font-medium";
+    else if (m[2]) cls = "text-bull";
+    else if (m[3]) cls = "text-fox-red";
+    else if (m[4]) cls = "text-gold/85";
+    else if (m[5]) cls = "text-bull/85";
+    out.push(
+      <span key={`t${key++}`} className={cls}>
+        {matched}
+      </span>,
+    );
+    last = start + matched.length;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out;
 }

--- a/apps/web/src/components/sections/BlackBoxProblem.tsx
+++ b/apps/web/src/components/sections/BlackBoxProblem.tsx
@@ -1,16 +1,32 @@
 "use client";
 
+import { Check, X } from "lucide-react";
 import { motion } from "motion/react";
 import { useTranslations } from "next-intl";
 
 import { BroadsheetSection } from "@/components/primitives/BroadsheetSection";
 import { fadeUp, stagger } from "@/lib/motion";
 
-const ROWS = ["signal", "reason", "replay"] as const;
+const ROWS = ["lineage", "replay", "guardrail"] as const;
 
 /**
- * 01 — The problem. Side-by-side comparison: what you want · black-box LLM · Inalpha.
- * Hairline grid, no card chrome — feels like a printed comparison table.
+ * 01 — The problem. Split-screen 视觉对峙：3 回合，每回合左红右青对置。
+ *
+ *   ─ 01 / LINEAGE · 血缘 ───────────  black box  vs  inalpha  ──
+ *   ╔═══════════════════════════╦═══════════════════════════════╗
+ *   ║ 01                        ║ 01                            ║
+ *   ║ ✗  「做多 BTC 0.62」     ║ ✓  research_id → backtest_…  ║
+ *   ║    源数据/prompt/模型版本   ║    全链 UUID，任意点反查       ║
+ *   ║ [fox-red glow]            ║ [cyan glow]                   ║
+ *   ╚═══════════════════════════╩═══════════════════════════════╝
+ *
+ * 设计要点：
+ *   - 每行独立 article，自带 eyebrow + 两半 split panel
+ *   - 大数字 `01/02/03` display-italic（跟 Hero 同字体）作视觉重锚
+ *   - 左半 fox-red 径向渐变 + ✗ 大图标；右半 cyan 径向渐变 + ✓ 大图标
+ *   - 中央一根 fox-red→cyan 渐变竖线，象征"对峙"
+ *   - hover：accent 强化（边线饱和度 + 渐变更深 + 图标 scale），3 处同时响应
+ *   - 移动端塌成上下堆叠，中央竖线变成横分隔条
  */
 export function BlackBoxProblem() {
   const t = useTranslations("problem");
@@ -34,42 +50,126 @@ export function BlackBoxProblem() {
         whileInView="visible"
         viewport={{ once: true, margin: "-80px" }}
         variants={stagger}
-        className="overflow-hidden border border-fg/12"
+        className="space-y-6"
       >
-        {/* Header row */}
-        <motion.div
-          variants={fadeUp}
-          className="grid grid-cols-12 border-b border-fg/12 font-mono text-[10px] uppercase tracking-[0.24em] text-fg-muted/70"
-        >
-          <div className="col-span-3 p-4">{t("table.header.want")}</div>
-          <div className="col-span-4 border-l border-fg/12 p-4">
-            {t("table.header.blackbox")}
-          </div>
-          <div className="col-span-5 border-l border-fg/12 p-4 text-cyan">
-            {t("table.header.inalpha")}
-          </div>
-        </motion.div>
+        {ROWS.map((row, idx) => {
+          const num = String(idx + 1).padStart(2, "0");
+          return (
+            <motion.article
+              key={row}
+              variants={fadeUp}
+              className="group relative overflow-hidden rounded-md border border-fg/10 bg-bg-deep/40"
+            >
+              {/* eyebrow ribbon */}
+              <header className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-b border-fg/10 bg-bg-deep/60 px-5 py-3">
+                <div className="flex items-baseline gap-3">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.32em] text-fg-muted/60">
+                    {num}
+                  </span>
+                  <span className="font-mono text-[13px] uppercase tracking-[0.22em] text-fg">
+                    {t(`table.${row}.want`)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.26em]">
+                  <span className="text-fox-red/75">black&nbsp;box</span>
+                  <span className="text-fg-muted/30">vs</span>
+                  <span className="text-cyan/85">inalpha</span>
+                </div>
+              </header>
 
-        {/* Body rows */}
-        {ROWS.map((row, idx) => (
-          <motion.div
-            key={row}
-            variants={fadeUp}
-            className={`grid grid-cols-12 ${
-              idx < ROWS.length - 1 ? "border-b border-fg/12" : ""
-            }`}
-          >
-            <div className="col-span-3 p-4 font-mono text-[13px] uppercase tracking-[0.16em] text-fg">
-              {t(`table.${row}.want`)}
-            </div>
-            <div className="col-span-4 border-l border-fg/12 p-4 text-[14px] leading-relaxed text-fg-muted/80">
-              <span className="font-mono italic">{t(`table.${row}.blackbox`)}</span>
-            </div>
-            <div className="col-span-5 border-l border-fg/12 p-4 text-[14px] leading-relaxed text-fg">
-              {t(`table.${row}.inalpha`)}
-            </div>
-          </motion.div>
-        ))}
+              {/* split body */}
+              <div className="relative grid grid-cols-1 md:grid-cols-2">
+                {/* 左 · 黑盒（fox-red glow） */}
+                <div className="relative overflow-hidden border-b border-fg/10 px-6 py-7 md:border-b-0 md:border-r md:border-fg/10 md:px-8 md:py-9">
+                  {/* fox-red radial glow */}
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-0 transition-opacity duration-300 group-hover:opacity-100"
+                    style={{
+                      background:
+                        "radial-gradient(ellipse at 0% 100%, rgba(200,70,60,0.18), rgba(200,70,60,0.06) 45%, transparent 78%)",
+                      opacity: 0.7,
+                    }}
+                  />
+                  <div className="relative flex items-start gap-5">
+                    {/* 大数字 + 图标列 */}
+                    <div className="flex flex-col items-start gap-3 shrink-0">
+                      <span
+                        className="display-italic leading-none text-fox-red/30 transition-colors group-hover:text-fox-red/55"
+                        style={{
+                          fontSize: "clamp(2.75rem, 5.5vw, 4.25rem)",
+                          fontWeight: 300,
+                        }}
+                      >
+                        {num}
+                      </span>
+                      <span className="inline-flex size-7 items-center justify-center rounded-full border border-fox-red/40 bg-fox-red/10 text-fox-red transition-all group-hover:scale-110 group-hover:border-fox-red/85">
+                        <X className="size-4 stroke-[2.5]" />
+                      </span>
+                    </div>
+                    {/* 内容 */}
+                    <div className="min-w-0 flex-1">
+                      <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-fox-red/65">
+                        Black box LLM
+                      </p>
+                      <p className="mt-3 font-mono text-[15.5px] italic leading-relaxed text-fg-muted/90">
+                        {t(`table.${row}.blackbox`)}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* 中央竖线（仅桌面） + vs glyph */}
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 md:block"
+                  style={{
+                    background:
+                      "linear-gradient(to bottom, transparent, rgba(200,70,60,0.4), rgba(95,179,255,0.4), transparent)",
+                  }}
+                />
+
+                {/* 右 · Inalpha（cyan glow） */}
+                <div className="relative overflow-hidden px-6 py-7 md:px-8 md:py-9">
+                  {/* cyan radial glow */}
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-0 transition-opacity duration-300 group-hover:opacity-100"
+                    style={{
+                      background:
+                        "radial-gradient(ellipse at 100% 0%, rgba(95,179,255,0.20), rgba(95,179,255,0.07) 45%, transparent 78%)",
+                      opacity: 0.7,
+                    }}
+                  />
+                  <div className="relative flex items-start gap-5">
+                    <div className="flex flex-col items-start gap-3 shrink-0">
+                      <span
+                        className="display-italic leading-none text-cyan/35 transition-colors group-hover:text-cyan/70"
+                        style={{
+                          fontSize: "clamp(2.75rem, 5.5vw, 4.25rem)",
+                          fontWeight: 300,
+                        }}
+                      >
+                        {num}
+                      </span>
+                      <span className="inline-flex size-7 items-center justify-center rounded-full border border-cyan/45 bg-cyan/10 text-cyan transition-all group-hover:scale-110 group-hover:border-cyan/90">
+                        <Check className="size-4 stroke-[2.5]" />
+                      </span>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-cyan/75">
+                        Inalpha
+                      </p>
+                      <p className="mt-3 text-[15.5px] leading-relaxed text-fg">
+                        {t(`table.${row}.inalpha`)}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </motion.article>
+          );
+        })}
       </motion.div>
     </BroadsheetSection>
   );

--- a/apps/web/src/components/sections/CTAFooter.tsx
+++ b/apps/web/src/components/sections/CTAFooter.tsx
@@ -3,24 +3,22 @@
 import { ArrowUpRight } from "lucide-react";
 import { motion } from "motion/react";
 import Link from "next/link";
-import { useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { CopyableCommand } from "@/components/primitives/CopyableCommand";
-import { cn } from "@/lib/cn";
+import { LINKS } from "@/lib/links";
 import { fadeUp } from "@/lib/motion";
-
-type TabKey = "git" | "pip";
+import { releaseFootline } from "@/lib/release-meta";
 
 /**
  * 07 — Closing CTA + footer.
  * Same bracketed-header rhythm as the other broadsheet sections so the
- * page closes the way it opens. Tabs flip between `git clone` and `pip install`.
+ * page closes the way it opens. Single `git clone` command — no pip yet
+ * (package not published to PyPI, kept off the page to avoid copy-paste 404s).
  */
 export function CTAFooter() {
   const t = useTranslations("cta");
   const tf = useTranslations("footer");
-  const [tab, setTab] = useState<TabKey>("git");
 
   return (
     <section className="relative border-t border-fg/12">
@@ -58,31 +56,9 @@ export function CTAFooter() {
             {t("sub")}
           </motion.p>
 
-          {/* Tab toggle */}
-          <motion.div
-            variants={fadeUp}
-            className="mt-12 inline-flex border border-fg/15 font-mono text-[11px] uppercase tracking-[0.2em]"
-          >
-            {(["git", "pip"] as TabKey[]).map((key) => (
-              <button
-                key={key}
-                type="button"
-                onClick={() => setTab(key)}
-                className={cn(
-                  "px-4 py-2 transition-colors",
-                  tab === key
-                    ? "bg-fg text-bg"
-                    : "text-fg-muted hover:bg-bg-deep hover:text-fg",
-                )}
-              >
-                {t(`tabs.${key}`)}
-              </button>
-            ))}
-          </motion.div>
-
-          <motion.div variants={fadeUp} className="mt-3 max-w-xl">
+          <motion.div variants={fadeUp} className="mt-12 max-w-xl">
             <CopyableCommand
-              command={t(`commands.${tab}`)}
+              command={t("commands.git")}
               copyLabel={t("copy")}
               copiedLabel={t("copied")}
             />
@@ -93,7 +69,7 @@ export function CTAFooter() {
             className="mt-8 flex flex-wrap items-center gap-x-8 gap-y-3"
           >
             <Link
-              href="https://github.com/mirror29/inalpha"
+              href={LINKS.github}
               target="_blank"
               rel="noreferrer"
               className="group inline-flex items-center gap-2 border border-fg/20 px-5 py-2.5 font-mono text-[12px] uppercase tracking-[0.22em] text-fg transition-colors hover:border-cyan hover:text-cyan"
@@ -102,7 +78,7 @@ export function CTAFooter() {
               <ArrowUpRight className="size-3.5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
             </Link>
             <Link
-              href="https://github.com/mirror29/inalpha/blob/main/LICENSE"
+              href={LINKS.license}
               target="_blank"
               rel="noreferrer"
               className="font-mono text-[11px] uppercase tracking-[0.22em] text-fg-muted underline-offset-4 hover:text-fg hover:underline"
@@ -126,7 +102,7 @@ export function CTAFooter() {
           </div>
           <div className="col-span-6 md:col-span-3">
             <p className="text-fg/40">rev</p>
-            <p className="mt-1.5 text-fg-muted">0.9-D9 · 2026.05.26</p>
+            <p className="mt-1.5 text-fg-muted">{releaseFootline}</p>
           </div>
           <div className="col-span-6 md:col-span-3">
             <p className="text-fg/40">© rights</p>

--- a/apps/web/src/components/sections/DualThesis.tsx
+++ b/apps/web/src/components/sections/DualThesis.tsx
@@ -85,20 +85,31 @@ function ThesisColumn({
 }) {
   const accentColor = accent === "cyan" ? "text-cyan" : "text-gold";
   const accentBar = accent === "cyan" ? "bg-cyan" : "bg-gold";
+  const accentGlow =
+    accent === "cyan"
+      ? "radial-gradient(ellipse at 0% 0%, rgba(95,179,255,0.10), transparent 60%)"
+      : "radial-gradient(ellipse at 0% 0%, rgba(212,167,68,0.10), transparent 60%)";
   const dotColor = accent === "cyan" ? "bg-cyan/70" : "bg-gold/70";
   return (
     <motion.article
       variants={slideInTilt}
       custom={direction}
-      className="group relative flex flex-col gap-8 bg-bg p-8 md:p-10"
+      className="group relative flex flex-col gap-8 overflow-hidden bg-bg p-8 transition-all duration-300 hover:-translate-y-0.5 hover:bg-bg-deep md:p-10"
     >
+      {/* accent 竖线：rest 1px/opacity 70，hover 2px/opacity 100 */}
       <span
         aria-hidden
-        className={`absolute left-0 top-0 h-full w-px ${accentBar} opacity-70`}
+        className={`absolute left-0 top-0 h-full w-px opacity-70 transition-all duration-300 group-hover:w-[2px] group-hover:opacity-100 ${accentBar}`}
       />
-      <header className="space-y-3">
+      {/* accent radial glow：rest 隐藏，hover 淡入 */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+        style={{ background: accentGlow }}
+      />
+      <header className="relative space-y-3">
         <p
-          className={`font-mono text-[11px] uppercase tracking-[0.32em] ${accentColor}`}
+          className={`font-mono text-[11px] uppercase tracking-[0.32em] transition-all duration-300 group-hover:tracking-[0.4em] ${accentColor}`}
         >
           {letter}.
         </p>
@@ -109,7 +120,7 @@ function ThesisColumn({
           {header}
         </h3>
       </header>
-      <ul className="space-y-3.5">
+      <ul className="relative space-y-3.5">
         {items.map((item) => (
           <li
             key={item}
@@ -117,13 +128,13 @@ function ThesisColumn({
           >
             <span
               aria-hidden
-              className={`mt-2 inline-block size-1.5 shrink-0 rounded-full ${dotColor} transition-transform group-hover/item:scale-125`}
+              className={`mt-2 inline-block size-1.5 shrink-0 rounded-full transition-transform group-hover/item:scale-125 ${dotColor}`}
             />
             <span>{item}</span>
           </li>
         ))}
       </ul>
-      <footer className="mt-auto border-t border-fg/10 pt-5 font-mono text-[11px] uppercase tracking-[0.18em] text-fg-muted">
+      <footer className="relative mt-auto border-t border-fg/10 pt-5 font-mono text-[11px] uppercase tracking-[0.18em] text-fg-muted transition-colors group-hover:text-fg/80">
         ── {footer}
       </footer>
     </motion.article>

--- a/apps/web/src/components/sections/EngineeringHarness.tsx
+++ b/apps/web/src/components/sections/EngineeringHarness.tsx
@@ -1,20 +1,31 @@
 "use client";
 
-import { motion } from "motion/react";
+import { AnimatePresence, motion } from "motion/react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { BroadsheetSection } from "@/components/primitives/BroadsheetSection";
 import { TerminalBlock } from "@/components/primitives/TerminalBlock";
+import { cn } from "@/lib/cn";
 import { fadeUp, stagger } from "@/lib/motion";
 
-const CHIPS = ["hooks", "permissions", "plan-exec", "subagent", "mcp", "swarm"] as const;
+const CHIPS = ["permissions", "hooks", "plan-exec", "subagent", "mcp", "swarm"] as const;
+type Chip = (typeof CHIPS)[number];
 
 /**
- * 05 — Engineering harness. Permissions config + 6 mechanism chips.
- * Left: real-looking permissions.yaml. Right: harness mechanisms list.
+ * 05 — Engineering harness. Interactive: 右侧 6 个机制 chip 点击后联动左侧终端，
+ * 展示对应真实片段（permissions yaml / hook handler / plan-exec trace 等）。
  */
 export function EngineeringHarness() {
   const t = useTranslations("harness");
+  const [active, setActive] = useState<Chip>("permissions");
+  // 用 t.raw 拿原始字符串，避免 ICU 把样本里 `{ planId, ... }` 当作占位符解析
+  const sampleLines = (t.raw(`samples.${active}`) as string).split("\n");
+  // 全部 chip 共享最大行高，切 chip 不会跳动
+  const maxLines = CHIPS.reduce(
+    (m, c) => Math.max(m, (t.raw(`samples.${c}`) as string).split("\n").length),
+    0,
+  );
 
   return (
     <BroadsheetSection
@@ -32,11 +43,25 @@ export function EngineeringHarness() {
     >
       <div className="grid gap-8 lg:grid-cols-12">
         <div className="lg:col-span-7">
-          <TerminalBlock
-            prompt="$"
-            caption="permissions.yaml"
-            content={t("configSample").split("\n")}
-          />
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={active}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            >
+              <TerminalBlock
+                caption={t(`captions.${active}`)}
+                content={sampleLines}
+                typewriter
+                minLines={maxLines}
+              />
+            </motion.div>
+          </AnimatePresence>
+          <p className="mt-3 font-mono text-[10px] uppercase tracking-[0.22em] text-fg-muted/55">
+            {t("hint")}
+          </p>
         </div>
 
         <motion.ul
@@ -45,32 +70,68 @@ export function EngineeringHarness() {
           viewport={{ once: true, margin: "-80px" }}
           variants={stagger}
           className="space-y-px bg-fg/10 lg:col-span-5"
+          role="tablist"
+          aria-label="harness mechanisms"
         >
-          {CHIPS.map((id, idx) => (
-            <motion.li
-              key={id}
-              variants={fadeUp}
-              className="group flex items-baseline gap-4 bg-bg p-4 transition-colors hover:bg-bg-deep"
-            >
-              <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-fg-muted/60">
-                {String(idx + 1).padStart(2, "0")}
-              </span>
-              <div className="min-w-0 flex-1">
-                <p className="font-mono text-[13px] uppercase tracking-[0.16em] text-fg">
-                  {t(`chips.${id}`)}
-                </p>
-                <p className="mt-1.5 text-[13.5px] leading-relaxed text-fg-muted">
-                  {t(`chipDescs.${id}`)}
-                </p>
-              </div>
-              <span
-                aria-hidden
-                className="font-mono text-fg-muted/30 transition-colors group-hover:text-cyan"
-              >
-                ▸
-              </span>
-            </motion.li>
-          ))}
+          {CHIPS.map((id, idx) => {
+            const isActive = active === id;
+            return (
+              <motion.li key={id} variants={fadeUp}>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  aria-controls="harness-terminal"
+                  onClick={() => setActive(id)}
+                  className={cn(
+                    "group relative flex w-full items-baseline gap-4 p-4 text-left transition-colors",
+                    isActive
+                      ? "bg-bg-deep"
+                      : "bg-bg hover:bg-bg-deep",
+                  )}
+                >
+                  {isActive ? (
+                    <span
+                      aria-hidden
+                      className="absolute left-0 top-0 h-full w-px bg-cyan"
+                    />
+                  ) : null}
+                  <span
+                    className={cn(
+                      "font-mono text-[10px] uppercase tracking-[0.22em]",
+                      isActive ? "text-cyan" : "text-fg-muted/60",
+                    )}
+                  >
+                    {String(idx + 1).padStart(2, "0")}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={cn(
+                        "font-mono text-[13px] uppercase tracking-[0.16em]",
+                        isActive ? "text-cyan" : "text-fg",
+                      )}
+                    >
+                      {t(`chips.${id}`)}
+                    </p>
+                    <p className="mt-1.5 text-[13.5px] leading-relaxed text-fg-muted">
+                      {t(`chipDescs.${id}`)}
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "font-mono transition-colors",
+                      isActive
+                        ? "text-cyan"
+                        : "text-fg-muted/30 group-hover:text-cyan",
+                    )}
+                  >
+                    {isActive ? "▾" : "▸"}
+                  </span>
+                </button>
+              </motion.li>
+            );
+          })}
         </motion.ul>
       </div>
     </BroadsheetSection>

--- a/apps/web/src/components/sections/GlobalCoverage.tsx
+++ b/apps/web/src/components/sections/GlobalCoverage.tsx
@@ -14,13 +14,26 @@ const TAG_GROUPS = {
   macro: ["indices", "macro"] as const,
 };
 
+const TOTAL_MARKETS = Object.values(TAG_GROUPS).reduce(
+  (acc, group) => acc + group.length,
+  0,
+);
+
+interface GlobalCoverageProps {
+  /** Server-side fetched GitHub stats; `null` 时退回静态兜底（仓库当前真实数值）。 */
+  stats?: { stars: number; contributors: number; commits: number } | null;
+}
+
 /**
  * 06 — Global coverage + current state (transparency).
  * Markets grouped + animated stat row + alpha-quality LiveBadges.
  */
-export function GlobalCoverage() {
+export function GlobalCoverage({ stats }: GlobalCoverageProps = {}) {
   const t = useTranslations("coverage");
   const items = t.raw("currentState.items") as string[];
+
+  // 拿不到 GitHub API（rate-limit / 离线 build）时用一个真实但保守的兜底
+  const safeStats = stats ?? { stars: 1, contributors: 1, commits: 170 };
 
   return (
     <BroadsheetSection
@@ -43,16 +56,16 @@ export function GlobalCoverage() {
               <motion.div
                 key={group}
                 variants={fadeUp}
-                className="bg-bg p-6"
+                className="group/coverage relative bg-bg p-6 transition-colors duration-300 hover:bg-bg-deep/60"
               >
-                <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-fg-muted/60">
+                <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-fg-muted/60 transition-colors group-hover/coverage:text-cyan/85">
                   ── {t(`groups.${group}`)} / {tags.length}
                 </p>
                 <ul className="mt-5 flex flex-wrap gap-2">
                   {tags.map((tag) => (
                     <li
                       key={tag}
-                      className="border border-fg/15 px-3 py-1 font-mono text-[11px] uppercase tracking-[0.16em] text-fg-muted transition-colors hover:border-cyan hover:text-cyan"
+                      className="cursor-default border border-fg/15 bg-transparent px-3 py-1 font-mono text-[11px] uppercase tracking-[0.16em] text-fg-muted transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.04] hover:border-cyan hover:bg-cyan/10 hover:text-cyan hover:shadow-[0_0_14px_-4px_rgba(95,179,255,0.5)]"
                     >
                       {t(`tags.${tag}`)}
                     </li>
@@ -71,12 +84,19 @@ export function GlobalCoverage() {
           transition={{ duration: 0.55 }}
           className="flex flex-wrap items-end gap-x-12 gap-y-6 border-y border-fg/12 py-10"
         >
-          <Stat target={142} suffix={t("stats.starsSuffix")} accent="text-cyan" />
-          <Stat target={23} suffix={t("stats.contributorsSuffix")} />
-          <Stat target={487} suffix={t("stats.commitsSuffix")} />
-          <Stat target={12} suffix="markets" accent="text-gold" />
+          <Stat
+            target={safeStats.stars}
+            suffix={t("stats.starsSuffix")}
+            accent="text-cyan"
+          />
+          <Stat
+            target={safeStats.contributors}
+            suffix={t("stats.contributorsSuffix")}
+          />
+          <Stat target={safeStats.commits} suffix={t("stats.commitsSuffix")} />
+          <Stat target={TOTAL_MARKETS} suffix="markets" accent="text-gold" />
           <div className="ml-auto">
-            <LiveBadge label={t("stats.qualityLabel")} />
+            <LiveBadge label={t("stats.qualityLabel")} tint="fox" />
           </div>
         </motion.div>
 
@@ -124,12 +144,12 @@ function Stat({
   accent?: string;
 }) {
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="group/stat flex cursor-default flex-col gap-1.5 transition-transform duration-200 hover:-translate-y-0.5">
       <StatCounter
         target={target}
-        className={`font-mono leading-none tabular-nums text-[clamp(2.25rem,4.4vw,3.75rem)] tracking-tight ${accent}`}
+        className={`font-mono leading-none tabular-nums text-[clamp(2.25rem,4.4vw,3.75rem)] tracking-tight transition-[text-shadow,filter] duration-300 group-hover/stat:[text-shadow:0_0_22px_rgba(95,179,255,0.45)] ${accent}`}
       />
-      <span className="font-mono text-[10px] uppercase tracking-[0.26em] text-fg-muted/70">
+      <span className="font-mono text-[10px] uppercase tracking-[0.26em] text-fg-muted/70 transition-colors group-hover/stat:text-fg/90">
         ── {suffix}
       </span>
     </div>

--- a/apps/web/src/components/sections/Hero.tsx
+++ b/apps/web/src/components/sections/Hero.tsx
@@ -6,8 +6,11 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import { CopyableCommand } from "@/components/primitives/CopyableCommand";
+import { HeroBackdrop } from "@/components/primitives/HeroBackdrop";
 import { LocaleSwitcher } from "@/components/primitives/LocaleSwitcher";
+import { LINKS } from "@/lib/links";
 import { fadeUp } from "@/lib/motion";
+import { releaseTag } from "@/lib/release-meta";
 
 /**
  * Page hero — broadsheet aesthetic, refined.
@@ -21,12 +24,14 @@ export function Hero() {
   const tCta = useTranslations("cta");
 
   return (
-    <header className="relative border-b border-fg/12">
+    <header className="relative overflow-hidden border-b border-fg/12">
+      <HeroBackdrop />
+
       <div className="absolute right-6 top-6 z-50">
         <LocaleSwitcher />
       </div>
 
-      <div className="mx-auto max-w-6xl px-6 pt-16 pb-24 md:px-12 md:pt-24 md:pb-32">
+      <div className="relative z-10 mx-auto max-w-6xl px-6 pt-16 pb-24 md:px-12 md:pt-24 md:pb-32">
         <motion.div
           initial="hidden"
           animate="visible"
@@ -45,7 +50,7 @@ export function Hero() {
             <span className="text-fg-muted/50">/</span>
             <span>open-source quant framework</span>
             <span className="ml-3 hidden h-px w-12 bg-fg/20 sm:inline-block" />
-            <span className="hidden text-fg-muted/60 sm:inline">rev 0.9 · D-9</span>
+            <span className="hidden text-fg-muted/60 sm:inline">{releaseTag}</span>
           </motion.div>
 
           <motion.h1
@@ -76,7 +81,7 @@ export function Hero() {
               className="min-w-[22rem] max-w-md"
             />
             <Link
-              href="https://github.com/mirror29/inalpha"
+              href={LINKS.github}
               target="_blank"
               rel="noreferrer"
               className="group inline-flex items-center gap-2 border-b border-fg/30 pb-1 font-mono text-[12px] uppercase tracking-[0.22em] text-fg-muted transition-colors hover:border-fg hover:text-fg"

--- a/apps/web/src/components/sections/SystemSchematic.tsx
+++ b/apps/web/src/components/sections/SystemSchematic.tsx
@@ -8,6 +8,7 @@ import {
   type LineageEdge,
   type LineageNode,
 } from "@/components/primitives/DataLineagePath";
+import { RELEASE } from "@/lib/release-meta";
 
 /**
  * 03 — Architecture. Hub → spokes → convergence → outputs.
@@ -174,9 +175,9 @@ export function SystemSchematic() {
         flowing
         meta={{
           title: "INALPHA · SYSTEM SCHEMATIC",
-          rev: "0.9-D9",
-          date: "2026.05.26",
-          counts: "9 NODES · 12 LINKS",
+          rev: `${RELEASE.rev}-${RELEASE.phase.replace("-", "")}`,
+          date: RELEASE.dateDot,
+          counts: `${nodes.length} NODES · ${edges.length} LINKS`,
         }}
       />
     </BroadsheetSection>

--- a/apps/web/src/components/sections/UnifiedKernel.tsx
+++ b/apps/web/src/components/sections/UnifiedKernel.tsx
@@ -49,10 +49,24 @@ export function UnifiedKernel() {
           {(["data", "paper", "research"] as const).map((id, i) => (
             <article
               key={id}
-              className="group relative flex flex-col gap-3 bg-bg p-6 transition-colors hover:bg-bg-deep"
+              className="group relative flex flex-col gap-3 overflow-hidden bg-bg p-6 transition-colors duration-300 hover:bg-bg-deep"
             >
-              <header className="flex items-baseline justify-between">
-                <span className="font-mono text-[11px] uppercase tracking-[0.24em] text-fg-muted/70">
+              {/* 左 accent 竖线：rest 0px slide in 到 2px */}
+              <span
+                aria-hidden
+                className="absolute left-0 top-0 h-full w-0 bg-cyan transition-all duration-300 group-hover:w-[2px]"
+              />
+              {/* cyan radial glow，hover 淡入 */}
+              <span
+                aria-hidden
+                className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                style={{
+                  background:
+                    "radial-gradient(ellipse at 0% 100%, rgba(95,179,255,0.10), transparent 60%)",
+                }}
+              />
+              <header className="relative flex items-baseline justify-between">
+                <span className="font-mono text-[11px] uppercase tracking-[0.24em] text-fg-muted/70 transition-colors group-hover:text-cyan/80">
                   {String(i + 1).padStart(2, "0")} / kernel
                 </span>
                 <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted/60">
@@ -60,15 +74,15 @@ export function UnifiedKernel() {
                 </span>
               </header>
               <h4
-                className="display-italic leading-tight text-fg"
+                className="relative display-italic leading-tight text-fg"
                 style={{ fontSize: "clamp(1.5rem, 2.4vw, 2rem)", fontWeight: 400 }}
               >
                 {t(`services.${id}.title`)}
               </h4>
-              <p className="text-[14px] leading-relaxed text-fg-muted">
+              <p className="relative text-[14px] leading-relaxed text-fg-muted transition-colors group-hover:text-fg/80">
                 {t(`services.${id}.desc`)}
               </p>
-              <code className="mt-auto border-l-2 border-cyan/40 bg-bg-deep/60 px-3 py-2 font-mono text-[12px] text-cyan/90">
+              <code className="relative mt-auto border-l-2 border-cyan/40 bg-bg-deep/60 px-3 py-2 font-mono text-[12px] text-cyan/90 transition-all duration-300 group-hover:border-cyan group-hover:text-cyan group-hover:shadow-[0_0_18px_-6px_rgba(95,179,255,0.45)]">
                 {t(`services.${id}.code`)}
               </code>
             </article>

--- a/apps/web/src/lib/github.ts
+++ b/apps/web/src/lib/github.ts
@@ -1,0 +1,95 @@
+/**
+ * GitHub repo stats fetcher（server-only）。
+ *
+ * 用法：
+ *   const stats = await getGithubStats({ owner: "mirror29", repo: "inalpha" });
+ *
+ * 设计：
+ * - stars：`/repos/:o/:r` 一次拿；
+ * - contributors / commits：用 `per_page=1` + 解析 `Link: ...; rel=\"last\"` 拿总数，
+ *   避免拉完整分页（仓库 commit 可能上千，全拉是浪费）；
+ * - 缓存 1h（`next.revalidate`），失败兜底返 `null`，调用方各自决定 fallback 文案 / 数值。
+ * - 未鉴权状态下 GitHub 给 IP 60 req/h，1h cache 足以承接 build + 偶发刷新；
+ *   生产可注入 `GITHUB_TOKEN` 走 5000 req/h。
+ */
+
+export interface GithubStats {
+  stars: number;
+  contributors: number;
+  commits: number;
+}
+
+interface GetStatsOptions {
+  owner: string;
+  repo: string;
+  /** ISR 秒数，默认 3600。 */
+  revalidate?: number;
+}
+
+const HEADERS_BASE: HeadersInit = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+
+function authHeaders(): HeadersInit {
+  const token = process.env.GITHUB_TOKEN;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * 从 `Link: <…&page=N>; rel="last"` 头里解析 last page 号；
+ * 当总数 <= per_page 时 GitHub 不返 Link，此时计 body 长度即可。
+ */
+function parseLastPage(linkHeader: string | null): number | null {
+  if (!linkHeader) return null;
+  const match = linkHeader.match(/<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"/);
+  return match ? Number(match[1]) : null;
+}
+
+async function countWithPagination(
+  url: string,
+  revalidate: number,
+): Promise<number | null> {
+  const res = await fetch(url, {
+    headers: { ...HEADERS_BASE, ...authHeaders() },
+    next: { revalidate },
+  });
+  if (!res.ok) return null;
+  const last = parseLastPage(res.headers.get("link"));
+  if (last !== null) return last;
+  const body = (await res.json()) as unknown[];
+  return Array.isArray(body) ? body.length : null;
+}
+
+export async function getGithubStats({
+  owner,
+  repo,
+  revalidate = 3600,
+}: GetStatsOptions): Promise<GithubStats | null> {
+  try {
+    const base = `https://api.github.com/repos/${owner}/${repo}`;
+
+    const [repoRes, contributors, commits] = await Promise.all([
+      fetch(base, {
+        headers: { ...HEADERS_BASE, ...authHeaders() },
+        next: { revalidate },
+      }),
+      countWithPagination(
+        `${base}/contributors?per_page=1&anon=true`,
+        revalidate,
+      ),
+      countWithPagination(`${base}/commits?per_page=1`, revalidate),
+    ]);
+
+    if (!repoRes.ok) return null;
+    const repoJson = (await repoRes.json()) as { stargazers_count?: number };
+
+    return {
+      stars: repoJson.stargazers_count ?? 0,
+      contributors: contributors ?? 0,
+      commits: commits ?? 0,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/links.ts
+++ b/apps/web/src/lib/links.ts
@@ -1,0 +1,20 @@
+/**
+ * 外链 / 仓库坐标的单点常量。
+ *
+ * `LINKS.github` 是仓库主页；`LINKS.license` 是 LICENSE 文件直链。
+ * 改 owner / repo 时只动 `REPO` 这里。
+ */
+
+const REPO = {
+  owner: "mirror29",
+  name: "inalpha",
+} as const;
+
+export const LINKS = {
+  github: `https://github.com/${REPO.owner}/${REPO.name}`,
+  license: `https://github.com/${REPO.owner}/${REPO.name}/blob/main/LICENSE`,
+  /** 同一来源的 git clone 命令，供 Hero / CTAFooter 复用。 */
+  gitClone: `git clone https://github.com/${REPO.owner}/${REPO.name}`,
+} as const;
+
+export const REPO_COORDS = REPO;

--- a/apps/web/src/lib/release-meta.ts
+++ b/apps/web/src/lib/release-meta.ts
@@ -1,0 +1,24 @@
+/**
+ * 单点维护的发布元信息。
+ *
+ * 任何展示 rev / phase / date 的位置（Hero / TickerStrip / SystemSchematic /
+ * CTAFooter colophon）都从这里读，避免散落硬编码导致版本漂移。
+ *
+ * - 切换 milestone 时只动这里一处。
+ * - `dateDot` 是 broadsheet 点号写法（2026.05.28），`dateIso` 给 SEO / 结构化数据。
+ */
+
+export const RELEASE = {
+  rev: "0.9",
+  phase: "D-9",
+  /** Broadsheet 点号写法，供 UI 展示。 */
+  dateDot: "2026.05.28",
+  /** ISO，供 <time dateTime> 或后续 schema.org。 */
+  dateIso: "2026-05-28",
+} as const;
+
+/** 复合短串，如 "rev 0.9 · D-9"。 */
+export const releaseTag = `rev ${RELEASE.rev} · ${RELEASE.phase}`;
+
+/** 复合长串，如 "0.9-D9 · 2026.05.28"。 */
+export const releaseFootline = `${RELEASE.rev}-${RELEASE.phase.replace("-", "")} · ${RELEASE.dateDot}`;


### PR DESCRIPTION
## Summary

Landing page 一轮大改，重点是把 §01 / §05 / §06 三个模块从「印刷品风克制」推到「贴产品定位的视觉打击」，文案重写得更尖锐 + 接真实数据 + 加交互反馈。

### Hero
- 新 `HeroBackdrop`：右侧贴边的「决策日志流」—— 12 行 mono JSONL 严格几何调度（垂直等距 ~69px，水平 12 个 buckets 散开，duration 三档循环），永不重叠
- 文案池用真实 tool id / hook 名 / 字段名（`trade.execute_plan` / `audit-log` / `grid-size-cap` / `research.deep_dive` 等），懂的人一眼认出是 Inalpha 内部状态
- dot grid 慢速 pan 打底；`prefers-reduced-motion` 仅降速到 240s 而非 disable（不留空背景）

### §01 Problem · 重写
- 文案按产品定位重写：「LLM 把策略写出来很容易 / 替它的每个决策签名才是工程」
- 表格 → 3 张 split-screen 对峙 article：左半 fox-red ✗ + radial glow + 大数字，右半 cyan ✓ + radial glow + 大数字，中央渐变竖线；hover 整张 4 处同时响应
- 3 行内容换成 Inalpha 真硬核机制：**lineage** (`research_id → backtest_run_id → plan_id`) / **replay** (`strategy_id + params_hash + as_of`) / **guardrail** (`permissions.yaml deny + plan/exec TTL token`)

### §05 Engineering harness · 改可交互
- 右侧 6 chip 改为 `role="tablist"` 按钮，点击切换左侧终端
- `TerminalBlock` 全重写：近黑 `#04060d` + cyan 边 + cyan 微辉光 + 右上 EXEC/IDLE 指示器 + 行内 token 高亮（注释/字符串/数字/`[REDACTED]`/`ok|approved`/`deny|error`）+ typewriter + `minLines` 锁定高度（切 chip 不跳）
- 5 个样本按真实代码重写（permissions 不动）：PostToolUse `audit-log` + `redact()` / `trade.create_plan` 三步含 `researchId/backtestRunId` 血缘 / D-8a → D-8a' subagent 演进 / `smoke-coingecko-mcp` 用 `StreamableHTTPClientTransport` / `swarm.run_backtest_grid` + `grid-size-cap` + `fitness vs baseline`

### §06 GlobalCoverage · 真实数据
- 新建 `lib/github.ts` server-only fetcher（用 `Link: rel="last"` 解析 contributors / commits 总数，避免拉完整分页）
- `page.tsx` server 端 fetch、1h `next.revalidate`、`GITHUB_TOKEN` env 走 5000/h、rate-limit 时退到真实兜底 `{stars:1, contributors:1, commits:170}`（原来写死 142/23/487 全假）

### 其他模块
- DualThesis / UnifiedKernel 服务卡 / Coverage tag chip 加 hover 反馈：accent 竖线 slide-in、radial glow 淡入、cyan 辉光阴影、scale + lift
- `lib/release-meta.ts` + `lib/links.ts` 单点常量，消除 Hero / Footer / Schematic / TickerStrip 散落的 rev/D-N/date/github URL 硬编码
- CTAFooter 删假 pip tab（PyPI 上 `inalpha` 404，避免 copy 即翻车）
- LiveBadge 改 `not for live capital` / `暂不用于真金`，跟「诚实告知」段一致
- `package.json` 去掉 `--port 3000` 写死，让 `PORT` env 生效

## Phase

D-9 · landing page polish · 单 PR 单次合并

## Test plan

- [x] `pnpm typecheck` 干净（apps/web）
- [x] `pnpm build` 干净，`/[locale]` 命中 1h ISR
- [x] `bash scripts/check-consistency.sh` 通过（含 2 个历史告警，跟本 PR 无关）
- [ ] 浏览器人工把玩：Hero 日志流不重叠 / Problem 三对照 hover 联动 / §05 chip 切换 + typewriter 高度不跳 / §06 stats 显示真实数据 / Cmd+Shift+R 清缓存看 zh + en
- [ ] Cloudflare preview deploy 跑 lighthouse 一眼

🤖 Generated with [Claude Code](https://claude.com/claude-code)