### PR TITLE
feat(console · D-11): 运行日志 + K线增强 + 侧边栏可折叠/移动端

### DIFF
--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -12,7 +12,11 @@
     "factors": "Factors",
     "risk": "Risk",
     "divination": "Omikuji",
-    "soon": "soon"
+    "soon": "soon",
+    "menu": "Menu",
+    "close": "Close",
+    "collapse": "Collapse sidebar",
+    "expand": "Expand sidebar"
   },
   "theme": {
     "label": "Theme",

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -112,6 +112,7 @@
       "chart": "Price",
       "chartEmpty": "No candles available for this instrument.",
       "chartError": "Could not load candles.",
+      "chartStale": "Refresh failed — showing previous data.",
       "chartLoading": "Loading…",
       "decisions": "Decision Timeline",
       "decisionsEmpty": "No decisions recorded yet — the runner hasn't placed an order.",

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -110,7 +110,9 @@
       "chartError": "Could not load candles.",
       "decisions": "Decision Timeline",
       "decisionsEmpty": "No decisions recorded yet — the runner hasn't placed an order.",
-      "errorLog": "Error Log",
+      "reasonFilled": "Filled on strategy signal",
+      "runLog": "Run Log",
+      "runLogEmpty": "No activity logged yet.",
       "config": "Config",
       "col": {
         "barTs": "Bar Time",

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -112,6 +112,7 @@
       "chart": "Price",
       "chartEmpty": "No candles available for this instrument.",
       "chartError": "Could not load candles.",
+      "chartLoading": "Loading…",
       "decisions": "Decision Timeline",
       "decisionsEmpty": "No decisions recorded yet — the runner hasn't placed an order.",
       "reasonFilled": "Filled on strategy signal",

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -113,6 +113,7 @@
       "chartEmpty": "No candles available for this instrument.",
       "chartError": "Could not load candles.",
       "chartStale": "Refresh failed — showing previous data.",
+      "chartStaleSwitch": "Switch failed — still showing {tf}.",
       "chartLoading": "Loading…",
       "decisions": "Decision Timeline",
       "decisionsEmpty": "No decisions recorded yet — the runner hasn't placed an order.",

--- a/apps/dashboard/messages/zh.json
+++ b/apps/dashboard/messages/zh.json
@@ -112,6 +112,7 @@
       "chart": "K 线",
       "chartEmpty": "该标的暂无 K 线数据。",
       "chartError": "K 线加载失败。",
+      "chartLoading": "加载中…",
       "decisions": "决策时间线",
       "decisionsEmpty": "尚无决策记录 —— runner 还没下过单。",
       "reasonFilled": "策略信号成交",

--- a/apps/dashboard/messages/zh.json
+++ b/apps/dashboard/messages/zh.json
@@ -113,6 +113,7 @@
       "chartEmpty": "该标的暂无 K 线数据。",
       "chartError": "K 线加载失败。",
       "chartStale": "刷新失败，显示的是上一次数据。",
+      "chartStaleSwitch": "切换失败，仍显示 {tf} 周期。",
       "chartLoading": "加载中…",
       "decisions": "决策时间线",
       "decisionsEmpty": "尚无决策记录 —— runner 还没下过单。",

--- a/apps/dashboard/messages/zh.json
+++ b/apps/dashboard/messages/zh.json
@@ -12,7 +12,11 @@
     "factors": "因子库",
     "risk": "风控",
     "divination": "狐神签",
-    "soon": "即将"
+    "soon": "即将",
+    "menu": "菜单",
+    "close": "关闭",
+    "collapse": "收起侧边栏",
+    "expand": "展开侧边栏"
   },
   "theme": {
     "label": "主题",

--- a/apps/dashboard/messages/zh.json
+++ b/apps/dashboard/messages/zh.json
@@ -112,6 +112,7 @@
       "chart": "K 线",
       "chartEmpty": "该标的暂无 K 线数据。",
       "chartError": "K 线加载失败。",
+      "chartStale": "刷新失败，显示的是上一次数据。",
       "chartLoading": "加载中…",
       "decisions": "决策时间线",
       "decisionsEmpty": "尚无决策记录 —— runner 还没下过单。",

--- a/apps/dashboard/messages/zh.json
+++ b/apps/dashboard/messages/zh.json
@@ -110,7 +110,9 @@
       "chartError": "K 线加载失败。",
       "decisions": "决策时间线",
       "decisionsEmpty": "尚无决策记录 —— runner 还没下过单。",
-      "errorLog": "错误日志",
+      "reasonFilled": "策略信号成交",
+      "runLog": "运行日志",
+      "runLogEmpty": "暂无运行日志。",
       "config": "配置",
       "col": {
         "barTs": "Bar 时间",

--- a/apps/dashboard/src/app/[locale]/layout.tsx
+++ b/apps/dashboard/src/app/[locale]/layout.tsx
@@ -34,7 +34,8 @@ export default async function LocaleLayout({
       <div className="grain flex min-h-dvh">
         <ConsoleSidebar />
         <main className="vignette relative flex-1 overflow-x-hidden">
-          <div className="relative z-10 mx-auto max-w-[1400px] px-6 py-8 lg:px-10">
+          {/* 移动端顶栏 fixed h-14,内容上方留位(lg 无顶栏,回正常间距)。 */}
+          <div className="relative z-10 mx-auto max-w-[1400px] px-4 pb-8 pt-[4.5rem] sm:px-6 lg:px-10 lg:py-8">
             {children}
           </div>
         </main>

--- a/apps/dashboard/src/app/api/bars/route.ts
+++ b/apps/dashboard/src/app/api/bars/route.ts
@@ -95,7 +95,10 @@ export async function GET(req: NextRequest) {
             body: { venue, symbol, timeframe, from_ts: fromTs, to_ts: toTs },
           }).then(() => undefined);
           inflightBackfill.set(key, pending);
-          pending.finally(() => inflightBackfill.delete(key));
+          // finally 链返回的 Promise 在 backfill reject 时本身也 rejected,下方只 await pending、
+          // 不消费它 → Node 15+ 会升级成 unhandledRejection;补 .catch 吞掉(实际错误仍由
+          // await pending 的 try/catch 处理)（CR）。
+          pending.finally(() => inflightBackfill.delete(key)).catch(() => {});
         }
         await pending;
         sorted = sortAsc(await readBars());

--- a/apps/dashboard/src/app/api/bars/route.ts
+++ b/apps/dashboard/src/app/api/bars/route.ts
@@ -54,22 +54,41 @@ export async function GET(req: NextRequest) {
   const nowMs = Date.now();
   // 多取一点窗口(×1.5)以防非交易时段/缺口导致根数不足。
   const fromMs = nowMs - limit * tfSec * 1500;
+  const fromTs = new Date(fromMs).toISOString();
+  const toTs = new Date(nowMs).toISOString();
 
-  try {
-    const bars = await backendFetch<BarPoint[]>("data", "/bars", {
-      query: {
-        venue,
-        symbol,
-        timeframe,
-        from_ts: new Date(fromMs).toISOString(),
-        to_ts: new Date(nowMs).toISOString(),
-        limit,
-      },
+  const readBars = () =>
+    backendFetch<BarPoint[]>("data", "/bars", {
+      query: { venue, symbol, timeframe, from_ts: fromTs, to_ts: toTs, limit },
       timeoutMs: 15_000,
     });
+  const sortAsc = (bs: BarPoint[]) =>
+    [...bs].sort((a, b) => +new Date(a.ts) - +new Date(b.ts));
 
-    // 升序排序(图表要求严格递增)+ 取末尾 limit 根。
-    const sorted = [...bars].sort((a, b) => +new Date(a.ts) - +new Date(b.ts));
+  try {
+    // 先读已落库的 bar。data 不主动回填 —— 切到没回填过的 timeframe（如某标的的 1d）
+    // 或窗口偏旧时会空/缺 → 图上"时间是空的"。
+    let sorted = sortAsc(await readBars());
+
+    // 新鲜度判定（§3.1 fresh=True）：空 或 最后一根距今 > 2×tf → 幂等回填该窗口再读，
+    // 保证 K 线完整且到当前。**只在缺/旧时回填**：数据已新鲜时直接返回，避免每次轮询都
+    // 重拉外部源（1d 回填实测可达 ~36s，不能每 20s 白跑）。best-effort：venue 不支持该
+    // tf 或外部源失败时不致命，仍用已有数据降级显示。
+    const lastMs = sorted.length ? +new Date(sorted[sorted.length - 1].ts) : 0;
+    const stale = sorted.length === 0 || nowMs - lastMs > 2 * tfSec * 1000;
+    if (stale) {
+      try {
+        await backendFetch("data", "/backfill/bars", {
+          method: "POST",
+          timeoutMs: 45_000,
+          body: { venue, symbol, timeframe, from_ts: fromTs, to_ts: toTs },
+        });
+        sorted = sortAsc(await readBars());
+      } catch {
+        // 忽略：回填失败仍用库里已有的 bar。
+      }
+    }
+
     const payload: BarsPayload = {
       venue,
       symbol,

--- a/apps/dashboard/src/app/api/bars/route.ts
+++ b/apps/dashboard/src/app/api/bars/route.ts
@@ -7,6 +7,13 @@ export const dynamic = "force-dynamic";
 
 const DEFAULT_LIMIT = 300;
 
+/**
+ * 进程级在途回填去重 —— 慢周期(1d 实测 ~36s)回填 > SWR 轮询间隔(20s),否则同一
+ * venue/symbol/tf 会在前一次还没回来时又发一次,两个请求都走进 stale 分支并发回填。
+ * 这里用 key→Promise 把同 key 的并发回填合并成一次,后到者复用同一 Promise。
+ */
+const inflightBackfill = new Map<string, Promise<void>>();
+
 /** timeframe → 秒;不认识返回 null。 */
 function timeframeSeconds(tf: string): number | null {
   const m = /^(\d+)(m|h|d|wk|mo)$/.exec(tf);
@@ -78,11 +85,19 @@ export async function GET(req: NextRequest) {
     const stale = sorted.length === 0 || nowMs - lastMs > 2 * tfSec * 1000;
     if (stale) {
       try {
-        await backendFetch("data", "/backfill/bars", {
-          method: "POST",
-          timeoutMs: 45_000,
-          body: { venue, symbol, timeframe, from_ts: fromTs, to_ts: toTs },
-        });
+        // 同 key 已有在途回填则复用,不再并发发第二次(见 inflightBackfill 注释)。
+        const key = `${venue}|${symbol}|${timeframe}`;
+        let pending = inflightBackfill.get(key);
+        if (!pending) {
+          pending = backendFetch("data", "/backfill/bars", {
+            method: "POST",
+            timeoutMs: 45_000,
+            body: { venue, symbol, timeframe, from_ts: fromTs, to_ts: toTs },
+          }).then(() => undefined);
+          inflightBackfill.set(key, pending);
+          pending.finally(() => inflightBackfill.delete(key));
+        }
+        await pending;
         sorted = sortAsc(await readBars());
       } catch {
         // 忽略：回填失败仍用库里已有的 bar。

--- a/apps/dashboard/src/components/chat/ChatThread.tsx
+++ b/apps/dashboard/src/components/chat/ChatThread.tsx
@@ -400,20 +400,20 @@ export function ChatThread({
   return (
     <aside
       aria-hidden={!open}
-      style={{ width: `${width}px` }}
+      style={{ width: `${width}px`, maxWidth: "100vw" }}
       className={cn(
         "fixed right-0 top-0 z-30 flex h-dvh flex-col border-l border-border-subtle bg-bg-elev/95 backdrop-blur-md",
         "transition-transform duration-300 ease-[cubic-bezier(0.22,0.7,0.22,1)] motion-reduce:transition-none",
         open ? "translate-x-0" : "translate-x-full",
       )}
     >
-      {/* 左缘拖动条 —— 调整栏宽,主内容同步 reflow。 */}
+      {/* 左缘拖动条 —— 调整栏宽,主内容同步 reflow。移动端满宽,无拖宽语义,隐藏。 */}
       <div
         onPointerDown={startResize}
         role="separator"
         aria-orientation="vertical"
         aria-label={t("resize")}
-        className="group absolute left-0 top-0 z-10 h-full w-2 -translate-x-1/2 cursor-col-resize touch-none before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-transparent before:transition-colors before:content-[''] hover:before:bg-cyan/60"
+        className="group absolute left-0 top-0 z-10 hidden h-full w-2 -translate-x-1/2 cursor-col-resize touch-none before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-transparent before:transition-colors before:content-[''] hover:before:bg-cyan/60 lg:block"
       />
       {/* 标题条 —— PageHeader 同款:朱红刻度 + 编辑体标题 + 在线点。 */}
       <header className="flex items-center gap-3 border-b border-border-subtle px-4 py-3.5">

--- a/apps/dashboard/src/components/runners/CandlestickChart.tsx
+++ b/apps/dashboard/src/components/runners/CandlestickChart.tsx
@@ -4,14 +4,18 @@ import { useEffect, useRef, useState } from "react";
 import {
   ColorType,
   createChart,
+  LineStyle,
   type CandlestickData,
+  type HistogramData,
   type IChartApi,
   type ISeriesApi,
+  type LineData,
   type SeriesMarker,
   type UTCTimestamp,
 } from "lightweight-charts";
 
 import type { BarPoint, StrategyRunDecisionRecord } from "@/lib/types";
+import { cn } from "@/lib/cn";
 
 /**
  * lightweight-charts 用 canvas 渲染,只吃字面色值(不认 color-mix),所以这里
@@ -43,9 +47,107 @@ function readColors(): ChartColors {
 
 const toSec = (iso: string) => Math.floor(new Date(iso).getTime() / 1000) as UTCTimestamp;
 
+// ── 技术指标(纯前端从收盘价算,可开关) ────────────────────────────────
+type OverlayKey = "ma5" | "ma10" | "ma20" | "ma60" | "ema" | "boll" | "vol";
+
+const LINE_COLORS: Record<string, string> = {
+  ma5: "#f5a623",
+  ma10: "#4f9dde",
+  ma20: "#9b8cff",
+  ma60: "#e056a0",
+  boll: "#8089a0",
+};
+const EMA_PERIOD = 20;
+const BOLL_PERIOD = 20;
+const BOLL_MULT = 2;
+
+/** 简单移动均线。 */
+function sma(closes: number[], times: UTCTimestamp[], period: number): LineData[] {
+  const out: LineData[] = [];
+  let sum = 0;
+  for (let i = 0; i < closes.length; i += 1) {
+    sum += closes[i];
+    if (i >= period) sum -= closes[i - period];
+    if (i >= period - 1) out.push({ time: times[i], value: sum / period });
+  }
+  return out;
+}
+
+/** 指数移动均线(以前 period 根的 SMA 作种子)。 */
+function ema(closes: number[], times: UTCTimestamp[], period: number): LineData[] {
+  const out: LineData[] = [];
+  const k = 2 / (period + 1);
+  let prev = 0;
+  let seed = 0;
+  for (let i = 0; i < closes.length; i += 1) {
+    if (i < period) {
+      seed += closes[i];
+      if (i === period - 1) {
+        prev = seed / period;
+        out.push({ time: times[i], value: prev });
+      }
+      continue;
+    }
+    prev = closes[i] * k + prev * (1 - k);
+    out.push({ time: times[i], value: prev });
+  }
+  return out;
+}
+
+/** 布林带上下轨(中轨=SMA20,与 MA20 重复故不画)。 */
+function bollinger(
+  closes: number[],
+  times: UTCTimestamp[],
+  period: number,
+  mult: number,
+): { upper: LineData[]; lower: LineData[] } {
+  const upper: LineData[] = [];
+  const lower: LineData[] = [];
+  for (let i = period - 1; i < closes.length; i += 1) {
+    let sum = 0;
+    for (let j = i - period + 1; j <= i; j += 1) sum += closes[j];
+    const mean = sum / period;
+    let varSum = 0;
+    for (let j = i - period + 1; j <= i; j += 1) varSum += (closes[j] - mean) ** 2;
+    const sd = Math.sqrt(varSum / period);
+    upper.push({ time: times[i], value: mean + mult * sd });
+    lower.push({ time: times[i], value: mean - mult * sd });
+  }
+  return { upper, lower };
+}
+
+const OVERLAYS: { key: OverlayKey; label: string }[] = [
+  { key: "ma5", label: "MA5" },
+  { key: "ma10", label: "MA10" },
+  { key: "ma20", label: "MA20" },
+  { key: "ma60", label: "MA60" },
+  { key: "ema", label: `EMA${EMA_PERIOD}` },
+  { key: "boll", label: "BOLL" },
+  { key: "vol", label: "VOL" },
+];
+
+const MA_PERIODS: Record<string, number> = { ma5: 5, ma10: 10, ma20: 20, ma60: 60 };
+
+/** 当前价格摘要(末根收盘 + 较上一根的涨跌幅)。 */
+interface PriceInfo {
+  last: number;
+  changePct: number;
+}
+
+/** 价格按量级取小数位,避免大币种一堆 0、小币种丢精度。 */
+function fmtPrice(p: number): string {
+  const abs = Math.abs(p);
+  const digits = abs >= 1000 ? 2 : abs >= 1 ? 2 : abs >= 0.01 ? 4 : 6;
+  return p.toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
 /**
- * 蜡烛图 + 决策打点。决策按 side 定上下、按 outcome 定颜色;marker 时间吸附到
- * ≤ 该时刻的最近一根 K 线,避免与蜡烛错位。
+ * 蜡烛图 + 决策打点 + 技术辅助线(MA5/10/20/60 / EMA / 布林带 / 成交量,可开关)+ 当前价。
+ * 决策按 side 定上下、按 outcome 定颜色;marker 时间吸附到 ≤ 该时刻的最近一根 K 线。
+ * 末根收盘价以虚线 priceLine 标在右轴(当前价),并在工具条左侧大字显示 + 涨跌幅。
  */
 export function CandlestickChart({
   bars,
@@ -59,8 +161,19 @@ export function CandlestickChart({
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const seriesRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
-  // 主题色(惰性读取,SSR 不跑;切 data-theme 时由 MutationObserver 更新)。
+  // 当前叠加的辅助线 / 成交量 series(开关 / 重建时清掉重画)。
+  const overlayRef = useRef<ISeriesApi<"Line" | "Histogram">[]>([]);
   const [C, setColors] = useState<ChartColors | null>(null);
+  const [info, setInfo] = useState<PriceInfo | null>(null);
+  const [on, setOn] = useState<Record<OverlayKey, boolean>>({
+    ma5: false,
+    ma10: false,
+    ma20: true,
+    ma60: false,
+    ema: false,
+    boll: false,
+    vol: true,
+  });
 
   // 首挂读色 + 监听主题切换。
   useEffect(() => {
@@ -78,13 +191,19 @@ export function CandlestickChart({
     const el = containerRef.current;
     if (!el || !C) return;
 
+    // canvas 的 ctx.font 不认 CSS 变量 —— 把 --font-mono 解析成真实字体串再传,
+    // 否则 lightweight-charts 拿 "var(--font-mono)" 解析失败、回退到默认字体(渲染发虚 / 串味)。
+    const fontFamily =
+      getComputedStyle(el).getPropertyValue("--font-mono").trim() ||
+      "ui-monospace, SFMono-Regular, Menlo, monospace";
+
     const chart = createChart(el, {
       width: el.clientWidth,
       height,
       layout: {
         background: { type: ColorType.Solid, color: "transparent" },
         textColor: C.text,
-        fontFamily: "var(--font-mono)",
+        fontFamily,
       },
       grid: {
         vertLines: { color: C.grid },
@@ -104,9 +223,14 @@ export function CandlestickChart({
       borderVisible: false,
       wickUpColor: C.bull,
       wickDownColor: C.fox,
+      priceLineVisible: true, // 末值价格线 = 当前价
+      priceLineStyle: LineStyle.Dashed,
+      priceLineColor: C.gold,
+      priceLineWidth: 1,
     });
     chartRef.current = chart;
     seriesRef.current = series;
+    overlayRef.current = []; // 旧 chart 已销毁,辅助线 series 引用作废
 
     const ro = new ResizeObserver((entries) => {
       const w = entries[0]?.contentRect.width;
@@ -119,10 +243,11 @@ export function CandlestickChart({
       chart.remove();
       chartRef.current = null;
       seriesRef.current = null;
+      overlayRef.current = [];
     };
   }, [height, C]);
 
-  // 灌数据 + 决策打点。
+  // 灌数据 + 决策打点 + 辅助线 + 当前价。
   useEffect(() => {
     const series = seriesRef.current;
     const chart = chartRef.current;
@@ -131,24 +256,85 @@ export function CandlestickChart({
     // 去重 + 升序(图表要求时间严格递增)。
     const seen = new Set<number>();
     const candles: CandlestickData[] = [];
+    const volumes: HistogramData[] = [];
     for (const b of bars) {
       const time = toSec(b.ts);
       if (seen.has(time)) continue;
       seen.add(time);
       candles.push({ time, open: b.open, high: b.high, low: b.low, close: b.close });
+      volumes.push({
+        time,
+        value: b.volume,
+        color: b.close >= b.open ? `${C.bull}66` : `${C.fox}66`,
+      });
     }
     series.setData(candles);
 
+    // 当前价 + 涨跌幅(末根 vs 前一根收盘)。
+    if (candles.length > 0) {
+      const last = candles[candles.length - 1].close;
+      const prev = candles.length > 1 ? candles[candles.length - 2].close : last;
+      setInfo({ last, changePct: prev ? (last - prev) / prev : 0 });
+    } else {
+      setInfo(null);
+    }
+
+    // 辅助线 / 成交量:先清掉上一轮 series,再按当前开关重画。
+    for (const s of overlayRef.current) chart.removeSeries(s);
+    overlayRef.current = [];
+    const closes = candles.map((c) => c.close);
+    const times = candles.map((c) => c.time as UTCTimestamp);
+    const addLine = (data: LineData[], color: string) => {
+      if (data.length === 0) return;
+      const s = chart.addLineSeries({
+        color,
+        lineWidth: 1,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        crosshairMarkerVisible: false,
+      });
+      s.setData(data);
+      overlayRef.current.push(s);
+    };
+
+    for (const key of ["ma5", "ma10", "ma20", "ma60"] as const) {
+      if (on[key]) addLine(sma(closes, times, MA_PERIODS[key]), LINE_COLORS[key]);
+    }
+    if (on.ema) addLine(ema(closes, times, EMA_PERIOD), C.gold);
+    if (on.boll) {
+      const { upper, lower } = bollinger(closes, times, BOLL_PERIOD, BOLL_MULT);
+      addLine(upper, LINE_COLORS.boll);
+      addLine(lower, LINE_COLORS.boll);
+    }
+
+    // 成交量 —— 独立价格刻度,贴底部约 1/5 高度;主价刻度据此留底边。
+    if (on.vol) {
+      const vol = chart.addHistogramSeries({
+        priceScaleId: "vol",
+        priceFormat: { type: "volume" },
+        priceLineVisible: false,
+        lastValueVisible: false,
+      });
+      vol.setData(volumes);
+      chart.priceScale("vol").applyOptions({
+        scaleMargins: { top: 0.82, bottom: 0 },
+      });
+      overlayRef.current.push(vol);
+    }
+    series.priceScale().applyOptions({
+      scaleMargins: on.vol ? { top: 0.06, bottom: 0.24 } : { top: 0.1, bottom: 0.1 },
+    });
+
     // 决策 → marker,时间吸附到 ≤ 该时刻的最近一根 K 线。
-    const times = candles.map((c) => c.time as number).sort((a, b) => a - b);
+    const sortedTimes = times.slice().sort((a, b) => a - b);
     const snap = (sec: number): number | null => {
       let lo = 0,
-        hi = times.length - 1,
+        hi = sortedTimes.length - 1,
         ans: number | null = null;
       while (lo <= hi) {
         const mid = (lo + hi) >> 1;
-        if (times[mid] <= sec) {
-          ans = times[mid];
+        if (sortedTimes[mid] <= sec) {
+          ans = sortedTimes[mid];
           lo = mid + 1;
         } else hi = mid - 1;
       }
@@ -160,8 +346,7 @@ export function CandlestickChart({
       const t = snap(toSec(d.bar_ts) as number);
       if (t === null) continue;
       const buy = d.side === "BUY";
-      const color =
-        d.outcome === "filled" ? (buy ? C.bull : C.fox) : C.gold;
+      const color = d.outcome === "filled" ? (buy ? C.bull : C.fox) : C.gold;
       markers.push({
         time: t as UTCTimestamp,
         position: buy ? "belowBar" : "aboveBar",
@@ -174,7 +359,56 @@ export function CandlestickChart({
     series.setMarkers(markers);
 
     chart.timeScale().fitContent();
-  }, [bars, decisions, C]);
+  }, [bars, decisions, C, on]);
 
-  return <div ref={containerRef} className="w-full" style={{ height }} />;
+  const up = (info?.changePct ?? 0) >= 0;
+
+  return (
+    // dir=ltr 钉死整块为从左到右 —— canvas 文字方向继承 DOM direction，上游若为 rtl
+    // 会让十字线/轴上的价格、时间气泡从右往左排。这里强制 LTR。
+    <div dir="ltr" className="flex flex-col gap-2">
+      {/* 工具条:当前价 + 辅助线开关 */}
+      <div className="flex flex-wrap items-center justify-between gap-2 px-1">
+        {info ? (
+          <div className="flex items-baseline gap-2">
+            <span className="tnum font-mono text-lg font-medium tracking-tight text-fg">
+              {fmtPrice(info.last)}
+            </span>
+            <span
+              className={cn(
+                "tnum font-mono text-xs",
+                up ? "text-bull" : "text-fox-red",
+              )}
+            >
+              {up ? "+" : ""}
+              {(info.changePct * 100).toFixed(2)}%
+            </span>
+          </div>
+        ) : (
+          <span />
+        )}
+        <div className="flex flex-wrap items-center gap-1">
+          {OVERLAYS.map((o) => (
+            <button
+              key={o.key}
+              type="button"
+              onClick={() => setOn((s) => ({ ...s, [o.key]: !s[o.key] }))}
+              aria-pressed={on[o.key]}
+              className={cn(
+                "rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider transition-colors",
+                on[o.key]
+                  ? "border-cyan/40 bg-cyan/10 text-cyan"
+                  : "border-border-subtle text-fg-muted/70 hover:text-fg",
+              )}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {/* dir=ltr：canvas 文字方向默认继承元素 direction，强制 LTR，避免轴/十字线
+          气泡里的价格、时间从右往左排（继承到 rtl 时会这样）。 */}
+      <div ref={containerRef} dir="ltr" className="w-full" style={{ height }} />
+    </div>
+  );
 }

--- a/apps/dashboard/src/components/runners/DecisionTimeline.tsx
+++ b/apps/dashboard/src/components/runners/DecisionTimeline.tsx
@@ -54,6 +54,12 @@ export function DecisionTimeline({
             <tbody>
               {decisions.map((d) => {
                 const blocked = d.outcome === "risk_rejected";
+                // reason 回退:拒单有真实 reason;成交(reason 为空)退到策略 tag,
+                // 再退到「策略信号成交」——让该列对正常成交行也有信息,不再一片「—」。
+                const reasonText =
+                  d.reason ??
+                  d.tag ??
+                  (d.outcome === "filled" ? t("reasonFilled") : null);
                 return (
                   <tr
                     key={d.id}
@@ -109,14 +115,16 @@ export function DecisionTimeline({
                       />
                     </Td>
                     <Td>
-                      {d.reason ? (
+                      {reasonText ? (
                         <span
+                          title={reasonText}
                           className={cn(
-                            "font-mono text-[11px]",
+                            // 单行不换行,过长截断省略,悬浮 title 看全文。
+                            "block max-w-[22rem] truncate font-mono text-[11px]",
                             blocked ? "text-fox-red" : "text-fg-muted",
                           )}
                         >
-                          {d.reason}
+                          {reasonText}
                         </span>
                       ) : (
                         <span className="text-fg-muted/40">—</span>

--- a/apps/dashboard/src/components/runners/RunnerCard.tsx
+++ b/apps/dashboard/src/components/runners/RunnerCard.tsx
@@ -19,7 +19,8 @@ export function RunnerCard({ run }: { run: StrategyRunRecord }) {
   const locale = useLocale();
   const now = useNow({ updateInterval: 10_000 });
 
-  const errorCount = run.error_log.length;
+  // 卡片角标只数 error 级(run_log 现含 info/warn 活动,全数会虚高)。
+  const errorCount = run.run_log.filter((e) => e.level === "error").length;
   // running 但 last_bar 超过 4× timeframe 没动 → 可能卡住,标黄提示。
   const lastBarStale = isLastBarStale(run, now.getTime());
 

--- a/apps/dashboard/src/components/runners/RunnerChart.tsx
+++ b/apps/dashboard/src/components/runners/RunnerChart.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 import useSWR from "swr";
 
 import type { BarsPayload, StrategyRunDecisionRecord } from "@/lib/types";
+import { cn } from "@/lib/cn";
 import { jsonFetcher } from "@/lib/fetcher";
 import { Panel } from "@/components/ui/Panel";
 import { CandlestickChart } from "./CandlestickChart";
@@ -11,9 +13,14 @@ import { CandlestickChart } from "./CandlestickChart";
 /** K 线随 bar 推进,20s 一刷。 */
 const REFRESH_MS = 20_000;
 
+/** 可选周期 —— 覆盖常见档；run 自身周期若不在内会自动并入(始终可切回)。 */
+const TF_CHOICES = ["1m", "5m", "15m", "30m", "1h", "4h", "1d", "1wk"];
+
 /**
  * Live Runner 详情的 K 线面板 —— 取该 run 标的的最近 K 线,把决策点叠在蜡烛上。
- * 图是辅助信息:取不到 / 为空只显示占位,不影响详情页其余部分。
+ *
+ * 周期可切:默认按 run 自身 timeframe,用户可临时切到其他周期看不同尺度的走势
+ * (决策 marker 仍按时间吸附到最近 bar)。图是辅助信息,取不到 / 为空只显示占位。
  */
 export function RunnerChart({
   venue,
@@ -27,30 +34,71 @@ export function RunnerChart({
   decisions: StrategyRunDecisionRecord[];
 }) {
   const t = useTranslations("runners.detail");
-  const key = `/api/bars?venue=${encodeURIComponent(venue)}&symbol=${encodeURIComponent(symbol)}&timeframe=${encodeURIComponent(timeframe)}&limit=300`;
-  const { data, error } = useSWR<BarsPayload>(key, jsonFetcher, {
+  const [tf, setTf] = useState(timeframe);
+  const choices = TF_CHOICES.includes(timeframe)
+    ? TF_CHOICES
+    : [timeframe, ...TF_CHOICES];
+
+  const key = `/api/bars?venue=${encodeURIComponent(venue)}&symbol=${encodeURIComponent(symbol)}&timeframe=${encodeURIComponent(tf)}&limit=300`;
+  const { data, error, isValidating } = useSWR<BarsPayload>(key, jsonFetcher, {
     refreshInterval: REFRESH_MS,
     keepPreviousData: true,
   });
 
   const bars = data?.bars ?? [];
+  // 切周期后 data 仍是旧周期的(keepPreviousData)→ 显示的与选中的不一致 = 正在拉新周期。
+  // 首次切到没回填过的周期要 backfill,可能十几~几十秒,这期间给明确「加载中」反馈,
+  // 否则看着像「切了没反应」(其实在拉数据)。
+  const switching = data?.timeframe !== tf && isValidating && !error;
 
   return (
     <Panel
       title={t("chart")}
       aside={
-        <span className="font-mono text-[11px] text-fg-muted">
-          {symbol} · {timeframe}
-        </span>
+        <div className="flex items-center gap-2">
+          {switching && (
+            <span className="flex items-center gap-1 font-mono text-[10px] text-cyan">
+              <span className="size-1.5 rounded-full bg-cyan caret-blink" />
+              {t("chartLoading")}
+            </span>
+          )}
+          <div className="flex items-center gap-0.5 rounded-md border border-border-subtle bg-bg/40 p-0.5">
+            {choices.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setTf(c)}
+                aria-pressed={tf === c}
+                className={cn(
+                  "rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider transition-colors",
+                  tf === c
+                    ? "bg-cyan/15 text-cyan"
+                    : "text-fg-muted/70 hover:text-fg",
+                )}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+        </div>
       }
     >
       {bars.length === 0 ? (
         <div className="px-4 py-12 text-center text-sm text-fg-muted/70">
-          {error ? t("chartError") : t("chartEmpty")}
+          {switching ? t("chartLoading") : error ? t("chartError") : t("chartEmpty")}
         </div>
       ) : (
-        <div className="px-2 py-2">
+        <div className="relative px-2 py-2">
           <CandlestickChart bars={bars} decisions={decisions} />
+          {/* 拉新周期时旧图压暗 + 角标,明确「在加载,不是没反应」。 */}
+          {switching && (
+            <div className="pointer-events-none absolute inset-0 flex items-start justify-center bg-bg-deep/30 pt-6">
+              <span className="flex items-center gap-1.5 rounded-md border border-cyan/30 bg-bg-elev/90 px-2.5 py-1 font-mono text-[11px] text-cyan">
+                <span className="size-1.5 rounded-full bg-cyan caret-blink" />
+                {t("chartLoading")}
+              </span>
+            </div>
+          )}
         </div>
       )}
     </Panel>

--- a/apps/dashboard/src/components/runners/RunnerChart.tsx
+++ b/apps/dashboard/src/components/runners/RunnerChart.tsx
@@ -50,6 +50,9 @@ export function RunnerChart({
   // 首次切到没回填过的周期要 backfill,可能十几~几十秒,这期间给明确「加载中」反馈,
   // 否则看着像「切了没反应」(其实在拉数据)。
   const switching = data?.timeframe !== tf && isValidating && !error;
+  // 切周期/刷新失败但 keepPreviousData 仍留着旧 bars：图照常画但内容与选中周期不符,
+  // 给个淡提示避免「按钮高亮 1d、图却是 1h」的静默误导(CR)。
+  const staleError = !!error && !switching && bars.length > 0;
 
   return (
     <Panel
@@ -96,6 +99,15 @@ export function RunnerChart({
               <span className="flex items-center gap-1.5 rounded-md border border-cyan/30 bg-bg-elev/90 px-2.5 py-1 font-mono text-[11px] text-cyan">
                 <span className="size-1.5 rounded-full bg-cyan caret-blink" />
                 {t("chartLoading")}
+              </span>
+            </div>
+          )}
+          {/* 刷新失败、图上是旧数据：角标提示「显示的是上一次数据」,不静默误导。 */}
+          {staleError && (
+            <div className="pointer-events-none absolute inset-0 flex items-start justify-center pt-6">
+              <span className="flex items-center gap-1.5 rounded-md border border-gold/30 bg-bg-elev/90 px-2.5 py-1 font-mono text-[11px] text-gold">
+                <span className="size-1.5 rounded-full bg-gold" />
+                {t("chartStale")}
               </span>
             </div>
           )}

--- a/apps/dashboard/src/components/runners/RunnerChart.tsx
+++ b/apps/dashboard/src/components/runners/RunnerChart.tsx
@@ -53,6 +53,10 @@ export function RunnerChart({
   // 切周期/刷新失败但 keepPreviousData 仍留着旧 bars：图照常画但内容与选中周期不符,
   // 给个淡提示避免「按钮高亮 1d、图却是 1h」的静默误导(CR)。
   const staleError = !!error && !switching && bars.length > 0;
+  // 进一步区分:周期切换失败时图上是**别的周期**(data.timeframe ≠ 选中 tf),提示要点名
+  // 实际在显示哪个周期;同周期刷新失败则只是旧快照。两者文案不同,避免语义误导(CR)。
+  const staleTf = data?.timeframe;
+  const staleSwitch = staleError && staleTf !== tf;
 
   return (
     <Panel
@@ -102,12 +106,14 @@ export function RunnerChart({
               </span>
             </div>
           )}
-          {/* 刷新失败、图上是旧数据：角标提示「显示的是上一次数据」,不静默误导。 */}
+          {/* 刷新/切周期失败、图上是旧数据：角标提示,不静默误导。切周期失败时点名实际周期。 */}
           {staleError && (
             <div className="pointer-events-none absolute inset-0 flex items-start justify-center pt-6">
               <span className="flex items-center gap-1.5 rounded-md border border-gold/30 bg-bg-elev/90 px-2.5 py-1 font-mono text-[11px] text-gold">
                 <span className="size-1.5 rounded-full bg-gold" />
-                {t("chartStale")}
+                {staleSwitch
+                  ? t("chartStaleSwitch", { tf: staleTf ?? "" })
+                  : t("chartStale")}
               </span>
             </div>
           )}

--- a/apps/dashboard/src/components/runners/RunnerDetailClient.tsx
+++ b/apps/dashboard/src/components/runners/RunnerDetailClient.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useLocale, useNow, useTranslations } from "next-intl";
-import { ArrowLeft, TriangleAlert } from "lucide-react";
+import { ArrowLeft, CircleAlert, Info, TriangleAlert } from "lucide-react";
 import useSWR from "swr";
 
 import type {
   RunDetailPayload,
+  RunLogEntry,
+  RunLogLevel,
   StrategyRunDecisionRecord,
   StrategyRunRecord,
 } from "@/lib/types";
@@ -100,8 +102,8 @@ export function RunnerDetailClient({ runId }: { runId: string }) {
 
           <DecisionTimeline decisions={data.decisions} />
 
-          {/* 错误日志置底(running 失败的逐次记录)。 */}
-          {run.error_log.length > 0 && <ErrorLog entries={run.error_log} />}
+          {/* 运行日志置底 —— agent 全量活动(起跑 / 出单 / 停止 / 退避 / 错误),按级别着色。 */}
+          <RunLog entries={run.run_log} />
         </>
       )}
     </div>
@@ -208,25 +210,55 @@ function BackLink({ label }: { label: string }) {
   );
 }
 
-function ErrorLog({ entries }: { entries: Array<Record<string, unknown>> }) {
+/** 日志级别 → 图标 + 颜色（info=电光青 / warn=金 / error=朱红）。 */
+const LEVEL_STYLE: Record<RunLogLevel, { icon: typeof Info; cls: string }> = {
+  info: { icon: Info, cls: "text-cyan" },
+  warn: { icon: TriangleAlert, cls: "text-gold" },
+  error: { icon: CircleAlert, cls: "text-fox-red" },
+};
+
+/** 运行日志面板 —— 全量活动按级别着色,最新在上。 */
+function RunLog({ entries }: { entries: RunLogEntry[] }) {
   const t = useTranslations("runners.detail");
+  // 后端按时间序追加(最新在末尾),这里倒序展示——最近活动一眼可见。
+  const rows = [...entries].reverse();
+
   return (
-    <Panel title={t("errorLog")}>
-      <ul className="divide-y divide-border-subtle/60">
-        {entries.map((e, i) => (
-          <li
-            key={i}
-            className="flex items-start gap-2 px-4 py-2.5 font-mono text-[11px] text-fox-red"
-          >
-            <TriangleAlert className="mt-0.5 size-3 shrink-0" strokeWidth={2} />
-            <span className="break-all text-fg-muted">
-              {typeof e === "object"
-                ? JSON.stringify(e)
-                : String(e)}
-            </span>
-          </li>
-        ))}
-      </ul>
+    <Panel
+      title={t("runLog")}
+      aside={
+        <span className="tnum font-mono text-xs text-fg-muted">{entries.length}</span>
+      }
+    >
+      {rows.length === 0 ? (
+        <p className="px-4 py-6 text-center text-sm text-fg-muted/70">
+          {t("runLogEmpty")}
+        </p>
+      ) : (
+        <ul className="divide-y divide-border-subtle/60">
+          {rows.map((e, i) => {
+            const lvl: RunLogLevel =
+              e.level === "warn" || e.level === "error" ? e.level : "info";
+            const { icon: Icon, cls } = LEVEL_STYLE[lvl];
+            return (
+              <li key={i} className="flex items-start gap-2.5 px-4 py-2 font-mono text-[11px]">
+                <Icon className={cn("mt-0.5 size-3 shrink-0", cls)} strokeWidth={2} />
+                <span className="shrink-0 text-fg-muted/60">{fmtLogTs(e.ts)}</span>
+                <span className="break-all text-fg-muted">
+                  {e.msg}
+                  {e.code ? <span className="ml-1.5 text-fg-muted/50">[{e.code}]</span> : null}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </Panel>
   );
+}
+
+/** 日志时间戳 —— 后端写 `NOW()::text`(形如 "2026-06-08 11:35:00.12+00")，取月日时分秒、不做时区换算。 */
+function fmtLogTs(ts: string): string {
+  const m = ts.match(/^\d{4}-(\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})/);
+  return m ? `${m[1]} ${m[2]}` : ts;
 }

--- a/apps/dashboard/src/components/runners/RunnerDetailClient.tsx
+++ b/apps/dashboard/src/components/runners/RunnerDetailClient.tsx
@@ -257,8 +257,25 @@ function RunLog({ entries }: { entries: RunLogEntry[] }) {
   );
 }
 
-/** 日志时间戳 —— 后端写 `NOW()::text`(形如 "2026-06-08 11:35:00.12+00")，取月日时分秒、不做时区换算。 */
+/**
+ * 日志时间戳 —— 后端写 `NOW()::text`(形如 "2026-06-08 11:35:00.12+00"，带时区偏移)。
+ * 按**用户本地时区**显示月日时分秒：否则 UTC+8 用户会把 UTC 的 "11:35" 误读成本地 11:35
+ * (实为本地 19:35)，排障对不上运行记录(§3 面向全球用户)。解析失败回退原串截取。
+ */
 function fmtLogTs(ts: string): string {
+  // 空格→T、裸偏移 "+00"→"+00:00" 以满足跨浏览器 ISO 解析；偏移由串自带,不硬编码 UTC。
+  const iso = ts.replace(" ", "T").replace(/([+-]\d{2})$/, "$1:00");
+  const d = new Date(iso);
+  if (!Number.isNaN(d.getTime())) {
+    return new Intl.DateTimeFormat(undefined, {
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).format(d);
+  }
   const m = ts.match(/^\d{4}-(\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})/);
   return m ? `${m[1]} ${m[2]}` : ts;
 }

--- a/apps/dashboard/src/components/shell/ConsoleSidebar.tsx
+++ b/apps/dashboard/src/components/shell/ConsoleSidebar.tsx
@@ -1,14 +1,19 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   Activity,
   FlaskConical,
   LayoutDashboard,
+  Menu,
+  PanelLeftClose,
+  PanelLeftOpen,
   Radio,
   ShieldAlert,
   Sigma,
   Sparkles,
+  X,
   type LucideIcon,
 } from "lucide-react";
 
@@ -36,33 +41,208 @@ const NAV: NavItem[] = [
   { key: "divination", href: "/divination", icon: Sparkles },
 ];
 
+const LS_COLLAPSED = "inalpha-sidebar-collapsed";
+
+/**
+ * 控制台导航 —— 三态自适应:
+ *  - 桌面(lg+):常驻左栏,可折叠成「仅图标」窄轨(w-16,持久化)。
+ *  - 移动(<lg):左栏隐藏,顶栏汉堡唤出滑入抽屉 + 半透遮罩;路由切换 / Esc / 点遮罩即关。
+ *
+ * 桌面栏与移动抽屉共用 {@link SidebarBody},避免导航重复定义。
+ */
 export function ConsoleSidebar() {
   const t = useTranslations("nav");
   const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  // 桌面折叠态持久化(mount 后读,避免 SSR/CSR 首帧不一致)。
+  useEffect(() => {
+    setCollapsed(localStorage.getItem(LS_COLLAPSED) === "1");
+  }, []);
+
+  const toggleCollapsed = () =>
+    setCollapsed((c) => {
+      const next = !c;
+      localStorage.setItem(LS_COLLAPSED, next ? "1" : "0");
+      return next;
+    });
+
+  // 路由切换关移动抽屉(切面即收起,避免遮挡新内容)。
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
+
+  // 抽屉打开时:Esc 关 + 锁背景滚动。
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [mobileOpen]);
 
   return (
-    <aside className="sticky top-0 z-10 flex h-dvh w-60 shrink-0 flex-col border-r border-border-subtle bg-bg-deep/70 backdrop-blur-sm">
-      {/* Brand —— 朱红印章 + 字标。印章是 Inalpha 的签名标记。 */}
-      <div className="flex items-center gap-3 border-b border-border-subtle px-5 py-5">
+    <>
+      {/* 移动顶栏(lg 隐藏)—— 汉堡 + 字标。 */}
+      <header className="fixed inset-x-0 top-0 z-30 flex h-14 items-center gap-3 border-b border-border-subtle bg-bg-deep/85 px-4 backdrop-blur-md lg:hidden">
+        <button
+          type="button"
+          onClick={() => setMobileOpen(true)}
+          aria-label={t("menu")}
+          className="-ml-1 flex size-9 items-center justify-center rounded-md text-fg-muted transition-colors hover:bg-bg-elev/60 hover:text-fg"
+        >
+          <Menu className="size-5" strokeWidth={1.75} />
+        </button>
         <img
           src="/inalpha-seal.png"
-          alt="Inalpha"
-          width={40}
-          height={40}
-          className="seal-glow size-10 shrink-0 select-none transition-transform duration-300 hover:rotate-[-4deg] hover:scale-110"
+          alt=""
+          width={28}
+          height={28}
+          className="seal-glow size-7 shrink-0 select-none"
           draggable={false}
         />
-        <div className="min-w-0">
-          <div className="font-display text-xl leading-none tracking-tight text-fg">
-            Inalpha
+        <span className="font-display text-lg leading-none tracking-tight text-fg">
+          Inalpha
+        </span>
+      </header>
+
+      {/* 桌面常驻栏(in-flow,可折叠)。
+          padding-bottom 让出底部活动日志条高度(--activity-h,与 main 同源)—— 否则
+          fixed 的 ActivityFooter(z-20)会盖住本栏 z-10 的底部控制(折叠后的展开钮就被压住打不开)。 */}
+      <aside
+        style={{ paddingBottom: "var(--activity-h, 0px)" }}
+        className={cn(
+          "sticky top-0 z-10 hidden h-dvh shrink-0 flex-col border-r border-border-subtle bg-bg-deep/70 backdrop-blur-sm transition-[width] duration-200 lg:flex",
+          collapsed ? "w-16" : "w-60",
+        )}
+      >
+        <SidebarBody
+          t={t}
+          pathname={pathname}
+          collapsed={collapsed}
+          onToggleCollapsed={toggleCollapsed}
+        />
+      </aside>
+
+      {/* 移动抽屉 + 遮罩(lg 隐藏)。 */}
+      <div
+        aria-hidden
+        onClick={() => setMobileOpen(false)}
+        className={cn(
+          "fixed inset-0 z-40 bg-bg-deep/60 backdrop-blur-sm transition-opacity duration-200 lg:hidden",
+          mobileOpen ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+      />
+      <aside
+        className={cn(
+          "fixed inset-y-0 left-0 z-50 flex w-64 max-w-[80vw] flex-col border-r border-border-subtle bg-bg-deep/95 backdrop-blur-md transition-transform duration-200 lg:hidden motion-reduce:transition-none",
+          mobileOpen ? "translate-x-0" : "-translate-x-full",
+        )}
+      >
+        <SidebarBody
+          t={t}
+          pathname={pathname}
+          collapsed={false}
+          onNavigate={() => setMobileOpen(false)}
+          onMobileClose={() => setMobileOpen(false)}
+        />
+      </aside>
+    </>
+  );
+}
+
+/** 栏体(品牌 + 导航 + 控制区)—— 桌面栏与移动抽屉共用。 */
+function SidebarBody({
+  t,
+  pathname,
+  collapsed,
+  onToggleCollapsed,
+  onNavigate,
+  onMobileClose,
+}: {
+  t: ReturnType<typeof useTranslations>;
+  pathname: string;
+  collapsed: boolean;
+  onToggleCollapsed?: () => void;
+  onNavigate?: () => void;
+  onMobileClose?: () => void;
+}) {
+  return (
+    <>
+      {/* Brand —— 朱红印章 + 字标。折叠态仅留印章。 */}
+      <div
+        className={cn(
+          "flex items-center gap-3 border-b border-border-subtle py-5",
+          collapsed ? "justify-center px-0" : "px-5",
+        )}
+      >
+        {collapsed && onToggleCollapsed ? (
+          // 折叠态:印章本身即「展开」按钮(悬浮露出展开图标),配底部按钮双保险。
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            aria-label={t("expand")}
+            title={t("expand")}
+            className="group relative flex size-10 shrink-0 items-center justify-center rounded-md"
+          >
+            <img
+              src="/inalpha-seal.png"
+              alt="Inalpha"
+              width={40}
+              height={40}
+              className="seal-glow size-10 select-none transition-opacity duration-200 group-hover:opacity-20"
+              draggable={false}
+            />
+            <PanelLeftOpen
+              className="absolute size-5 text-cyan opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+              strokeWidth={2}
+            />
+          </button>
+        ) : (
+          <img
+            src="/inalpha-seal.png"
+            alt="Inalpha"
+            width={40}
+            height={40}
+            className="seal-glow size-10 shrink-0 select-none transition-transform duration-300 hover:rotate-[-4deg] hover:scale-110"
+            draggable={false}
+          />
+        )}
+        {!collapsed && (
+          <div className="min-w-0 flex-1">
+            <div className="font-display text-xl leading-none tracking-tight text-fg">
+              Inalpha
+            </div>
+            <div className="mt-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted">
+              {t("console")}
+            </div>
           </div>
-          <div className="mt-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted">
-            {t("console")}
-          </div>
-        </div>
+        )}
+        {onMobileClose ? (
+          <button
+            type="button"
+            onClick={onMobileClose}
+            aria-label={t("close")}
+            className="ml-auto flex size-8 items-center justify-center rounded-md text-fg-muted transition-colors hover:bg-bg-elev/60 hover:text-fg"
+          >
+            <X className="size-4" strokeWidth={1.75} />
+          </button>
+        ) : onToggleCollapsed && !collapsed ? (
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            aria-label={t("collapse")}
+            title={t("collapse")}
+            className="ml-auto flex size-8 shrink-0 items-center justify-center rounded-md border border-border-subtle text-fg-muted transition-colors hover:border-cyan/40 hover:bg-bg-elev/60 hover:text-cyan"
+          >
+            <PanelLeftClose className="size-4" strokeWidth={1.75} />
+          </button>
+        ) : null}
       </div>
 
-      {/* Nav —— 终端「行号 + 标的」语感:序号 / 图标 / 名称。 */}
+      {/* Nav —— 折叠态仅图标(居中 + title 悬浮提示)。 */}
       <nav className="flex flex-1 flex-col gap-0.5 p-3">
         {NAV.map((item) => {
           const active = !item.soon && pathname === item.href;
@@ -72,29 +252,34 @@ export function ConsoleSidebar() {
               <Icon
                 className={cn(
                   "size-4 shrink-0 transition-colors",
-                  active
-                    ? "text-cyan"
-                    : "text-fg-muted group-hover:text-fg",
+                  active ? "text-cyan" : "text-fg-muted group-hover:text-fg",
                 )}
                 strokeWidth={1.75}
               />
-              <span className="flex-1 truncate">{t(item.key)}</span>
-              {item.soon && (
-                <span className="rounded-sm border border-border-subtle px-1 py-px font-mono text-[9px] uppercase tracking-wider text-fg-muted/70">
-                  {t("soon")}
-                </span>
+              {!collapsed && (
+                <>
+                  <span className="flex-1 truncate">{t(item.key)}</span>
+                  {item.soon && (
+                    <span className="rounded-sm border border-border-subtle px-1 py-px font-mono text-[9px] uppercase tracking-wider text-fg-muted/70">
+                      {t("soon")}
+                    </span>
+                  )}
+                </>
               )}
             </>
           );
 
-          const baseCls =
-            "group relative flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-[color,background-color,transform] duration-200";
+          const baseCls = cn(
+            "group relative flex items-center rounded-md py-2 text-sm transition-[color,background-color,transform] duration-200",
+            collapsed ? "justify-center px-0" : "gap-2.5 px-3",
+          );
 
           if (item.soon) {
             return (
               <div
                 key={item.key}
                 aria-disabled
+                title={collapsed ? t(item.key) : undefined}
                 className={cn(baseCls, "cursor-not-allowed text-fg-muted/50")}
               >
                 {inner}
@@ -106,17 +291,19 @@ export function ConsoleSidebar() {
             <Link
               key={item.key}
               href={item.href}
+              onClick={onNavigate}
               aria-current={active ? "page" : undefined}
+              title={collapsed ? t(item.key) : undefined}
               className={cn(
                 baseCls,
-                "hover:translate-x-0.5",
+                !collapsed && "hover:translate-x-0.5",
                 active
                   ? "bg-cyan/10 text-fg"
                   : "text-fg-muted hover:bg-bg-elev/60 hover:text-fg",
               )}
             >
               {/* 激活态:左侧朱红印章刻度(品牌色锚定当前位置)。 */}
-              {active && (
+              {active && !collapsed && (
                 <span className="absolute left-0 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-r-full bg-seal" />
               )}
               {inner}
@@ -125,17 +312,34 @@ export function ConsoleSidebar() {
         })}
       </nav>
 
-      {/* Footer —— 控制区(主题 / 语言)+ build 标记。 */}
-      <div className="flex flex-col gap-3 border-t border-border-subtle px-4 py-3">
-        <div className="flex items-center justify-between">
+      {/* Footer —— 控制区(主题 / 语言)+ 折叠开关 + build 标记。 */}
+      {collapsed ? (
+        <div className="flex flex-col items-center gap-3 border-t border-border-subtle px-2 py-3">
           <ThemeToggle />
-          <LocaleSwitcher />
+          {onToggleCollapsed && (
+            <button
+              type="button"
+              onClick={onToggleCollapsed}
+              aria-label={t("expand")}
+              title={t("expand")}
+              className="flex size-8 items-center justify-center rounded-md border border-border-subtle text-fg-muted transition-colors hover:border-cyan/40 hover:bg-bg-elev/60 hover:text-cyan"
+            >
+              <PanelLeftOpen className="size-4" strokeWidth={1.75} />
+            </button>
+          )}
         </div>
-        <div className="flex items-center gap-1.5 whitespace-nowrap font-mono text-[10px] uppercase tracking-[0.18em] text-fg-muted/60">
-          <span className="size-1.5 shrink-0 rounded-full bg-seal" />
-          <span>Build · D-11</span>
+      ) : (
+        <div className="flex flex-col gap-3 border-t border-border-subtle px-4 py-3">
+          <div className="flex items-center justify-between">
+            <ThemeToggle />
+            <LocaleSwitcher />
+          </div>
+          <div className="flex items-center gap-1.5 whitespace-nowrap font-mono text-[10px] uppercase tracking-[0.18em] text-fg-muted/60">
+            <span className="size-1.5 shrink-0 rounded-full bg-seal" />
+            <span>Build · D-11</span>
+          </div>
         </div>
-      </div>
-    </aside>
+      )}
+    </>
   );
 }

--- a/apps/dashboard/src/components/shell/ConsoleSidebar.tsx
+++ b/apps/dashboard/src/components/shell/ConsoleSidebar.tsx
@@ -73,14 +73,19 @@ export function ConsoleSidebar() {
     setMobileOpen(false);
   }, [pathname]);
 
-  // 抽屉打开时:Esc 关 + 锁背景滚动。
+  // 抽屉打开时:Esc 关 + 锁背景滚动(防遮罩下方页面仍可拖动)。
   useEffect(() => {
     if (!mobileOpen) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setMobileOpen(false);
     };
     window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
   }, [mobileOpen]);
 
   return (

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -53,6 +53,17 @@ export interface OrderRecord {
   trade_plan_id: string | null;
 }
 
+/** 运行日志级别 —— 与后端 live_runner 写入一致。 */
+export type RunLogLevel = "info" | "warn" | "error";
+
+/** run_log 一条 —— 运行日志(info 活动 / warn 可恢复 / error 终态)。 */
+export interface RunLogEntry {
+  ts: string;
+  level: RunLogLevel;
+  msg: string;
+  code: string | null;
+}
+
 /** GET /strategy_runs 元素(live runner 运行态)。 */
 export interface StrategyRunRecord {
   id: string;
@@ -65,7 +76,8 @@ export interface StrategyRunRecord {
   params: Record<string, unknown>;
   last_bar_ts: string | null;
   cumulative_pnl: number;
-  error_log: Array<Record<string, unknown>>;
+  /** 运行日志(滚动窗口,最近 N 条):起跑 / 出单 / 停止 / 退避 / 错误。 */
+  run_log: RunLogEntry[];
   started_at: string;
   stopped_at: string | null;
 }

--- a/infra/migrations/versions/0015_run_log.py
+++ b/infra/migrations/versions/0015_run_log.py
@@ -52,7 +52,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # 回退条目形态 {ts, level, msg, code} → {ts, error, code}（丢弃 level；msg→error）
+    # 回退条目形态 {ts, level, msg, code} → {ts, error, code}（丢弃 level；msg→error）。
+    # **只保留 level='error'**：旧 error_log 语义是纯错误日志，旧版 RunnerCard 角标 =
+    # error_log.length（不分级）、面板把每条都当错误显示。若把 info/warn（起跑 / 出单 /
+    # 停止，随 bar 累积）一并写回，回滚后角标暴增、正常活动被当错误 —— 在排障窗口反成噪音。
+    # 保留 WITH ORDINALITY + ORDER BY ord 维持时序。
     op.execute(
         """
         UPDATE strategy_runs
@@ -60,8 +64,10 @@ def downgrade() -> None:
             (
                 SELECT jsonb_agg(
                     jsonb_build_object('ts', e->>'ts', 'error', e->>'msg', 'code', e->'code')
+                    ORDER BY ord
                 )
-                FROM jsonb_array_elements(run_log) AS e
+                FROM jsonb_array_elements(run_log) WITH ORDINALITY AS arr(e, ord)
+                WHERE e->>'level' = 'error'
             ),
             '[]'::jsonb
         )

--- a/infra/migrations/versions/0015_run_log.py
+++ b/infra/migrations/versions/0015_run_log.py
@@ -1,0 +1,71 @@
+"""strategy_runs.error_log → run_log：统一运行日志（info/warn/error）
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-06-08
+
+live runner 原来只在出错时往 ``error_log`` 追加 ``{ts, error, code}``。需求升级为「记录
+agent 的所有日志」——起跑 / 出单 / 停止等 info 级活动、退避 / 熔断 / TTL 等 warn 级、终态
+error 级，统一进一个带 ``level`` 的运行日志。
+
+本迁移：
+
+1. 列改名 ``error_log`` → ``run_log``（语义从「错误日志」升级为「运行日志」）。
+2. 历史条目形态 ``{ts, error, code}`` → ``{ts, level:'error', msg, code}``（旧条目都是错误，
+   补 ``level='error'``，``error`` 字段更名 ``msg``，与新写入形态统一）。
+
+容量：写入侧（``storage.append_log``）按滚动窗口裁到最近 N 条，防 info 级随 bar 无界膨胀。
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0015"
+down_revision: str | None = "0014"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE strategy_runs RENAME COLUMN error_log TO run_log")
+    # 历史条目 {ts, error, code} → {ts, level:'error', msg, code}
+    op.execute(
+        """
+        UPDATE strategy_runs
+        SET run_log = COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'ts', e->>'ts',
+                        'level', 'error',
+                        'msg', e->>'error',
+                        'code', e->'code'
+                    )
+                )
+                FROM jsonb_array_elements(run_log) AS e
+            ),
+            '[]'::jsonb
+        )
+        WHERE jsonb_array_length(run_log) > 0
+        """
+    )
+
+
+def downgrade() -> None:
+    # 回退条目形态 {ts, level, msg, code} → {ts, error, code}（丢弃 level；msg→error）
+    op.execute(
+        """
+        UPDATE strategy_runs
+        SET run_log = COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object('ts', e->>'ts', 'error', e->>'msg', 'code', e->'code')
+                )
+                FROM jsonb_array_elements(run_log) AS e
+            ),
+            '[]'::jsonb
+        )
+        WHERE jsonb_array_length(run_log) > 0
+        """
+    )
+    op.execute("ALTER TABLE strategy_runs RENAME COLUMN run_log TO error_log")

--- a/services/paper/src/inalpha_paper/api/strategy_runs.py
+++ b/services/paper/src/inalpha_paper/api/strategy_runs.py
@@ -239,7 +239,7 @@ def _row_to_record(row: dict[str, Any]) -> StrategyRunRecord:
         params=row.get("params") or {},
         last_bar_ts=row.get("last_bar_ts"),
         cumulative_pnl=float(row["cumulative_pnl"]),
-        error_log=row.get("error_log") or [],
+        run_log=row.get("run_log") or [],
         started_at=row["started_at"],
         stopped_at=row.get("stopped_at"),
     )

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -157,7 +157,14 @@ class LiveRunnerManager:
         async with get_conn() as conn:
             current = await runs_store.get(conn, run_id)
             if current is not None and current["status"] == "running":
-                await runs_store.append_log(conn, run_id, "info", "用户停止运行")
+                # 日志写入是 best-effort，失败不应阻断 set_status——否则 run 停不下来、
+                # API 返回 500，用户以为停止失败（CR）。用 savepoint 隔离：append_log 抛错
+                # 只回滚这一步（否则会污染整个事务，连带 set_status 也失败），再照常置 stopped。
+                try:
+                    async with conn.transaction():
+                        await runs_store.append_log(conn, run_id, "info", "用户停止运行")
+                except Exception:
+                    _logger.warning("live run %s: 停止日志写入失败（已忽略）", run_id, exc_info=True)
                 await runs_store.set_status(conn, run_id, "stopped")
 
     async def stop_all(self) -> None:

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -241,12 +241,18 @@ class LiveRunnerManager:
         # 边界，第一根 fetch 到的 warmup_ts bar 会绕过 dedup → 对已喂过的 bar 二次 on_bar →
         # 信号重复 → spurious 订单落库。全新 run（last_bar_ts 为 None）退化为 warmup_ts，行为不变。
         # 起跑 / 恢复 —— info 级运行日志（供运行详情「运行日志」面板观测，不只记错误）。
-        async with get_conn() as conn:
-            await runs_store.append_log(
-                conn, run_id, "info",
-                f"{'恢复运行' if run.get('last_bar_ts') else '策略起跑'}："
-                f"{run['venue']} {run['symbol']} {run['timeframe']}",
-            )
+        # best-effort：日志写入失败（连接池耗尽 / DB 抖动）绝不能逃逸 _run_loop——否则 task
+        # 带异常退出，done_callback 只移除引用、不置 errored，run 永久卡 'running' 却无 task 在跑
+        # （与 stop()/_process_bar 出单日志的 try/except 对齐）（CR）。
+        try:
+            async with get_conn() as conn:
+                await runs_store.append_log(
+                    conn, run_id, "info",
+                    f"{'恢复运行' if run.get('last_bar_ts') else '策略起跑'}："
+                    f"{run['venue']} {run['symbol']} {run['timeframe']}",
+                )
+        except Exception:
+            _logger.warning("live run %s: 起跑日志写入失败（已忽略）", run_id, exc_info=True)
 
         _db_bound = run.get("last_bar_ts")
         last_bar_ts: datetime | None = (

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -502,13 +502,15 @@ class LiveRunnerManager:
             except Exception:
                 _logger.exception("live run %s: 记不支持单型决策行失败", run["id"])
         # 本根 bar 有下单意图 → info 级运行日志（无信号的空 bar 不记，避免刷屏）。
+        # 措辞「触发 N 个信号（待撮合）」：此处 orders 是策略意图、尚未过风控/撮合，
+        # 后续可能被 risk_rejected 全拦——不写「产生 N 个下单意图」以免与最终无成交割裂（CR）。
         if orders:
             try:
                 async with get_conn() as conn:
                     await runs_store.append_log(
                         conn, run["id"], "info",
                         f"bar {_ns_to_dt(bar.ts_event):%Y-%m-%d %H:%M} · "
-                        f"策略产生 {len(orders)} 个下单意图",
+                        f"策略触发 {len(orders)} 个信号（待撮合）",
                     )
             except Exception:
                 _logger.exception("live run %s: 写出单日志失败", run["id"])

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -157,6 +157,7 @@ class LiveRunnerManager:
         async with get_conn() as conn:
             current = await runs_store.get(conn, run_id)
             if current is not None and current["status"] == "running":
+                await runs_store.append_log(conn, run_id, "info", "用户停止运行")
                 await runs_store.set_status(conn, run_id, "stopped")
 
     async def stop_all(self) -> None:
@@ -194,8 +195,8 @@ class LiveRunnerManager:
             # 显式放行：留一条醒目告警，让用户知道这个 run 在零风控下跑
             _logger.warning("live run %s: 风控不可用但已显式放行，零风控运行", run_id)
             async with get_conn() as conn:
-                await runs_store.append_error_log(
-                    conn, run_id,
+                await runs_store.append_log(
+                    conn, run_id, "warn",
                     "⚠ 风控不可用且 INALPHA_LIVE_RUNNER_REQUIRE_RISK_GUARD=false，本 run 在零风控下运行",
                 )
         # build 退避（issue #41）：data 服务短暂不可用不该直接判死，退避重试；策略代码 /
@@ -223,8 +224,8 @@ class LiveRunnerManager:
                         await runs_store.set_status(conn, run_id, "errored")
                     return
                 async with get_conn() as conn:
-                    await runs_store.append_error_log(
-                        conn, run_id, f"build retry {build_streak}: {e}", code=code
+                    await runs_store.append_log(
+                        conn, run_id, "warn", f"build retry {build_streak}: {e}", code=code
                     )
                 await asyncio.sleep(min(2 ** build_streak, 60))
 
@@ -232,6 +233,14 @@ class LiveRunnerManager:
         # resume 续跑时 warmup 已把历史喂到 warmup_ts（可能 > DB last_bar_ts），若只用 DB
         # 边界，第一根 fetch 到的 warmup_ts bar 会绕过 dedup → 对已喂过的 bar 二次 on_bar →
         # 信号重复 → spurious 订单落库。全新 run（last_bar_ts 为 None）退化为 warmup_ts，行为不变。
+        # 起跑 / 恢复 —— info 级运行日志（供运行详情「运行日志」面板观测，不只记错误）。
+        async with get_conn() as conn:
+            await runs_store.append_log(
+                conn, run_id, "info",
+                f"{'恢复运行' if run.get('last_bar_ts') else '策略起跑'}："
+                f"{run['venue']} {run['symbol']} {run['timeframe']}",
+            )
+
         _db_bound = run.get("last_bar_ts")
         last_bar_ts: datetime | None = (
             max(_db_bound, warmup_ts)
@@ -265,8 +274,8 @@ class LiveRunnerManager:
                 if circuit_break and self._settings.live_runner_auto_stop_on_circuit_break:
                     _logger.warning("live run %s: 账户级风控熔断，auto-stop", run_id)
                     async with get_conn() as conn:
-                        await runs_store.append_error_log(
-                            conn, run_id,
+                        await runs_store.append_log(
+                            conn, run_id, "warn",
                             "账户级风控熔断（global scope 锁：回撤 / 连续止损上限）→ auto-stop；"
                             "复核账户状态后可重新 start。设 "
                             "INALPHA_LIVE_RUNNER_AUTO_STOP_ON_CIRCUIT_BREAK=false 维持旧行为（继续跑）",
@@ -321,8 +330,8 @@ class LiveRunnerManager:
             "live run %s: 运行 %.0fs 超过 TTL %ds，auto-stop", run_id, elapsed, max_runtime_s
         )
         async with get_conn() as conn:
-            await runs_store.append_error_log(
-                conn, run_id,
+            await runs_store.append_log(
+                conn, run_id, "warn",
                 f"运行时长 {elapsed:.0f}s 超过 TTL（INALPHA_LIVE_RUNNER_MAX_RUNTIME_S="
                 f"{max_runtime_s}s）→ auto-stop（防长尾僵尸 run）；复核后可重新 start。",
             )
@@ -485,6 +494,17 @@ class LiveRunnerManager:
                     )
             except Exception:
                 _logger.exception("live run %s: 记不支持单型决策行失败", run["id"])
+        # 本根 bar 有下单意图 → info 级运行日志（无信号的空 bar 不记，避免刷屏）。
+        if orders:
+            try:
+                async with get_conn() as conn:
+                    await runs_store.append_log(
+                        conn, run["id"], "info",
+                        f"bar {_ns_to_dt(bar.ts_event):%Y-%m-%d %H:%M} · "
+                        f"策略产生 {len(orders)} 个下单意图",
+                    )
+            except Exception:
+                _logger.exception("live run %s: 写出单日志失败", run["id"])
         circuit_break = False
         for order, strategy_id in orders:
             try:
@@ -648,8 +668,8 @@ class LiveRunnerManager:
                 reason=f"RISK_REJECTED: {e.message}", ts_event=bar.ts_event,
             )
             async with get_conn() as conn:
-                await runs_store.append_error_log(
-                    conn, run_id, f"order rejected by risk: {e.message}"
+                await runs_store.append_log(
+                    conn, run_id, "warn", f"order rejected by risk: {e.message}"
                 )
                 await self._record_decision(
                     conn, run, order, bar, outcome="risk_rejected", intent=intent,

--- a/services/paper/src/inalpha_paper/schemas.py
+++ b/services/paper/src/inalpha_paper/schemas.py
@@ -584,7 +584,10 @@ class StrategyRunRecord(BaseModel):
     params: dict[str, Any] = Field(default_factory=dict)
     last_bar_ts: datetime | None = None
     cumulative_pnl: float = 0.0
-    error_log: list[dict[str, Any]] = Field(default_factory=list)
+    run_log: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="运行日志（滚动窗口）：每条 {ts, level(info/warn/error), msg, code}",
+    )
     started_at: datetime
     stopped_at: datetime | None = None
 

--- a/services/paper/src/inalpha_paper/storage/strategy_runs.py
+++ b/services/paper/src/inalpha_paper/storage/strategy_runs.py
@@ -192,7 +192,9 @@ async def append_log(
                 FROM (
                     SELECT elem, ord
                     FROM jsonb_array_elements(
-                        run_log || jsonb_build_array(
+                        -- NULL::jsonb || '[...]' 求值为 NULL → 新条目被静默丢弃；
+                        -- COALESCE 兜底,防 run_log 日后改 nullable / fixture 插 NULL（CR）。
+                        COALESCE(run_log, '[]'::jsonb) || jsonb_build_array(
                             jsonb_build_object(
                                 'ts', NOW()::text, 'level', %s::text,
                                 'msg', %s::text, 'code', %s::text
@@ -250,7 +252,8 @@ async def mark_running_as_errored(conn: AsyncConnection, *, reason: str) -> int:
                     FROM (
                         SELECT elem, ord
                         FROM jsonb_array_elements(
-                            run_log || jsonb_build_array(
+                            -- COALESCE 兜底 NULL run_log（见 append_log 同款防护，CR）。
+                            COALESCE(run_log, '[]'::jsonb) || jsonb_build_array(
                                 jsonb_build_object(
                                     'ts', NOW()::text, 'level', 'error',
                                     'msg', %s::text, 'code', NULL

--- a/services/paper/src/inalpha_paper/storage/strategy_runs.py
+++ b/services/paper/src/inalpha_paper/storage/strategy_runs.py
@@ -234,21 +234,36 @@ async def list_all_running(conn: AsyncConnection) -> list[dict[str, Any]]:
 
 
 async def mark_running_as_errored(conn: AsyncConnection, *, reason: str) -> int:
-    """把所有 running 行标 errored（服务重启 reconcile：内存 task 已丢失）。返回受影响行数。"""
+    """把所有 running 行标 errored（服务重启 reconcile：内存 task 已丢失）。返回受影响行数。
+
+    追加 error 条后同样按 ``_RUN_LOG_CAP`` 滚动裁剪 —— 这些 run 标 errored 后不再收到
+    :func:`append_log`，若此处不裁，恰好满 300 条的 run_log 会被推到 301 条且永久超限。
+    """
     async with conn.cursor() as cur:
         await cur.execute(
             """
             UPDATE strategy_runs
             SET status = 'errored',
                 stopped_at = NOW(),
-                run_log = run_log || jsonb_build_array(
-                    jsonb_build_object(
-                        'ts', NOW()::text, 'level', 'error', 'msg', %s::text, 'code', NULL
-                    )
+                run_log = (
+                    SELECT COALESCE(jsonb_agg(elem ORDER BY ord), '[]'::jsonb)
+                    FROM (
+                        SELECT elem, ord
+                        FROM jsonb_array_elements(
+                            run_log || jsonb_build_array(
+                                jsonb_build_object(
+                                    'ts', NOW()::text, 'level', 'error',
+                                    'msg', %s::text, 'code', NULL
+                                )
+                            )
+                        ) WITH ORDINALITY AS arr(elem, ord)
+                        ORDER BY ord DESC
+                        LIMIT %s
+                    ) recent
                 )
             WHERE status = %s
             """,
-            (reason, _RUNNING),
+            (reason, _RUN_LOG_CAP, _RUNNING),
         )
         return cur.rowcount
 

--- a/services/paper/src/inalpha_paper/storage/strategy_runs.py
+++ b/services/paper/src/inalpha_paper/storage/strategy_runs.py
@@ -46,7 +46,7 @@ async def insert(
                     candidate_id, account_id, status, venue, symbol, timeframe, params
                 ) VALUES (%s, %s, 'running', %s, %s, %s, %s::jsonb)
                 RETURNING id, candidate_id, account_id, status, venue, symbol,
-                          timeframe, params, last_bar_ts, cumulative_pnl, error_log,
+                          timeframe, params, last_bar_ts, cumulative_pnl, run_log,
                           started_at, stopped_at
                 """,
                 (
@@ -69,7 +69,7 @@ async def get(conn: AsyncConnection, run_id: UUID) -> dict[str, Any] | None:
     async with conn.cursor() as cur:
         await cur.execute(
             "SELECT id, candidate_id, account_id, status, venue, symbol, timeframe, "
-            "params, last_bar_ts, cumulative_pnl, error_log, started_at, stopped_at "
+            "params, last_bar_ts, cumulative_pnl, run_log, started_at, stopped_at "
             "FROM strategy_runs WHERE id = %s",
             (str(run_id),),
         )
@@ -86,7 +86,7 @@ async def list_by_account(
 ) -> list[dict[str, Any]]:
     sql = (
         "SELECT id, candidate_id, account_id, status, venue, symbol, timeframe, "
-        "params, last_bar_ts, cumulative_pnl, error_log, started_at, stopped_at "
+        "params, last_bar_ts, cumulative_pnl, run_log, started_at, stopped_at "
         "FROM strategy_runs WHERE account_id = %s"
     )
     args: list[Any] = [str(account_id)]
@@ -129,7 +129,7 @@ async def set_status(
                 stopped_at = CASE WHEN %s <> 'running' THEN NOW() ELSE stopped_at END
             WHERE id = %s
             RETURNING id, candidate_id, account_id, status, venue, symbol, timeframe,
-                      params, last_bar_ts, cumulative_pnl, error_log, started_at, stopped_at
+                      params, last_bar_ts, cumulative_pnl, run_log, started_at, stopped_at
             """,
             (status, status, str(run_id)),
         )
@@ -162,25 +162,58 @@ async def update_progress(
             )
 
 
-async def append_error_log(
-    conn: AsyncConnection, run_id: UUID, error: str, *, code: str | None = None
-) -> None:
-    """往 error_log JSONB 数组追加一条 ``{ts, error, code}``（``code`` 为错误分类，issue #41）。
+# run_log 单条容量上限 —— info 级日志按 bar 增长，只保留最近 N 条（滚动窗口），
+# 防 JSONB 数组无界膨胀拖慢 run 行读写。
+_RUN_LOG_CAP = 300
 
-    ``code`` 为 ``None`` 时写 JSON ``null``（结构仍统一）；build 阶段的可重试 / 不可重试
-    分类见 ``live_runner._classify_build_error``（infra_unavailable / strategy_error / unknown）。
+
+async def append_log(
+    conn: AsyncConnection,
+    run_id: UUID,
+    level: str,
+    msg: str,
+    *,
+    code: str | None = None,
+) -> None:
+    """往 run_log JSONB 数组追加一条 ``{ts, level, msg, code}`` 并裁到最近 ``_RUN_LOG_CAP`` 条。
+
+    ``level`` ∈ ``{info, warn, error}``：info=正常活动（起跑 / 出单 / 停止），warn=可恢复
+    异常（退避重试 / 熔断 / TTL），error=终态错误。``code`` 为错误分类（可空，仅 warn/error 用，
+    见 ``live_runner._classify_build_error``：infra_unavailable / strategy_error / unknown）。
+
+    裁剪：append 后按时间序只留尾部 N 条 —— info 级随 bar 增长，无上限会让 run 行越读越重。
     """
     async with conn.cursor() as cur:
         await cur.execute(
             """
             UPDATE strategy_runs
-            SET error_log = error_log || jsonb_build_array(
-                    jsonb_build_object('ts', NOW()::text, 'error', %s::text, 'code', %s::text)
-                )
+            SET run_log = (
+                SELECT COALESCE(jsonb_agg(elem ORDER BY ord), '[]'::jsonb)
+                FROM (
+                    SELECT elem, ord
+                    FROM jsonb_array_elements(
+                        run_log || jsonb_build_array(
+                            jsonb_build_object(
+                                'ts', NOW()::text, 'level', %s::text,
+                                'msg', %s::text, 'code', %s::text
+                            )
+                        )
+                    ) WITH ORDINALITY AS arr(elem, ord)
+                    ORDER BY ord DESC
+                    LIMIT %s
+                ) recent
+            )
             WHERE id = %s
             """,
-            (error, code, str(run_id)),
+            (level, msg, code, _RUN_LOG_CAP, str(run_id)),
         )
+
+
+async def append_error_log(
+    conn: AsyncConnection, run_id: UUID, error: str, *, code: str | None = None
+) -> None:
+    """兼容旧调用：以 ``error`` 级写一条 run_log（见 :func:`append_log`）。"""
+    await append_log(conn, run_id, "error", error, code=code)
 
 
 async def list_all_running(conn: AsyncConnection) -> list[dict[str, Any]]:
@@ -192,7 +225,7 @@ async def list_all_running(conn: AsyncConnection) -> list[dict[str, Any]]:
     async with conn.cursor() as cur:
         await cur.execute(
             "SELECT id, candidate_id, account_id, status, venue, symbol, timeframe, "
-            "params, last_bar_ts, cumulative_pnl, error_log, started_at, stopped_at "
+            "params, last_bar_ts, cumulative_pnl, run_log, started_at, stopped_at "
             "FROM strategy_runs WHERE status = %s ORDER BY started_at",
             (_RUNNING,),
         )
@@ -208,8 +241,10 @@ async def mark_running_as_errored(conn: AsyncConnection, *, reason: str) -> int:
             UPDATE strategy_runs
             SET status = 'errored',
                 stopped_at = NOW(),
-                error_log = error_log || jsonb_build_array(
-                    jsonb_build_object('ts', NOW()::text, 'error', %s::text)
+                run_log = run_log || jsonb_build_array(
+                    jsonb_build_object(
+                        'ts', NOW()::text, 'level', 'error', 'msg', %s::text, 'code', NULL
+                    )
                 )
             WHERE status = %s
             """,

--- a/services/paper/tests/test_live_runner.py
+++ b/services/paper/tests/test_live_runner.py
@@ -236,7 +236,7 @@ async def test_run_loop_circuit_break_auto_stops(
         fresh = await runs_store.get(conn, run["id"])
     assert fresh["status"] == "stopped"  # 熔断是正常终态，非 errored
     assert calls["n"] == 1  # 处理完第一根就 auto-stop，没再拉第 2 根
-    assert any("熔断" in e.get("error", "") for e in (fresh["error_log"] or []))
+    assert any("熔断" in e.get("msg", "") for e in (fresh["run_log"] or []))
 
 
 async def test_process_bar_risk_rejected_records_decision(
@@ -400,7 +400,7 @@ async def test_run_loop_fail_closed_without_risk_guard(app_with_lifespan: Any) -
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
     assert fresh["status"] == "errored"
-    assert any("风控不可用" in e.get("error", "") for e in (fresh["error_log"] or []))
+    assert any("风控不可用" in e.get("msg", "") for e in (fresh["run_log"] or []))
 
 
 async def test_process_bar_no_signal_no_order(app_with_lifespan: Any) -> None:
@@ -465,7 +465,7 @@ async def test_run_loop_non_retryable_error_immediate_errored(
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
     assert fresh["status"] == "errored"
-    assert any("ValidationError" in e.get("error", "") for e in (fresh["error_log"] or []))
+    assert any("ValidationError" in e.get("msg", "") for e in (fresh["run_log"] or []))
 
 
 async def test_run_loop_retryable_error_accumulates_to_errored(
@@ -497,7 +497,7 @@ async def test_run_loop_retryable_error_accumulates_to_errored(
         fresh = await runs_store.get(conn, run["id"])
     assert fresh["status"] == "errored"
     # 攒到 streak=2 才挂：≥2 条网络错（证明第 1 次没杀 run）
-    blips = [e for e in (fresh["error_log"] or []) if "network blip" in e.get("error", "")]
+    blips = [e for e in (fresh["run_log"] or []) if "network blip" in e.get("msg", "")]
     assert len(blips) >= 2
 
 
@@ -543,7 +543,7 @@ async def test_run_loop_build_session_failure_errored(app_with_lifespan: Any) ->
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
     assert fresh["status"] == "errored"
-    assert any("build failed" in e.get("error", "") for e in (fresh["error_log"] or []))
+    assert any("build failed" in e.get("msg", "") for e in (fresh["run_log"] or []))
 
 
 async def test_process_bar_not_filled_rejects(
@@ -616,7 +616,7 @@ async def test_mark_running_as_errored_reconcile(app_with_lifespan: Any) -> None
         f_stopped = await runs_store.get(conn, stopped_run["id"])
     assert f_running["status"] == "errored"
     assert f_stopped["status"] == "stopped"  # 非 running 不受影响
-    assert any("reconcile" in e.get("error", "") for e in (f_running["error_log"] or []))
+    assert any("reconcile" in e.get("msg", "") for e in (f_running["run_log"] or []))
 
 
 async def test_compute_run_pnl_from_db_realized_plus_unrealized(
@@ -719,7 +719,7 @@ async def test_ttl_exceeded_stops_run(app_with_lifespan: Any) -> None:
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
     assert fresh["status"] == "stopped"
-    assert any("TTL" in e.get("error", "") for e in (fresh["error_log"] or []))
+    assert any("TTL" in e.get("msg", "") for e in (fresh["run_log"] or []))
 
 
 async def test_ttl_disabled_when_zero_or_no_start(app_with_lifespan: Any) -> None:
@@ -769,7 +769,7 @@ async def test_build_non_retryable_errors_immediately(
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
     assert fresh["status"] == "errored"
-    assert any(e.get("code") == "strategy_error" for e in (fresh["error_log"] or []))
+    assert any(e.get("code") == "strategy_error" for e in (fresh["run_log"] or []))
 
 
 async def test_build_retryable_backs_off_then_errored(
@@ -799,7 +799,7 @@ async def test_build_retryable_backs_off_then_errored(
         fresh = await runs_store.get(conn, run["id"])
     assert fresh["status"] == "errored"
     assert calls >= 2  # 退避重试过（不是一次就死）
-    assert any(e.get("code") == "infra_unavailable" for e in (fresh["error_log"] or []))
+    assert any(e.get("code") == "infra_unavailable" for e in (fresh["run_log"] or []))
 
 
 async def test_restore_position_from_db_brings_session_to_position(

--- a/services/paper/tests/test_strategy_runs_store.py
+++ b/services/paper/tests/test_strategy_runs_store.py
@@ -71,8 +71,8 @@ async def test_update_progress_and_error_log(app_with_lifespan: Any) -> None:
         fresh = await runs_store.get(conn, run["id"])
     assert fresh is not None
     assert Decimal(str(fresh["cumulative_pnl"])) == Decimal("12.5")
-    assert len(fresh["error_log"]) == 1
-    assert fresh["error_log"][0]["error"] == "boom"
+    assert len(fresh["run_log"]) == 1
+    assert fresh["run_log"][0]["msg"] == "boom"
 
 
 async def test_mark_running_as_errored_reconcile(app_with_lifespan: Any) -> None:


### PR DESCRIPTION
模拟盘运行详情 + 控制台外壳一组优化(4 个独立 commit)。

## 改动

**① `feat(paper)` live runner 统一运行日志 run_log（info/warn/error）**
- `error_log` 升级为 `run_log`：live_runner 在起跑/恢复、每根出单 bar、用户停止记 **info**；退避重试/风控熔断/TTL/零风控放行记 **warn**；终态错误记 **error**。
- storage 加 `append_log(level,msg)` + 滚动容量上限（最近 N 条，防 info 随 bar 无界膨胀），`append_error_log` 兼容壳保留。
- schema/api 字段 `error_log→run_log`；迁移 **0015** 改列名 + 旧条目 `{ts,error,code}→{ts,level:'error',msg,code}`。

**② `feat(dashboard)` 运行详情运行日志面板 + 决策时间线原因**
- 错误日志面板 → 「运行日志」：按级别着色（info 青 / warn 金 / error 朱红）+ 图标 + 时间戳，最新在上，空态兜底；卡片角标只数 error 级。
- 决策时间线「原因」：成交行 reason 为空时回退 `tag → 「策略信号成交」`，不再一片「—」；并改**单行不换行**（truncate + 悬浮 title 看全文）。

**③ `feat(dashboard)` 侧边栏可展开收缩 + 移动端外壳**
- 桌面侧边栏可折叠成「仅图标」窄轨（持久化）；折叠开关在品牌行，折叠态印章本身即展开钮 + 底部展开钮双保险。
- 修复 fixed `ActivityFooter`(z-20) 压住侧边栏底部控制导致「收起后展开钮点不到」（侧边栏底部预留 `--activity-h`）。
- 移动端（<lg）左栏隐藏为抽屉 + 顶栏汉堡 + 遮罩（路由/Esc/点遮罩关）；内容区让位 + 响应式 padding；对话栏满宽 + 隐藏拖宽手柄。

**④ `feat(dashboard)` K线 数据新鲜度 + 周期切换 + 当前价/指标/LTR**
- 数据新鲜度（§3.1 fresh=True）：`/api/bars` 改为「先读、仅当空/旧才回填再读」——修复切到没回填过的周期（BTC `1d`=0 根）/窗口偏旧时「时间是空的」；数据已新鲜则直返，不每轮重拉外部源。
- 周期切换加载反馈（首次回填较慢时不再像「点了没反应」）。
- 当前价大字 + 涨跌幅 + 右轴虚线 priceLine；指标扩到 **MA5/MA10/MA20/MA60 / EMA / 布林带 / 成交量**，独立开关。
- 修复 hover 气泡文字从右到左（canvas 强制 `dir=ltr`）+ canvas 字体由 `var(--font-mono)` 解析成真实字体串。

## 验证
- `pnpm typecheck` ✓ · `pnpm build`（dashboard）exit 0 ✓
- paper：`ruff` ✓ · 47 tests ✓（新日志路径已覆盖）
- 迁移 0015 已在本地库 apply + 旧数据转换正确；`/api/bars` 多周期回填实测正确
- i18n en·zh 对齐（nav + runners.detail）

## 部署注意
含迁移 `infra/migrations/versions/0015_run_log.py` —— 合并后需 `alembic upgrade head`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)