### PR TITLE
chore: gitignore agent 工具状态 + substack 编译产物

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,10 @@ _refs/
 
 # 个人思考/设计文档 —— 不开源
 docs/miro/
+.gstack/
+
+# Agent 工具 notepad —— 不入库
+.sisyphus/
+
+# Substack 发布工具的编译产物（二进制）—— 只入源码不入产物
+/scripts/substack-copy


### PR DESCRIPTION
把三类本地产物加入 `.gitignore`，让 `git status` 干净、避免误提交：

- `.gstack/` — gstack 技能状态目录
- `.sisyphus/` — agent notepad
- `/scripts/substack-copy` — `substack-copy.swift` 的编译二进制（按需由 `md-to-substack.sh` 重建，只入源码不入产物）

纯 `.gitignore` 改动，无代码 / 行为变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)