### PR TITLE
chore: bump 各包版本 0.1.0 → 0.2.0

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inalpha/dashboard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Inalpha 操作者控制台 / operator console — 只读运行时看板(账户/持仓/Live Runner/Agent 活动)",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inalpha/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Inalpha 官网首页 / inalpha.dev landing page (static Next.js)",

--- a/infra/migrations/pyproject.toml
+++ b/infra/migrations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inalpha-migrations"
-version = "0.1.0"
+version = "0.2.0"
 description = "Inalpha database migrations (alembic + psycopg)"
 license = "AGPL-3.0-only"
 requires-python = ">=3.12"

--- a/infra/migrations/uv.lock
+++ b/infra/migrations/uv.lock
@@ -85,7 +85,7 @@ wheels = [
 
 [[package]]
 name = "inalpha-migrations"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inalpha/orchestration",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Mastra 编排层：tool / agent / workflow / memory，把后端 service 暴露给 LLM",

--- a/services/_shared/pyproject.toml
+++ b/services/_shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inalpha-shared"
-version = "0.1.0"
+version = "0.2.0"
 description = "Inalpha 各 service 共享的 FastAPI 基础设施（middleware / auth / db / errors）"
 license = "AGPL-3.0-only"
 requires-python = ">=3.12"

--- a/services/_shared/uv.lock
+++ b/services/_shared/uv.lock
@@ -243,7 +243,7 @@ wheels = [
 
 [[package]]
 name = "inalpha-shared"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/services/data/pyproject.toml
+++ b/services/data/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inalpha-data"
-version = "0.1.0"
+version = "0.2.0"
 description = "Inalpha data service: 行情接入 / 历史回放 / 实时订阅"
 license = "AGPL-3.0-only"
 requires-python = ">=3.12"

--- a/services/data/uv.lock
+++ b/services/data/uv.lock
@@ -1021,7 +1021,7 @@ wheels = [
 
 [[package]]
 name = "inalpha-data"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "akshare" },
@@ -1068,7 +1068,7 @@ dev = [
 
 [[package]]
 name = "inalpha-shared"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../_shared" }
 dependencies = [
     { name = "fastapi" },

--- a/services/factor/pyproject.toml
+++ b/services/factor/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inalpha-factor"
-version = "0.1.0"
+version = "0.2.0"
 description = "Inalpha factor service：接现成因子库（pandas-ta / WorldQuant Alpha101 / qlib Alpha158）+ 有效性打分（前瞻收益 / Rank IC）"
 license = "AGPL-3.0-only"
 requires-python = ">=3.12"

--- a/services/factor/uv.lock
+++ b/services/factor/uv.lock
@@ -1455,7 +1455,7 @@ wheels = [
 
 [[package]]
 name = "inalpha-factor"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -1511,7 +1511,7 @@ dev = [
 
 [[package]]
 name = "inalpha-shared"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../_shared" }
 dependencies = [
     { name = "fastapi" },

--- a/services/paper/pyproject.toml
+++ b/services/paper/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inalpha-paper"
-version = "0.1.0"
+version = "0.2.0"
 description = "Inalpha paper / live / backtest 三合一引擎：内核（Clock + MessageBus + Strategy）+ Gateway + Engine"
 license = "AGPL-3.0-only"
 requires-python = ">=3.12"

--- a/services/paper/uv.lock
+++ b/services/paper/uv.lock
@@ -448,7 +448,7 @@ wheels = [
 
 [[package]]
 name = "inalpha-paper"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "backtester-mcp" },
@@ -491,7 +491,7 @@ dev = [
 
 [[package]]
 name = "inalpha-shared"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../_shared" }
 dependencies = [
     { name = "fastapi" },

--- a/services/research/pyproject.toml
+++ b/services/research/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inalpha-research"
-version = "0.1.0"
+version = "0.2.0"
 description = "Inalpha research service: 多 agent LLM 决策（TradingAgents 风格）"
 license = "AGPL-3.0-only"
 requires-python = ">=3.12"

--- a/services/research/uv.lock
+++ b/services/research/uv.lock
@@ -543,7 +543,7 @@ wheels = [
 
 [[package]]
 name = "inalpha-research"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -588,7 +588,7 @@ dev = [
 
 [[package]]
 name = "inalpha-shared"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../_shared" }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
对齐 v0.2.0 release：6 pyproject + uv.lock + 3 package.json 版本号 0.1.0 → 0.2.0，纯字符串无逻辑改动。uv sync --frozen 已本地验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)