### PR TITLE
ci(claude-review): 每次 push 重审 + sticky 评论防邮件洪水

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,14 +1,17 @@
 name: Claude PR Review
 
-# PR 打开 / reopen 时自动 review diff（**不**在每次 push 时跑——避免每 push 一轮评论 +
-# 邮件洪水；要对新 commit 重审，去 Actions 页手动跑 workflow_dispatch）。
+# PR 打开 / reopen / 每次 push 新 commit（synchronize）时自动 review diff。
+# 防邮件洪水靠三道闸而非「少触发」：① concurrency + cancel-in-progress 让同一 PR
+# 新 push 立刻取消上一轮；② review step 只维护**一条 sticky 总结评论**
+# （gh pr comment --edit-last 原地覆盖，GitHub 对编辑评论不发邮件，仅首条发一封）；
+# ③ 不逐行贴 inline 评论。需对历史 commit 重审可去 Actions 页跑 workflow_dispatch。
 # 非阻塞设计：即使 Claude 出错（API 超时、token 过期等），
 # 本 workflow 不会阻止 PR 合并。review 评论是锦上添花，不是门禁。
 # Auth: Max/Pro 订阅 OAuth（CLAUDE_CODE_OAUTH_TOKEN），本地 `claude setup-token` 生成
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -94,11 +97,15 @@ jobs:
             - **不重复 lint**：ruff / tsc / mypy 已能抓的不要再提
             - **误报闸**：设计 / 架构类意见必须能说出"在什么输入 / 时序下会真的出问题"的具体失败场景，
               说不出就降级或不提——宁可漏报一条主观的，不要用噪音淹没真问题
-            - **只发一条总结评论**（`gh pr comment`），**不**逐行贴 inline 评论——避免一轮 review
-              触发 N 封邮件。把所有 finding 汇总进这一条，每条用
+            - **只维护一条 sticky 总结评论**，**不**逐行贴 inline 评论。每次 review 都用
+              `gh pr comment <PR> --edit-last --create-if-none --body "..."` **原地覆盖**上一轮结论
+              （首次没有评论时 `--create-if-none` 自动新建；之后编辑同一条，GitHub 对编辑不发邮件，
+              避免每次 push 一封邮件洪水）。**不要**用裸 `gh pr comment` 新建评论。
+              把所有 finding 汇总进这一条，每条用
               `[critical|major|medium] file:line — 一句描述 — 依据(CLAUDE.md §X 或 通用原则:<维度>)` 写清位置。
+              评论开头带一行 `<!-- claude-review -->` 标记 + 本轮 commit 短 sha，方便辨识这是哪一轮。
             - 评论结构：1) 必修（critical / major）2) 可选优化（medium）；没问题 → 一段中文 LGTM，不硬挑刺
-            - 只发这一条 GitHub 评论，不要把审查文字当聊天消息发
+            - 只维护这一条 GitHub 评论，不要把审查文字当聊天消息发
 
           claude_args: |
             --allowedTools "Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"


### PR DESCRIPTION
## 背景

#35 为消除邮件洪水把 Claude PR Review 的触发砍成只剩 `opened` / `reopened`，副作用是**每次 push 新 commit 不再重审**（用户希望每次 push 都重审）。

## 改动

`.github/workflows/claude-review.yml`：

- 触发加回 `synchronize` → `[opened, reopened, synchronize]`，恢复每次 push 重审
- review step 改为维护**一条 sticky 总结评论**：`gh pr comment --edit-last --create-if-none` 原地覆盖上一轮结论。GitHub 对**编辑**评论不发邮件，仅首条发一封 → 既每 push 重审又几乎零邮件
- 叠加已有的 `concurrency` + `cancel-in-progress`（新 push 取消上一轮在跑的 review）

## 防洪三道闸

| 闸 | 作用 |
|---|---|
| concurrency cancel-in-progress | 同 PR 新 push 立刻取消上一轮 review |
| sticky 评论（edit-last） | 编辑同一条评论，不新建 → 不发新邮件 |
| 不贴 inline 评论 | 全部 finding 汇进一条总结 |

`allowedTools` 的 `Bash(gh pr comment:*)` 已覆盖 `--edit-last --create-if-none`，无需改权限。非阻塞设计不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)