### PR TITLE
feat(dashboard): 对话栏工具输出渲染 + 侧栏气泡 + RunnerChart 标题 + workingMemory

### DIFF
--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -408,6 +408,7 @@
     "loadingHistory": "Loading history…",
     "toolRunning": "running",
     "toolDone": "done",
+    "toolResult": "output",
     "errorGeneric": "Agent reply failed. Please retry — likely an upstream LLM error or dropped stream.",
     "errorDismiss": "Dismiss",
     "context": {

--- a/apps/dashboard/messages/zh.json
+++ b/apps/dashboard/messages/zh.json
@@ -408,6 +408,7 @@
     "loadingHistory": "加载历史会话…",
     "toolRunning": "调用中",
     "toolDone": "已完成",
+    "toolResult": "输出",
     "errorGeneric": "Agent 回复失败，请重试 —— 多半是上游 LLM 报错或连接中断。",
     "errorDismiss": "关闭",
     "context": {

--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -268,6 +268,17 @@
     animation: rise 0.5s cubic-bezier(0.22, 0.7, 0.22, 1) both;
   }
 
+  /* 折叠侧栏气泡:右滑淡入(挂 body 的 portal,外层负责定位、本层只动画)。 */
+  @keyframes tip-in {
+    from {
+      opacity: 0;
+      transform: translateX(4px);
+    }
+  }
+  .tip-in {
+    animation: tip-in 0.15s ease-out both;
+  }
+
   /* 数据列起始处的青色刻度(终端「行号 / 标尺」语感)。 */
   .tick-accent {
     position: relative;

--- a/apps/dashboard/src/components/chat/ChatThread.tsx
+++ b/apps/dashboard/src/components/chat/ChatThread.tsx
@@ -31,6 +31,8 @@ import {
 import { DivinationCard } from "@/components/divination/DivinationCard";
 import { isDivinationTool, parseDivination } from "@/components/divination/types";
 import { ChatMarkdown } from "./ChatMarkdown";
+import { ToolOutput } from "./ToolOutput";
+import { resolveToolView } from "./tool-views";
 
 /** AG-UI 消息(@ag-ui/core)的最小形态 —— 只取渲染需要的字段。 */
 type AGMessage = {
@@ -77,6 +79,7 @@ interface ThreadSummary {
  * @param open 是否展开(驱动 translate-x 滑入)
  * @param width 当前栏宽(px),由左缘分隔条拖动调整
  * @param threadId 当前会话 ID(变化即触发回填)
+ * @param freshThreads 本地「新建会话」刚生成的 threadId 集合 —— 必然无历史,跳过回填 fetch
  * @param onClose 收起回调
  * @param onWidthChange 拖动时上报新宽度(父组件 clamp + 持久化 + 驱动 main reflow)
  * @param onDragChange 拖动开始/结束(父组件打 data-chat-dragging 关 main 过渡)
@@ -87,6 +90,7 @@ export function ChatThread({
   open,
   width,
   threadId,
+  freshThreads,
   onClose,
   onWidthChange,
   onDragChange,
@@ -96,6 +100,7 @@ export function ChatThread({
   open: boolean;
   width: number;
   threadId: string;
+  freshThreads?: Set<string>;
   onClose: () => void;
   onWidthChange: (px: number) => void;
   onDragChange: (dragging: boolean) => void;
@@ -308,6 +313,12 @@ export function ChatThread({
   useEffect(() => {
     if (!threadId || loadedThreadRef.current === threadId) return;
     loadedThreadRef.current = threadId;
+    // 「新建会话」刚生成的 thread 后端必然为空 —— 同步清空即可,不打 loading 不发请求
+    // (否则点新建要等一次网络往返,后端慢时面板会闪「加载历史会话…」)。
+    if (freshThreads?.has(threadId)) {
+      setMessagesRef.current([] as never);
+      return;
+    }
     let cancelled = false;
     setHistoryLoading(true);
     fetch(`/api/chat/threads/${threadId}/messages`)
@@ -326,7 +337,7 @@ export function ChatThread({
     return () => {
       cancelled = true;
     };
-  }, [threadId]);
+  }, [threadId, freshThreads]);
 
   // 点开历史下拉:**保留上次列表立即展示**(不再清空回 loading 态),后台 no-store 重新拉、
   // 拿到再替换 —— 重开瞬间出内容,避免每次「思考中」白屏 +（标题持久化后）后端只剩一次
@@ -587,6 +598,7 @@ export function ChatThread({
               resolvedToolCallIds={resolvedToolCallIds}
               toolRunning={t("toolRunning")}
               toolDone={t("toolDone")}
+              toolResultLabel={t("toolResult")}
             />
           ))
         )}
@@ -665,12 +677,14 @@ function MessageRow({
   resolvedToolCallIds,
   toolRunning,
   toolDone,
+  toolResultLabel,
 }: {
   message: AGMessage;
   toolNames: Map<string, string>;
   resolvedToolCallIds: Set<string>;
   toolRunning: string;
   toolDone: string;
+  toolResultLabel: string;
 }) {
   const text = textOf(message.content);
 
@@ -698,9 +712,16 @@ function MessageRow({
         );
       }
     }
+    // 已完成 chip:展开只看**输出结果**(入参噪音大,按用户要求不展示)。
     return (
       <div className="rise flex justify-start">
-        <ToolChip name={toolName} body={text} label={toolDone} done />
+        <ToolChip
+          name={toolName}
+          result={text}
+          label={toolDone}
+          resultLabel={toolResultLabel}
+          done
+        />
       </div>
     );
   }
@@ -723,26 +744,77 @@ function MessageRow({
         <ToolChip
           key={c.id}
           name={c.function?.name ?? "tool"}
-          body={c.function?.arguments ?? ""}
           label={toolRunning}
+          resultLabel={toolResultLabel}
         />
       ))}
     </div>
   );
 }
 
-/** 工具调用 / 结果的紧凑 chip,可展开看入参或结果。 */
+/** JSON 字符串美化(两格缩进);不是合法 JSON 原样返回。 */
+function pretty(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * 工具调用 / 结果的紧凑 chip。
+ * 调用中(金):仅 chip 标头;已完成(绿):展开看**输出结果**(入参不展示,按需看 raw)。
+ * 输出按优先级渲染:工具专属视图(tool-views,行情卡/回测指标格等)→ 通用结构化
+ * ({@link ToolOutput} 键值行/表格)→ raw 钮永远可切回原始 JSON。
+ */
 function ToolChip({
   name,
-  body,
   label,
+  resultLabel,
+  result,
   done = false,
 }: {
   name: string;
-  body: string;
   label: string;
+  resultLabel: string;
+  result?: string;
   done?: boolean;
 }) {
+  const [showRaw, setShowRaw] = useState(false);
+  // 工具专属视图:结果可解析且形态命中才有;否则 null 落回通用结构化视图。
+  const view = useMemo(() => {
+    if (!result) return null;
+    try {
+      return resolveToolView(name, JSON.parse(result));
+    } catch {
+      return null;
+    }
+  }, [name, result]);
+  const sectionCaption =
+    "px-2.5 pt-1.5 font-mono text-[9px] uppercase tracking-[0.18em] text-fg-muted/60";
+
+  const head = (
+    <>
+      <Wrench
+        className="size-3.5 shrink-0 transition-colors group-hover:text-cyan"
+        strokeWidth={1.75}
+      />
+      <span className="truncate text-fg">{name}</span>
+      <span className="ml-auto uppercase tracking-[0.12em] text-fg-muted/70 transition-colors group-hover:text-fg-muted">
+        {label}
+      </span>
+    </>
+  );
+
+  // 调用中 / 无结果:没有可展开内容,渲染普通行,不给假的展开预期。
+  if (!done || !result) {
+    return (
+      <div className="group flex w-full max-w-[90%] items-center gap-2 rounded-md border border-border-subtle bg-bg/40 px-2.5 py-1.5 font-mono text-xs text-gold">
+        {head}
+      </div>
+    );
+  }
+
   return (
     <details className="group w-full max-w-[90%] overflow-hidden rounded-md border border-border-subtle bg-bg/40 text-xs transition-colors hover:border-cyan/40 hover:bg-bg-elev/50">
       <summary
@@ -751,19 +823,35 @@ function ToolChip({
           done ? "text-bull" : "text-gold",
         )}
       >
-        <Wrench
-          className="size-3.5 shrink-0 transition-colors group-hover:text-cyan"
-          strokeWidth={1.75}
-        />
-        <span className="truncate text-fg">{name}</span>
-        <span className="ml-auto uppercase tracking-[0.12em] text-fg-muted/70 transition-colors group-hover:text-fg-muted">
-          {label}
-        </span>
+        {head}
       </summary>
-      {body && (
-        <pre className="max-h-48 overflow-auto border-t border-border-subtle bg-bg-deep/50 px-2.5 py-2 font-mono text-[11px] leading-relaxed text-fg-muted">
-          {body}
-        </pre>
+      {done && result && (
+        <div className="border-t border-border-subtle bg-bg-deep/50">
+          <div className="flex items-baseline justify-between pr-2.5">
+            <div className={sectionCaption}>{resultLabel}</div>
+            <button
+              type="button"
+              onClick={() => setShowRaw((v) => !v)}
+              className={cn(
+                "rounded-sm px-1 font-mono text-[9px] uppercase tracking-[0.18em] transition-colors",
+                showRaw
+                  ? "text-cyan"
+                  : "text-fg-muted/40 hover:text-fg-muted",
+              )}
+            >
+              raw
+            </button>
+          </div>
+          {showRaw ? (
+            <pre className="max-h-64 overflow-auto px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-fg-muted">
+              {pretty(result)}
+            </pre>
+          ) : view ? (
+            <div className="max-h-72 overflow-auto px-2.5 py-1.5">{view}</div>
+          ) : (
+            <ToolOutput raw={result} />
+          )}
+        </div>
       )}
     </details>
   );

--- a/apps/dashboard/src/components/chat/ConsoleChat.tsx
+++ b/apps/dashboard/src/components/chat/ConsoleChat.tsx
@@ -3,7 +3,7 @@
 import { CopilotKit } from "@copilotkit/react-core";
 import { MessageSquare } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { ChatThread } from "./ChatThread";
 
@@ -81,9 +81,15 @@ export function ConsoleChat() {
     localStorage.setItem(LS_WIDTH, String(w));
   }, []);
 
+  // 本会话内由「新建会话」刚生成的 threadId 集合 —— 这些 thread 后端必然还没有消息,
+  // ChatThread 据此跳过历史回填 fetch,同步清空 UI(否则新建会话也要等一次网络往返,
+  // 后端慢时面板会闪「加载历史会话…」)。刷新后集合清空 → 恢复正常回填,语义不变。
+  const freshThreads = useRef<Set<string>>(new Set());
+
   // 新建会话:换一个 threadId,CopilotKit 切到全新上下文(ChatThread 会清空 UI)。
   const onNewSession = useCallback(() => {
     const id = crypto.randomUUID();
+    freshThreads.current.add(id);
     localStorage.setItem(LS_THREAD, id);
     setThreadId(id);
   }, []);
@@ -142,6 +148,7 @@ export function ConsoleChat() {
         open={open}
         width={width}
         threadId={threadId}
+        freshThreads={freshThreads.current}
         onClose={close}
         onWidthChange={onWidthChange}
         onDragChange={setDragging}

--- a/apps/dashboard/src/components/chat/ToolOutput.tsx
+++ b/apps/dashboard/src/components/chat/ToolOutput.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { cn } from "@/lib/cn";
+
+import { compact, shortTimestamp } from "./tool-views/format";
+
+/**
+ * 工具输出的结构化可视化 —— 按 JSON 形态自适应渲染,替代裸 JSON 文本:
+ *  - 对象 → 键值行(嵌套对象/数组折叠成 <details>,带条目数提示)
+ *  - 对象数组 → 紧凑表格(K 线 / run_log / 因子列表等最常见形态)
+ *  - 标量数组 → 内联 chip 列表
+ *  - 长文本 / 多行字符串(策略代码等)→ 折叠块,展开看全文
+ *  - 标量格式化:ISO 时间戳缩短、boolean 中性区分(true 实色/false 弱化,红色只留给 error)、null/空串区分
+ *  - mastra 工具错误封套 {isError, output} → 红色 ERROR 标头 + 只展开 output
+ *
+ * 解析失败(非 JSON)原样显示纯文本。容量护栏:深度 / 表格行列 / chip 数均有上限,
+ * 截断处显式标注剩余条数 —— 完整数据由 ToolChip 的 raw 切换兜底。
+ */
+export function ToolOutput({ raw }: { raw: string }) {
+  const parsed = useMemo(() => {
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return UNPARSEABLE;
+    }
+  }, [raw]);
+
+  if (parsed === UNPARSEABLE) {
+    return (
+      <pre className="max-h-64 overflow-auto px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-fg-muted">
+        {raw}
+      </pre>
+    );
+  }
+
+  // mastra 工具报错封套:红标头 + 直接展开 output(不让用户先点开一层 isError)。
+  if (isErrorEnvelope(parsed)) {
+    return (
+      <div className="max-h-64 overflow-auto px-2.5 py-1.5">
+        <div className="mb-1 inline-block rounded-sm border border-fox-red/40 bg-fox-red/10 px-1.5 py-px font-mono text-[9px] uppercase tracking-[0.18em] text-fox-red">
+          error
+        </div>
+        <JsonNode value={parsed.output} depth={0} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-h-64 overflow-auto px-2.5 py-1.5">
+      <JsonNode value={parsed} depth={0} />
+    </div>
+  );
+}
+
+/** JSON.parse 失败的哨兵(结果本身可能是 null/false,不能用它们当失败标记)。 */
+const UNPARSEABLE = Symbol("unparseable");
+
+const MAX_DEPTH = 5;
+const TABLE_ROW_CAP = 20;
+const TABLE_COL_CAP = 6;
+const CHIP_CAP = 30;
+const LONG_TEXT_THRESHOLD = 160;
+
+function isErrorEnvelope(
+  v: unknown,
+): v is { isError: true; output: unknown } {
+  return (
+    !!v &&
+    typeof v === "object" &&
+    (v as { isError?: unknown }).isError === true &&
+    "output" in v
+  );
+}
+
+/** 形态分发:数组 / 对象 / 标量。深度超限退回紧凑 JSON 文本。 */
+function JsonNode({ value, depth }: { value: unknown; depth: number }) {
+  if (depth > MAX_DEPTH) {
+    return (
+      <span className="break-all font-mono text-[11px] text-fg-muted/70">
+        {compact(value)}
+      </span>
+    );
+  }
+  if (Array.isArray(value)) return <ArrayNode value={value} depth={depth} />;
+  if (value && typeof value === "object")
+    return <ObjectNode value={value as Record<string, unknown>} depth={depth} />;
+  return <Scalar value={value} />;
+}
+
+/** 对象 → 键值行;嵌套容器折叠,空容器原位显示。 */
+function ObjectNode({
+  value,
+  depth,
+}: {
+  value: Record<string, unknown>;
+  depth: number;
+}) {
+  const entries = Object.entries(value);
+  if (entries.length === 0)
+    return <span className="font-mono text-[11px] text-fg-muted/50">{"{}"}</span>;
+  return (
+    <div className="flex flex-col gap-0.5">
+      {entries.map(([k, v]) => (
+        <ObjectRow key={k} k={k} v={v} depth={depth} />
+      ))}
+    </div>
+  );
+}
+
+function ObjectRow({ k, v, depth }: { k: string; v: unknown; depth: number }) {
+  const keyEl = (
+    <span className="shrink-0 break-all font-mono text-[11px] text-fg-muted/60">
+      {k}
+    </span>
+  );
+
+  // 嵌套容器(非空)→ 折叠块,summary 带形态提示(N 项 / N 字段)。
+  if (isNonEmptyContainer(v)) {
+    return (
+      <details className="group/nest min-w-0">
+        <summary className="flex cursor-pointer items-baseline gap-2 rounded-sm py-px hover:bg-bg-elev/40">
+          {keyEl}
+          <span className="font-mono text-[10px] text-fg-muted/40 transition-colors group-open/nest:text-cyan/60">
+            {Array.isArray(v) ? `[${v.length}]` : `{${Object.keys(v as object).length}}`}
+          </span>
+        </summary>
+        <div className="ml-2 border-l border-border-subtle/60 pl-2 pt-0.5">
+          <JsonNode value={v} depth={depth + 1} />
+        </div>
+      </details>
+    );
+  }
+
+  // 长文本(策略代码 / 日志)→ 单独折叠块。
+  if (typeof v === "string" && isLongText(v)) {
+    return (
+      <details className="min-w-0">
+        <summary className="flex cursor-pointer items-baseline gap-2 rounded-sm py-px hover:bg-bg-elev/40">
+          {keyEl}
+          <span className="min-w-0 truncate font-mono text-[11px] text-fg-muted/70">
+            {firstLine(v)}
+          </span>
+        </summary>
+        <pre className="ml-2 mt-0.5 max-h-48 overflow-auto whitespace-pre-wrap break-all border-l border-border-subtle/60 pl-2 font-mono text-[11px] leading-relaxed text-fg-muted">
+          {v}
+        </pre>
+      </details>
+    );
+  }
+
+  return (
+    <div className="flex min-w-0 items-baseline gap-2 py-px">
+      {keyEl}
+      <span className="min-w-0 break-words text-right ml-auto">
+        <Scalar value={v} />
+      </span>
+    </div>
+  );
+}
+
+/** 数组:全标量 → chip 列;对象数组 → 表格;混合 → 逐项折叠。 */
+function ArrayNode({ value, depth }: { value: unknown[]; depth: number }) {
+  if (value.length === 0)
+    return <span className="font-mono text-[11px] text-fg-muted/50">[]</span>;
+
+  if (value.every((v) => !v || typeof v !== "object")) {
+    const shown = value.slice(0, CHIP_CAP);
+    return (
+      <div className="flex flex-wrap items-center gap-1 py-0.5">
+        {shown.map((v, i) => (
+          <span
+            key={i}
+            className="rounded-sm border border-border-subtle/70 bg-bg/40 px-1 py-px"
+          >
+            <Scalar value={v} />
+          </span>
+        ))}
+        {value.length > shown.length && (
+          <MoreHint n={value.length - shown.length} />
+        )}
+      </div>
+    );
+  }
+
+  if (isUniformObjectArray(value)) {
+    return <ObjectTable rows={value} />;
+  }
+
+  // 混合 / 异构数组:逐项折叠。
+  return (
+    <div className="flex flex-col gap-0.5">
+      {value.slice(0, TABLE_ROW_CAP).map((v, i) => (
+        <ObjectRow key={i} k={`[${i}]`} v={v} depth={depth} />
+      ))}
+      {value.length > TABLE_ROW_CAP && (
+        <MoreHint n={value.length - TABLE_ROW_CAP} />
+      )}
+    </div>
+  );
+}
+
+/** 数组元素是否全为(可做表格的)普通对象。 */
+function isUniformObjectArray(v: unknown[]): v is Record<string, unknown>[] {
+  return v.every(
+    (x) => !!x && typeof x === "object" && !Array.isArray(x),
+  );
+}
+
+/**
+ * 对象数组 → 紧凑表格。列按信息量排序后取前 N:
+ * 值有变化的列(K 线的 OHLC / 时间)优先于全列相同的常量列(venue / symbol),
+ * 同档再按出现频率;行超限标注剩余。
+ */
+function ObjectTable({ rows }: { rows: Record<string, unknown>[] }) {
+  const sample = rows.slice(0, 10);
+  const freq = new Map<string, number>();
+  const distinct = new Map<string, Set<string>>();
+  for (const r of sample)
+    for (const [k, v] of Object.entries(r)) {
+      freq.set(k, (freq.get(k) ?? 0) + 1);
+      const set = distinct.get(k) ?? new Set<string>();
+      set.add(compact(v, 60));
+      distinct.set(k, set);
+    }
+  const varies = (k: string) =>
+    sample.length > 1 && (distinct.get(k)?.size ?? 0) > 1 ? 0 : 1;
+  const cols = [...freq.entries()]
+    .sort((a, b) => varies(a[0]) - varies(b[0]) || b[1] - a[1])
+    .slice(0, TABLE_COL_CAP)
+    .map(([k]) => k);
+  const hiddenCols = freq.size - cols.length;
+  const shown = rows.slice(0, TABLE_ROW_CAP);
+
+  return (
+    <div className="overflow-x-auto py-0.5">
+      <table className="w-full border-collapse font-mono text-[11px]">
+        <thead>
+          <tr>
+            {cols.map((c) => (
+              <th
+                key={c}
+                className="whitespace-nowrap border-b border-border-subtle px-1.5 py-0.5 text-left font-normal uppercase tracking-wider text-fg-muted/50"
+              >
+                {c}
+              </th>
+            ))}
+            {hiddenCols > 0 && (
+              <th className="whitespace-nowrap border-b border-border-subtle px-1.5 py-0.5 text-left font-normal text-fg-muted/40">
+                +{hiddenCols}
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {shown.map((r, i) => (
+            <tr key={i} className="border-b border-border-subtle/40 last:border-b-0">
+              {cols.map((c) => (
+                <td
+                  key={c}
+                  className="max-w-40 truncate whitespace-nowrap px-1.5 py-0.5"
+                  title={cellTitle(r[c])}
+                >
+                  {isNonEmptyContainer(r[c]) ? (
+                    <span className="text-fg-muted/60">{compact(r[c], 40)}</span>
+                  ) : (
+                    <Scalar value={r[c]} />
+                  )}
+                </td>
+              ))}
+              {hiddenCols > 0 && <td className="px-1.5 py-0.5 text-fg-muted/30">…</td>}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > shown.length && <MoreHint n={rows.length - shown.length} />}
+    </div>
+  );
+}
+
+/** 标量格式化:时间戳缩短 / boolean 着色 / null·空串区分 / 数字 tabular。 */
+function Scalar({ value }: { value: unknown }) {
+  if (value === null || value === undefined)
+    return <span className="font-mono text-[11px] text-fg-muted/40">—</span>;
+  // boolean 中性区分（true 实色 / false 弱化），不用红绿——这里没有字段语义，
+  // truncated:false / fresh:false 都是正常态，红色会被误读成报错；红色只留给 error 封套。
+  if (typeof value === "boolean")
+    return (
+      <span
+        className={cn(
+          "font-mono text-[11px]",
+          value ? "text-cyan/80" : "text-fg-muted/60",
+        )}
+      >
+        {String(value)}
+      </span>
+    );
+  if (typeof value === "number")
+    return (
+      <span className="font-mono text-[11px] tabular-nums text-fg">
+        {value}
+      </span>
+    );
+  const s = String(value);
+  if (s === "")
+    return <span className="font-mono text-[11px] text-fg-muted/40">&quot;&quot;</span>;
+  const ts = shortTimestamp(s);
+  if (ts)
+    return (
+      <span title={s} className="font-mono text-[11px] tabular-nums text-fg-muted">
+        {ts}
+      </span>
+    );
+  return <span className="break-all font-mono text-[11px] text-fg">{s}</span>;
+}
+
+function MoreHint({ n }: { n: number }) {
+  return (
+    <div className="py-0.5 font-mono text-[10px] text-fg-muted/40">+{n} …</div>
+  );
+}
+
+function isNonEmptyContainer(v: unknown): boolean {
+  if (Array.isArray(v)) return v.length > 0;
+  if (v && typeof v === "object") return Object.keys(v).length > 0;
+  return false;
+}
+
+function isLongText(s: string): boolean {
+  return s.includes("\n") || s.length > LONG_TEXT_THRESHOLD;
+}
+
+function firstLine(s: string): string {
+  const line = s.split("\n", 1)[0];
+  return line.length > 60 ? `${line.slice(0, 60)}…` : line;
+}
+
+/** 表格单元格悬浮提示:完整值(容器转紧凑 JSON,标量原样)。 */
+function cellTitle(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  return typeof v === "object" ? compact(v, 300) : String(v);
+}

--- a/apps/dashboard/src/components/chat/tool-views/MarketViews.tsx
+++ b/apps/dashboard/src/components/chat/tool-views/MarketViews.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+
+import { fmtNum, shortTimestamp } from "./format";
+import { Sparkline, SymbolHeader } from "./primitives";
+
+/**
+ * 行情类工具视图:data.get_ticker(最新价卡片)/ data.get_bars(走势 + OHLC 表)。
+ * shape guard 导出给注册表 —— 形态不符回 null,由通用 ToolOutput 兜底。
+ */
+
+export interface TickerShape {
+  venue: string;
+  symbol: string;
+  price: number;
+  ts?: string;
+  source?: string;
+  is_stale?: boolean;
+  stale_seconds?: number;
+}
+
+export function isTicker(v: unknown): v is TickerShape {
+  const o = v as TickerShape;
+  return (
+    !!o &&
+    typeof o === "object" &&
+    typeof o.symbol === "string" &&
+    typeof o.price === "number"
+  );
+}
+
+/** 最新价卡片:大号价格 + 标的/venue + 时间 + staleness 提示。 */
+export function TickerView({ t }: { t: TickerShape }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <SymbolHeader
+        symbol={t.symbol}
+        tags={[t.venue]}
+        right={
+          t.is_stale ? (
+            <span className="rounded-sm border border-fox-red/40 bg-fox-red/10 px-1 py-px font-mono text-[9px] uppercase tracking-wider text-fox-red">
+              stale {t.stale_seconds != null ? `${t.stale_seconds}s` : ""}
+            </span>
+          ) : null
+        }
+      />
+      <div className="font-mono text-xl tabular-nums leading-none text-fg">
+        {fmtNum(t.price)}
+      </div>
+      <div className="font-mono text-[10px] text-fg-muted/60">
+        {t.ts ? (shortTimestamp(t.ts) ?? t.ts) : null}
+        {t.source ? ` · ${t.source}` : null}
+      </div>
+    </div>
+  );
+}
+
+export interface BarShape {
+  ts: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+  symbol?: string;
+  venue?: string;
+  timeframe?: string;
+}
+
+export interface BarsShape {
+  bars: BarShape[];
+  count?: number;
+}
+
+export function isBars(v: unknown): v is BarsShape {
+  const o = v as BarsShape;
+  return (
+    !!o &&
+    typeof o === "object" &&
+    Array.isArray(o.bars) &&
+    o.bars.length > 0 &&
+    typeof o.bars[0]?.close === "number"
+  );
+}
+
+const BARS_ROW_CAP = 12;
+
+/** K 线视图:收盘价走势图 + 紧凑 OHLC 表(行多取尾部最新)。 */
+export function BarsView({ d }: { d: BarsShape }) {
+  const bars = d.bars;
+  const first = bars[0];
+  const shown = bars.slice(-BARS_ROW_CAP);
+  const hidden = bars.length - shown.length;
+  const hasVol = bars.some((b) => typeof b.volume === "number");
+  return (
+    <div className="flex flex-col gap-1">
+      <SymbolHeader
+        symbol={first.symbol ?? ""}
+        tags={[first.venue, first.timeframe]}
+        right={
+          <span className="font-mono text-[10px] tabular-nums text-fg-muted/60">
+            {bars.length} bars
+          </span>
+        }
+      />
+      <Sparkline values={bars.map((b) => b.close)} />
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse font-mono text-[10px] tabular-nums">
+          <thead>
+            <tr className="text-fg-muted/50">
+              {["ts", "open", "high", "low", "close", ...(hasVol ? ["vol"] : [])].map(
+                (h) => (
+                  <th
+                    key={h}
+                    className={cn(
+                      "whitespace-nowrap border-b border-border-subtle px-1 py-0.5 font-normal uppercase tracking-wider",
+                      h === "ts" ? "text-left" : "text-right",
+                    )}
+                  >
+                    {h}
+                  </th>
+                ),
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {shown.map((b) => (
+              <tr key={b.ts} className="border-b border-border-subtle/40 last:border-b-0">
+                <td className="whitespace-nowrap px-1 py-0.5 text-left text-fg-muted">
+                  {shortTimestamp(b.ts)?.slice(0, 16) ?? b.ts}
+                </td>
+                {[b.open, b.high, b.low].map((n, i) => (
+                  <td key={i} className="whitespace-nowrap px-1 py-0.5 text-right text-fg-muted">
+                    {fmtNum(n)}
+                  </td>
+                ))}
+                <td
+                  className={cn(
+                    "whitespace-nowrap px-1 py-0.5 text-right",
+                    b.close >= b.open ? "text-bull" : "text-fox-red",
+                  )}
+                >
+                  {fmtNum(b.close)}
+                </td>
+                {hasVol && (
+                  <td className="whitespace-nowrap px-1 py-0.5 text-right text-fg-muted/60">
+                    {b.volume != null ? fmtNum(b.volume) : "—"}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {hidden > 0 && (
+          <div className="py-0.5 font-mono text-[10px] text-fg-muted/40">
+            +{hidden} earlier …
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/chat/tool-views/PaperViews.tsx
+++ b/apps/dashboard/src/components/chat/tool-views/PaperViews.tsx
@@ -1,0 +1,491 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+
+import {
+  fmtNum,
+  fmtSigned,
+  shortDate,
+  shortId,
+  shortTimestamp,
+} from "./format";
+import {
+  CollapseSection,
+  MetricGrid,
+  Pnl,
+  Sparkline,
+  StatusBadge,
+  SymbolHeader,
+} from "./primitives";
+
+/**
+ * paper 域工具视图:策略候选 / 模拟盘运行 / 回测 / 账户持仓。
+ * 每个视图带 shape guard,形态不符回 null 由通用 ToolOutput 兜底。
+ */
+
+// ── 候选策略 ──────────────────────────────────────────────────────
+
+export interface CandidateShape {
+  id: string;
+  description: string;
+  status: string;
+  author?: string;
+  fitness?: number | null;
+  metrics?: Record<string, unknown> | null;
+  code?: string;
+  created_at?: string;
+}
+
+export function isCandidate(v: unknown): v is CandidateShape {
+  const o = v as CandidateShape;
+  return (
+    !!o &&
+    typeof o === "object" &&
+    typeof o.description === "string" &&
+    typeof o.status === "string" &&
+    typeof o.id === "string"
+  );
+}
+
+export function isCandidateList(v: unknown): v is CandidateShape[] {
+  return Array.isArray(v) && v.length > 0 && v.every(isCandidate);
+}
+
+/** metrics dict 里挑常用绩效键做指标格(命名以 paper 服务为准)。 */
+function candidateMetrics(m: Record<string, unknown> | null | undefined) {
+  if (!m) return [];
+  const pick: [string, string][] = [
+    ["sharpe", "sharpe"],
+    ["sortino", "sortino"],
+    ["calmar", "calmar"],
+    ["max_drawdown_pct", "max dd %"],
+    ["total_return_pct", "return %"],
+    ["win_rate", "win %"],
+    ["num_trades", "trades"],
+  ];
+  return pick
+    .filter(([k]) => typeof m[k] === "number")
+    .map(([k, label]) => ({ label, value: fmtNum(m[k] as number) }));
+}
+
+/** 单个候选卡片:状态 + 描述 + fitness/绩效格 + 代码折叠。 */
+export function CandidateView({ c }: { c: CandidateShape }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <StatusBadge status={c.status} />
+        {c.fitness != null && (
+          <span className="font-mono text-[10px] tabular-nums text-fg-muted">
+            fitness {fmtNum(c.fitness)}
+          </span>
+        )}
+        <span className="ml-auto font-mono text-[10px] text-fg-muted/50">
+          {shortId(c.id)}
+          {c.author ? ` · ${c.author}` : ""}
+        </span>
+      </div>
+      <p className="text-[11px] leading-relaxed text-fg">{c.description}</p>
+      <MetricGrid items={candidateMetrics(c.metrics)} />
+      {c.code && (
+        <CollapseSection label="code" hint={`${c.code.split("\n").length} lines`}>
+          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-[10px] leading-relaxed text-fg-muted">
+            {c.code}
+          </pre>
+        </CollapseSection>
+      )}
+    </div>
+  );
+}
+
+/** 候选列表:紧凑行(状态 + 描述截断 + fitness)。 */
+export function CandidateListView({ list }: { list: CandidateShape[] }) {
+  return (
+    <div className="flex flex-col gap-1">
+      {list.map((c) => (
+        <div
+          key={c.id}
+          className="flex items-start gap-2 rounded-sm border border-border-subtle/60 bg-bg/40 px-1.5 py-1"
+        >
+          <StatusBadge status={c.status} />
+          <span className="min-w-0 flex-1 truncate text-[11px] text-fg" title={c.description}>
+            {c.description}
+          </span>
+          {c.fitness != null && (
+            <span className="shrink-0 font-mono text-[10px] tabular-nums text-fg-muted">
+              {fmtNum(c.fitness)}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── 模拟盘运行(strategy run)──────────────────────────────────────
+
+export interface StrategyRunShape {
+  id: string;
+  status: string;
+  venue: string;
+  symbol: string;
+  timeframe: string;
+  cumulative_pnl?: number;
+  last_bar_ts?: string | null;
+  started_at?: string;
+  stopped_at?: string | null;
+  run_log?: { ts?: string; level?: string; msg?: string }[];
+}
+
+export function isStrategyRun(v: unknown): v is StrategyRunShape {
+  const o = v as StrategyRunShape;
+  return (
+    !!o &&
+    typeof o === "object" &&
+    typeof o.status === "string" &&
+    typeof o.symbol === "string" &&
+    typeof o.timeframe === "string" &&
+    ("cumulative_pnl" in o || "run_log" in o || "last_bar_ts" in o)
+  );
+}
+
+export function isStrategyRunList(v: unknown): v is StrategyRunShape[] {
+  return Array.isArray(v) && v.length > 0 && v.every(isStrategyRun);
+}
+
+const LOG_TONE: Record<string, string> = {
+  error: "text-fox-red",
+  warn: "text-gold",
+};
+
+/** 单个 run 卡片:状态 + 标的 + 累计盈亏 + 最近 bar + 日志折叠。 */
+export function StrategyRunView({ r }: { r: StrategyRunShape }) {
+  const log = r.run_log ?? [];
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SymbolHeader
+        symbol={r.symbol}
+        tags={[r.venue, r.timeframe]}
+        right={<StatusBadge status={r.status} />}
+      />
+      <div className="flex items-baseline gap-3 font-mono text-[11px]">
+        {r.cumulative_pnl != null && (
+          <span>
+            pnl <Pnl value={r.cumulative_pnl} />
+          </span>
+        )}
+        <span className="text-fg-muted/60">
+          {r.last_bar_ts
+            ? `last bar ${shortTimestamp(r.last_bar_ts) ?? r.last_bar_ts}`
+            : null}
+        </span>
+        <span className="ml-auto text-[10px] text-fg-muted/50">{shortId(r.id)}</span>
+      </div>
+      {log.length > 0 && (
+        <CollapseSection label="run log" hint={`${log.length}`}>
+          <div className="max-h-40 overflow-auto font-mono text-[10px] leading-relaxed">
+            {log.slice(-50).map((l, i) => (
+              <div key={i} className="flex gap-1.5">
+                <span className="shrink-0 text-fg-muted/40">
+                  {l.ts ? (shortTimestamp(l.ts)?.slice(5) ?? "") : ""}
+                </span>
+                <span
+                  className={cn(
+                    "min-w-0 break-words",
+                    LOG_TONE[l.level ?? ""] ?? "text-fg-muted",
+                  )}
+                >
+                  {l.msg ?? ""}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CollapseSection>
+      )}
+    </div>
+  );
+}
+
+/** run 列表:紧凑行。 */
+export function StrategyRunListView({ list }: { list: StrategyRunShape[] }) {
+  return (
+    <div className="flex flex-col gap-1">
+      {list.map((r) => (
+        <div
+          key={r.id}
+          className="flex items-center gap-2 rounded-sm border border-border-subtle/60 bg-bg/40 px-1.5 py-1 font-mono text-[11px]"
+        >
+          <StatusBadge status={r.status} />
+          <span className="text-fg">{r.symbol}</span>
+          <span className="text-[10px] text-fg-muted/60">
+            {r.venue} · {r.timeframe}
+          </span>
+          {r.cumulative_pnl != null && (
+            <span className="ml-auto">
+              <Pnl value={r.cumulative_pnl} />
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── 回测 ──────────────────────────────────────────────────────────
+
+export interface BacktestShape {
+  strategy_id?: string;
+  symbol?: string;
+  venue?: string;
+  timeframe?: string;
+  total_return_pct?: number;
+  sharpe?: number | null;
+  sortino?: number | null;
+  max_drawdown_pct?: number;
+  win_rate?: number | null;
+  num_trades?: number;
+  fitness?: number | null;
+  total_fees?: number;
+  num_bars_processed?: number;
+  final_equity?: number;
+  initial_cash?: number;
+  period_start?: string;
+  period_end?: string;
+  equity_curve?: { ts: string; equity: number }[];
+  baseline?: {
+    strategy_id?: string;
+    fitness?: number | null;
+    sharpe?: number | null;
+    total_return_pct?: number;
+  } | null;
+  blew_up?: boolean;
+  health_warnings?: string[];
+}
+
+export function isBacktest(v: unknown): v is BacktestShape {
+  const o = v as BacktestShape;
+  return (
+    !!o &&
+    typeof o === "object" &&
+    typeof o.total_return_pct === "number" &&
+    ("num_trades" in o || "equity_curve" in o || "max_drawdown_pct" in o)
+  );
+}
+
+/** 回测结果:穿仓告警 → 指标格 → 权益曲线 → baseline 对照。 */
+export function BacktestView({ b }: { b: BacktestShape }) {
+  const warnings = [
+    ...(b.blew_up ? ["blew up — 账户穿仓,本次回测物理不可信"] : []),
+    ...(b.health_warnings ?? []),
+  ];
+  // 9 项 = 3 列网格整三排(sharpe/sortino/win 可能为 null 被滤掉,fees/bars 总有值兜满)。
+  const metrics: [string, string | null][] = [
+    ["return %", b.total_return_pct != null ? fmtSigned(b.total_return_pct) : null],
+    ["sharpe", b.sharpe != null ? fmtNum(b.sharpe) : null],
+    ["sortino", b.sortino != null ? fmtNum(b.sortino) : null],
+    ["max dd %", b.max_drawdown_pct != null ? fmtNum(b.max_drawdown_pct) : null],
+    ["win %", b.win_rate != null ? fmtNum(b.win_rate) : null],
+    ["trades", b.num_trades != null ? String(b.num_trades) : null],
+    ["fees", b.total_fees != null ? fmtNum(b.total_fees) : null],
+    ["bars", b.num_bars_processed != null ? String(b.num_bars_processed) : null],
+    ["fitness", b.fitness != null ? fmtNum(b.fitness) : null],
+  ];
+  const metricItems = metrics
+    .filter((x): x is [string, string] => x[1] != null)
+    .map(([label, value]) => ({ label, value }));
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SymbolHeader
+        symbol={b.symbol ?? b.strategy_id ?? ""}
+        tags={[b.venue, b.timeframe, b.strategy_id !== b.symbol ? b.strategy_id : null]}
+      />
+      {warnings.map((w) => (
+        <div
+          key={w}
+          className="rounded-sm border border-fox-red/40 bg-fox-red/10 px-1.5 py-1 text-[10px] text-fox-red"
+        >
+          {w}
+        </div>
+      ))}
+      <MetricGrid items={metricItems} />
+      {!!b.equity_curve?.length && (
+        <Sparkline values={b.equity_curve.map((p) => p.equity)} />
+      )}
+      <div className="flex flex-wrap gap-x-3 font-mono text-[10px] text-fg-muted/60">
+        {b.period_start && b.period_end && (
+          <span>
+            {shortDate(b.period_start)} → {shortDate(b.period_end)}
+          </span>
+        )}
+        {b.initial_cash != null && b.final_equity != null && (
+          <span>
+            {fmtNum(b.initial_cash)} → {fmtNum(b.final_equity)}
+          </span>
+        )}
+      </div>
+      {b.baseline && (
+        <div className="flex flex-wrap items-baseline gap-x-2 rounded-sm border border-border-subtle/60 bg-bg/40 px-1.5 py-1 font-mono text-[10px] text-fg-muted">
+          <span className="uppercase tracking-wider text-fg-muted/50">
+            baseline · {b.baseline.strategy_id ?? "buy_and_hold"}
+          </span>
+          {b.baseline.total_return_pct != null && (
+            <span>return {fmtSigned(b.baseline.total_return_pct)}%</span>
+          )}
+          {b.baseline.sharpe != null && <span>sharpe {fmtNum(b.baseline.sharpe)}</span>}
+          {b.baseline.fitness != null && (
+            <span>fitness {fmtNum(b.baseline.fitness)}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── 账户 / 持仓 ───────────────────────────────────────────────────
+
+export interface AccountShape {
+  account_id: string;
+  base_currency?: string;
+  cash: number;
+  initial_cash?: number;
+  positions_value?: number;
+  total_equity?: number;
+  cash_balances?: Record<string, number>;
+  fx_warnings?: string[];
+}
+
+export function isAccount(v: unknown): v is AccountShape {
+  const o = v as AccountShape;
+  return (
+    !!o &&
+    typeof o === "object" &&
+    typeof o.account_id === "string" &&
+    typeof o.cash === "number"
+  );
+}
+
+/** 账户快照:总权益 + 现金/持仓 + 币种桶 + FX 告警。 */
+export function AccountView({ a }: { a: AccountShape }) {
+  const ccy = a.base_currency ?? "USD";
+  return (
+    <div className="flex flex-col gap-1.5">
+      {a.total_equity != null && (
+        <div>
+          <div className="font-mono text-[9px] uppercase tracking-wider text-fg-muted/50">
+            total equity · {ccy}
+          </div>
+          <div className="font-mono text-xl tabular-nums leading-none text-fg">
+            {fmtNum(a.total_equity)}
+          </div>
+        </div>
+      )}
+      <MetricGrid
+        items={[
+          { label: `cash · ${ccy}`, value: fmtNum(a.cash) },
+          ...(a.positions_value != null
+            ? [{ label: "positions", value: fmtNum(a.positions_value) }]
+            : []),
+          ...(a.initial_cash != null && a.total_equity != null
+            ? [
+                {
+                  label: "pnl",
+                  value: <Pnl value={a.total_equity - a.initial_cash} />,
+                },
+              ]
+            : []),
+        ]}
+      />
+      {a.cash_balances && Object.keys(a.cash_balances).length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {Object.entries(a.cash_balances).map(([c, n]) => (
+            <span
+              key={c}
+              className="rounded-sm border border-border-subtle/70 bg-bg/40 px-1 py-px font-mono text-[10px] tabular-nums text-fg-muted"
+            >
+              {c} {fmtNum(n)}
+            </span>
+          ))}
+        </div>
+      )}
+      {(a.fx_warnings ?? []).map((w) => (
+        <div
+          key={w}
+          className="rounded-sm border border-gold/40 bg-gold/10 px-1.5 py-1 text-[10px] text-gold"
+        >
+          {w}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export interface PositionShape {
+  venue: string;
+  symbol: string;
+  quantity: number;
+  avg_open_price: number;
+  realized_pnl?: number;
+  currency?: string | null;
+}
+
+export function isPositionList(v: unknown): v is PositionShape[] {
+  return (
+    Array.isArray(v) &&
+    v.length > 0 &&
+    v.every((o) => {
+      const p = o as PositionShape;
+      return (
+        !!p &&
+        typeof p === "object" &&
+        typeof p.symbol === "string" &&
+        typeof p.quantity === "number" &&
+        typeof p.avg_open_price === "number"
+      );
+    })
+  );
+}
+
+/** 持仓表:标的 / 数量 / 开仓均价 / 已实现盈亏。 */
+export function PositionsView({ list }: { list: PositionShape[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse font-mono text-[10px] tabular-nums">
+        <thead>
+          <tr className="text-fg-muted/50">
+            {["symbol", "qty", "avg price", "realized pnl"].map((h, i) => (
+              <th
+                key={h}
+                className={cn(
+                  "whitespace-nowrap border-b border-border-subtle px-1 py-0.5 font-normal uppercase tracking-wider",
+                  i === 0 ? "text-left" : "text-right",
+                )}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((p, i) => (
+            <tr key={`${p.symbol}@${p.venue}-${i}`} className="border-b border-border-subtle/40 last:border-b-0">
+              <td className="whitespace-nowrap px-1 py-0.5 text-left text-fg">
+                {p.symbol}
+                <span className="ml-1 text-fg-muted/50">@{p.venue}</span>
+              </td>
+              <td className="whitespace-nowrap px-1 py-0.5 text-right text-fg-muted">
+                {fmtNum(p.quantity)}
+              </td>
+              <td className="whitespace-nowrap px-1 py-0.5 text-right text-fg-muted">
+                {fmtNum(p.avg_open_price)}
+                {p.currency ? ` ${p.currency}` : ""}
+              </td>
+              <td className="whitespace-nowrap px-1 py-0.5 text-right">
+                {p.realized_pnl != null ? <Pnl value={p.realized_pnl} /> : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/chat/tool-views/SearchView.tsx
+++ b/apps/dashboard/src/components/chat/tool-views/SearchView.tsx
@@ -47,7 +47,10 @@ export function SearchView({ s }: { s: SearchShape }) {
         </div>
       )}
       {list.map((it, i) => {
-        const href = it.url ?? it.link ?? "";
+        // 仅放行 http(s):后端返回可能被搜索投毒注入 javascript: 等危险协议,
+        // React 不做 href 白名单、rel 也拦不住当前页执行,非 http(s) 一律降级为纯文本。
+        const raw = it.url ?? it.link ?? "";
+        const href = /^https?:\/\//i.test(raw) ? raw : "";
         const desc = it.snippet ?? it.summary ?? "";
         return (
           <div key={`${href}-${i}`} className="min-w-0">

--- a/apps/dashboard/src/components/chat/tool-views/SearchView.tsx
+++ b/apps/dashboard/src/components/chat/tool-views/SearchView.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { hostOf, shortDate } from "./format";
+
+/**
+ * 检索类工具视图:web.search / web.search_news(results[])与 data 新闻(items[])。
+ * 标题即外链,副行 host/publisher + 日期,摘要两行截断。
+ */
+
+interface SearchItem {
+  title: string;
+  url?: string;
+  link?: string;
+  snippet?: string;
+  summary?: string;
+  publisher?: string;
+  published_at?: string | null;
+}
+
+export interface SearchShape {
+  results?: SearchItem[];
+  items?: SearchItem[];
+  query?: string;
+  backend?: string;
+}
+
+export function isSearch(v: unknown): v is SearchShape {
+  const o = v as SearchShape;
+  if (!o || typeof o !== "object") return false;
+  const list = o.results ?? o.items;
+  return (
+    Array.isArray(list) && list.length > 0 && typeof list[0]?.title === "string"
+  );
+}
+
+const ITEM_CAP = 10;
+
+export function SearchView({ s }: { s: SearchShape }) {
+  const list = (s.results ?? s.items ?? []).slice(0, ITEM_CAP);
+  const total = (s.results ?? s.items ?? []).length;
+  return (
+    <div className="flex flex-col gap-1.5">
+      {(s.query || s.backend) && (
+        <div className="font-mono text-[10px] text-fg-muted/60">
+          {s.query}
+          {s.backend ? ` · ${s.backend}` : ""}
+        </div>
+      )}
+      {list.map((it, i) => {
+        const href = it.url ?? it.link ?? "";
+        const desc = it.snippet ?? it.summary ?? "";
+        return (
+          <div key={`${href}-${i}`} className="min-w-0">
+            {href ? (
+              <a
+                href={href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="block truncate text-[11px] text-cyan underline-offset-2 hover:underline"
+                title={it.title}
+              >
+                {it.title}
+              </a>
+            ) : (
+              <div className="truncate text-[11px] text-fg">{it.title}</div>
+            )}
+            <div className="font-mono text-[9px] text-fg-muted/50">
+              {href ? hostOf(href) : (it.publisher ?? "")}
+              {it.publisher && href ? ` · ${it.publisher}` : ""}
+              {it.published_at ? ` · ${shortDate(it.published_at)}` : ""}
+            </div>
+            {desc && (
+              <p className="line-clamp-2 text-[10px] leading-relaxed text-fg-muted">
+                {desc}
+              </p>
+            )}
+          </div>
+        );
+      })}
+      {total > list.length && (
+        <div className="font-mono text-[10px] text-fg-muted/40">
+          +{total - list.length} …
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/chat/tool-views/format.ts
+++ b/apps/dashboard/src/components/chat/tool-views/format.ts
@@ -1,0 +1,62 @@
+/**
+ * 工具输出可视化的共享格式化工具 —— ToolOutput(通用)与 tool-views/*(分工具)共用。
+ */
+
+/** ISO 时间戳 → "YYYY-MM-DD HH:mm[:ss]"(去 T / 毫秒 / 时区);不是时间戳返回 null。 */
+export function shortTimestamp(s: string): string | null {
+  const m = s.match(
+    /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}(?::\d{2})?)(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/,
+  );
+  return m ? `${m[1]} ${m[2]}` : null;
+}
+
+/** 日期部分("YYYY-MM-DD");解析不了原样返回。 */
+export function shortDate(s: string): string {
+  return shortTimestamp(s)?.slice(0, 10) ?? s;
+}
+
+/**
+ * 金融数字显示:千分位 + 按量级控制小数位(≥1 两位、<1 最多六位、极小走科学计数)。
+ * 不做四舍五入语义承诺 —— 仅展示层,精确值悬浮 title / raw 里看。
+ */
+export function fmtNum(n: number): string {
+  if (!Number.isFinite(n)) return String(n);
+  if (Number.isInteger(n))
+    return Math.abs(n) >= 10000 ? n.toLocaleString("en-US") : String(n);
+  const abs = Math.abs(n);
+  if (abs > 0 && abs < 0.0001) return n.toExponential(2);
+  return n.toLocaleString("en-US", {
+    maximumFractionDigits: abs >= 1 ? 2 : 6,
+  });
+}
+
+/** 带正负号的数字(盈亏 / alpha 类),0 不带号。 */
+export function fmtSigned(n: number): string {
+  const s = fmtNum(Math.abs(n));
+  return n > 0 ? `+${s}` : n < 0 ? `-${s}` : s;
+}
+
+/** URL → 裸 host(去 www.);解析失败原样返回截断。 */
+export function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url.slice(0, 40);
+  }
+}
+
+/** 紧凑单行 JSON,截断到 n 字符。 */
+export function compact(v: unknown, n = 80): string {
+  let s: string;
+  try {
+    s = JSON.stringify(v) ?? String(v);
+  } catch {
+    s = String(v);
+  }
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}
+
+/** UUID → 短显示(前 8 位)。 */
+export function shortId(s: string): string {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}/.test(s) ? s.slice(0, 8) : s;
+}

--- a/apps/dashboard/src/components/chat/tool-views/index.tsx
+++ b/apps/dashboard/src/components/chat/tool-views/index.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import {
+  BarsView,
+  TickerView,
+  isBars,
+  isTicker,
+} from "./MarketViews";
+import {
+  AccountView,
+  BacktestView,
+  CandidateListView,
+  CandidateView,
+  PositionsView,
+  StrategyRunListView,
+  StrategyRunView,
+  isAccount,
+  isBacktest,
+  isCandidate,
+  isCandidateList,
+  isPositionList,
+  isStrategyRun,
+  isStrategyRunList,
+} from "./PaperViews";
+import { SearchView, isSearch } from "./SearchView";
+
+/**
+ * 工具名 → 专属可视化视图的注册分发。
+ *
+ * 设计:
+ *  - 工具名先归一(AG-UI 把 id 里的 `.` 换成了 `_`,两种写法都接);
+ *  - 命中工具名后仍要过 shape guard —— 服务端字段演进 / 错误形态不符时返 null,
+ *    由调用方(ToolChip)回落到通用 ToolOutput,**宁可降级不可渲染错**;
+ *  - 工具名没命中时做一轮纯形态嗅探(列表 / ticker / 回测等特征足够独特),
+ *    新工具只要返回同形态数据即自动获得专属视图;
+ *  - 错误封套 {isError:true} 一律不接,通用视图的红色 ERROR 标头处理。
+ *
+ * 新增视图三步:tool-views/ 下建组件 + 导出 shape guard + 在这里挂名字/嗅探。
+ */
+export function resolveToolView(toolName: string, v: unknown): ReactNode | null {
+  if (!v || typeof v !== "object") return null;
+  if ((v as { isError?: unknown }).isError === true) return null;
+
+  const name = toolName.replace(/\./g, "_");
+  const body = unwrapList(v);
+
+  switch (name) {
+    case "data_get_ticker":
+      return isTicker(v) ? <TickerView t={v} /> : null;
+    case "data_get_bars":
+    case "data_backfill_bars":
+      return isBars(v) ? <BarsView d={v} /> : null;
+    case "paper_get_candidate":
+    case "paper_promote_candidate":
+      return isCandidate(v) ? <CandidateView c={v} /> : null;
+    case "paper_list_candidates":
+      return isCandidateList(body) ? <CandidateListView list={body} /> : null;
+    case "paper_start_strategy":
+    case "paper_stop_strategy":
+      return isStrategyRun(v) ? <StrategyRunView r={v} /> : null;
+    case "paper_list_strategy_runs":
+    case "paper_list_strategies":
+      return isStrategyRunList(body) ? <StrategyRunListView list={body} /> : null;
+    case "paper_run_backtest":
+      return isBacktest(v) ? <BacktestView b={v} /> : null;
+    case "paper_get_account":
+      return isAccount(v) ? <AccountView a={v} /> : null;
+    case "paper_list_positions":
+      return isPositionList(body) ? <PositionsView list={body} /> : null;
+    case "web_search":
+    case "web_search_news":
+      return isSearch(v) ? <SearchView s={v} /> : null;
+  }
+
+  // 名字没命中 → 形态嗅探(特征从强到弱,避免误判)。
+  if (isBars(v)) return <BarsView d={v} />;
+  if (isBacktest(v)) return <BacktestView b={v} />;
+  if (isSearch(v)) return <SearchView s={v} />;
+  if (isCandidate(v)) return <CandidateView c={v} />;
+  if (isStrategyRun(v)) return <StrategyRunView r={v} />;
+  if (isCandidateList(body)) return <CandidateListView list={body} />;
+  if (isStrategyRunList(body)) return <StrategyRunListView list={body} />;
+  if (isTicker(v)) return <TickerView t={v} />;
+  return null;
+}
+
+/** 列表工具可能返回裸数组,也可能包一层 {candidates|runs|positions|items: [...]}。 */
+function unwrapList(v: unknown): unknown {
+  if (Array.isArray(v)) return v;
+  if (v && typeof v === "object") {
+    for (const k of ["candidates", "runs", "strategy_runs", "positions", "items"]) {
+      const inner = (v as Record<string, unknown>)[k];
+      if (Array.isArray(inner)) return inner;
+    }
+  }
+  return v;
+}

--- a/apps/dashboard/src/components/chat/tool-views/primitives.tsx
+++ b/apps/dashboard/src/components/chat/tool-views/primitives.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+
+import { fmtSigned } from "./format";
+
+/**
+ * 工具视图共享原语 —— 状态徽章 / 指标格 / 迷你走势图 / 盈亏数字 / 折叠区,
+ * 全部贴「印章终端」主题(bull / fox-red / gold / cyan + mono tabular)。
+ */
+
+/** 业务状态 → 颜色档:运行·通过=绿,候选·进行=金,错误·拒绝=红,其余中性。 */
+const STATUS_TONE: Record<string, string> = {
+  running: "text-bull border-bull/40 bg-bull/10",
+  promoted: "text-bull border-bull/40 bg-bull/10",
+  ok: "text-bull border-bull/40 bg-bull/10",
+  filled: "text-bull border-bull/40 bg-bull/10",
+  completed: "text-bull border-bull/40 bg-bull/10",
+  candidate: "text-gold border-gold/40 bg-gold/10",
+  pending: "text-gold border-gold/40 bg-gold/10",
+  errored: "text-fox-red border-fox-red/40 bg-fox-red/10",
+  error: "text-fox-red border-fox-red/40 bg-fox-red/10",
+  rejected: "text-fox-red border-fox-red/40 bg-fox-red/10",
+  failed: "text-fox-red border-fox-red/40 bg-fox-red/10",
+  stopped: "text-fg-muted border-border-subtle bg-bg/40",
+};
+
+export function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={cn(
+        "rounded-sm border px-1.5 py-px font-mono text-[10px] uppercase tracking-wider",
+        STATUS_TONE[status.toLowerCase()] ??
+          "border-border-subtle bg-bg/40 text-fg-muted",
+      )}
+    >
+      {status}
+    </span>
+  );
+}
+
+/** 指标格:小标题 + mono 数值,3 列网格摆放。 */
+export function MetricGrid({
+  items,
+}: {
+  items: { label: string; value: React.ReactNode }[];
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="grid grid-cols-3 gap-1.5">
+      {items.map((m) => (
+        <div
+          key={m.label}
+          className="rounded-sm border border-border-subtle/60 bg-bg/40 px-1.5 py-1"
+        >
+          <div className="font-mono text-[9px] uppercase tracking-wider text-fg-muted/50">
+            {m.label}
+          </div>
+          <div className="mt-0.5 truncate font-mono text-[11px] tabular-nums text-fg">
+            {m.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** 盈亏 / 带方向数字:正绿负红零中性。 */
+export function Pnl({ value, suffix = "" }: { value: number; suffix?: string }) {
+  return (
+    <span
+      className={cn(
+        "font-mono tabular-nums",
+        value > 0 ? "text-bull" : value < 0 ? "text-fox-red" : "text-fg-muted",
+      )}
+    >
+      {fmtSigned(value)}
+      {suffix}
+    </span>
+  );
+}
+
+/** 迷你走势图(SVG polyline):首尾对比定涨跌色;数据 <2 点不画。 */
+export function Sparkline({
+  values,
+  className,
+}: {
+  values: number[];
+  className?: string;
+}) {
+  const pts = values.filter((v) => Number.isFinite(v));
+  if (pts.length < 2) return null;
+  const W = 240;
+  const H = 36;
+  const P = 2;
+  const min = Math.min(...pts);
+  const max = Math.max(...pts);
+  const span = max - min || 1;
+  const path = pts
+    .map(
+      (v, i) =>
+        `${P + (i * (W - 2 * P)) / (pts.length - 1)},${
+          H - P - ((v - min) / span) * (H - 2 * P)
+        }`,
+    )
+    .join(" ");
+  const up = pts[pts.length - 1] >= pts[0];
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      aria-hidden
+      className={cn("h-9 w-full", className)}
+    >
+      <polyline
+        points={path}
+        fill="none"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+        className={up ? "stroke-bull" : "stroke-fox-red"}
+      />
+    </svg>
+  );
+}
+
+/** 标的头:SYMBOL 主体 + venue / timeframe 等小标签。 */
+export function SymbolHeader({
+  symbol,
+  tags,
+  right,
+}: {
+  symbol: string;
+  tags?: (string | null | undefined)[];
+  right?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span className="font-mono text-[12px] text-fg">{symbol}</span>
+      {(tags ?? [])
+        .filter((t): t is string => !!t)
+        .map((t) => (
+          <span
+            key={t}
+            className="rounded-sm border border-border-subtle/70 px-1 py-px font-mono text-[9px] uppercase tracking-wider text-fg-muted/70"
+          >
+            {t}
+          </span>
+        ))}
+      {right && <span className="ml-auto">{right}</span>}
+    </div>
+  );
+}
+
+/** 折叠次要区(运行日志 / 代码等):summary 小标题 + 条数提示。 */
+export function CollapseSection({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details className="min-w-0">
+      <summary className="flex cursor-pointer items-baseline gap-2 rounded-sm py-px font-mono text-[10px] uppercase tracking-wider text-fg-muted/60 hover:bg-bg-elev/40 hover:text-fg-muted">
+        {label}
+        {hint && <span className="normal-case tracking-normal text-fg-muted/40">{hint}</span>}
+      </summary>
+      <div className="ml-2 mt-0.5 border-l border-border-subtle/60 pl-2">
+        {children}
+      </div>
+    </details>
+  );
+}

--- a/apps/dashboard/src/components/lab/CandidateDetailClient.tsx
+++ b/apps/dashboard/src/components/lab/CandidateDetailClient.tsx
@@ -139,6 +139,8 @@ export function CandidateDetailClient({ id }: { id: string }) {
                 symbol={data.runs[0].symbol}
                 timeframe={data.runs[0].timeframe}
                 decisions={data.latestRunDecisions}
+                // 同屏上方还有「回测 K 线」,标题点名这是最近 run 的实时图,避免看似重复。
+                title={t("chart")}
               />
               <DecisionTimeline decisions={data.latestRunDecisions} />
             </>

--- a/apps/dashboard/src/components/runners/RunnerChart.tsx
+++ b/apps/dashboard/src/components/runners/RunnerChart.tsx
@@ -21,17 +21,22 @@ const TF_CHOICES = ["1m", "5m", "15m", "30m", "1h", "4h", "1d", "1wk"];
  *
  * 周期可切:默认按 run 自身 timeframe,用户可临时切到其他周期看不同尺度的走势
  * (决策 marker 仍按时间吸附到最近 bar)。图是辅助信息,取不到 / 为空只显示占位。
+ *
+ * @param title 面板标题覆盖 —— lab 候选详情页同屏还有「回测 K 线」,要传
+ *   「K 线(最近 run)」区分语义;不传用 runners 详情页的通用「K 线」。
  */
 export function RunnerChart({
   venue,
   symbol,
   timeframe,
   decisions,
+  title,
 }: {
   venue: string;
   symbol: string;
   timeframe: string;
   decisions: StrategyRunDecisionRecord[];
+  title?: string;
 }) {
   const t = useTranslations("runners.detail");
   const [tf, setTf] = useState(timeframe);
@@ -60,7 +65,7 @@ export function RunnerChart({
 
   return (
     <Panel
-      title={t("chart")}
+      title={title ?? t("chart")}
       aside={
         <div className="flex items-center gap-2">
           {switching && (

--- a/apps/dashboard/src/components/shell/ConsoleSidebar.tsx
+++ b/apps/dashboard/src/components/shell/ConsoleSidebar.tsx
@@ -184,6 +184,12 @@ function SidebarBody({
     null,
   );
 
+  // 侧栏因视口 resize 从折叠态自动展开时,onMouseLeave 不会触发(handler 已不绑),
+  // 残留的 tip 会以旧坐标浮在展开后的栏上 —— collapsed 转 false 即清。
+  useEffect(() => {
+    if (!collapsed) setTip(null);
+  }, [collapsed]);
+
   const tipHandlers = (label: string) =>
     collapsed
       ? {

--- a/apps/dashboard/src/components/shell/ConsoleSidebar.tsx
+++ b/apps/dashboard/src/components/shell/ConsoleSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslations } from "next-intl";
 import {
   Activity,
@@ -176,6 +177,29 @@ function SidebarBody({
   onNavigate?: () => void;
   onMobileClose?: () => void;
 }) {
+  // 折叠态气泡:label + 触发项的视口坐标。挂 body 的 portal + fixed 定位,
+  // 脱离 aside(z-10 + backdrop-blur)的层叠上下文 —— 否则在 aside 内无论写多大
+  // z-index 都会被外部 z-20+ 的模块(活动日志条 / 对话栏等)压住。
+  const [tip, setTip] = useState<{ label: string; top: number; left: number } | null>(
+    null,
+  );
+
+  const tipHandlers = (label: string) =>
+    collapsed
+      ? {
+          onMouseEnter: (e: { currentTarget: HTMLElement }) => {
+            const r = e.currentTarget.getBoundingClientRect();
+            setTip({ label, top: r.top + r.height / 2, left: r.right });
+          },
+          onMouseLeave: () => setTip(null),
+          onFocus: (e: { currentTarget: HTMLElement }) => {
+            const r = e.currentTarget.getBoundingClientRect();
+            setTip({ label, top: r.top + r.height / 2, left: r.right });
+          },
+          onBlur: () => setTip(null),
+        }
+      : undefined;
+
   return (
     <>
       {/* Brand —— 朱红印章 + 字标。折叠态仅留印章。 */}
@@ -249,7 +273,7 @@ function SidebarBody({
         ) : null}
       </div>
 
-      {/* Nav —— 折叠态仅图标(居中 + title 悬浮提示)。 */}
+      {/* Nav —— 折叠态仅图标(居中 + 右侧气泡显示菜单名)。 */}
       <nav className="flex flex-1 flex-col gap-0.5 p-3">
         {NAV.map((item) => {
           const active = !item.soon && pathname === item.href;
@@ -280,13 +304,17 @@ function SidebarBody({
             "group relative flex items-center rounded-md py-2 text-sm transition-[color,background-color,transform] duration-200",
             collapsed ? "justify-center px-0" : "gap-2.5 px-3",
           );
+          const tipLabel = item.soon
+            ? `${t(item.key)} · ${t("soon")}`
+            : t(item.key);
 
           if (item.soon) {
             return (
               <div
                 key={item.key}
                 aria-disabled
-                title={collapsed ? t(item.key) : undefined}
+                aria-label={collapsed ? tipLabel : undefined}
+                {...tipHandlers(tipLabel)}
                 className={cn(baseCls, "cursor-not-allowed text-fg-muted/50")}
               >
                 {inner}
@@ -300,7 +328,8 @@ function SidebarBody({
               href={item.href}
               onClick={onNavigate}
               aria-current={active ? "page" : undefined}
-              title={collapsed ? t(item.key) : undefined}
+              aria-label={collapsed ? tipLabel : undefined}
+              {...tipHandlers(tipLabel)}
               className={cn(
                 baseCls,
                 !collapsed && "hover:translate-x-0.5",
@@ -318,6 +347,23 @@ function SidebarBody({
           );
         })}
       </nav>
+
+      {/* 折叠态气泡本体:portal 到 body,fixed + z-[60](全局最高 z-50 是移动抽屉,
+          但抽屉与桌面折叠态互斥,不会同屏)。外层钉坐标,内层 .tip-in 只做淡入右滑,
+          避免动画 transform 覆盖居中位移。pointer-events-none 防气泡截获 hover 闪烁。 */}
+      {tip &&
+        createPortal(
+          <span
+            role="tooltip"
+            style={{ top: tip.top, left: tip.left + 12 }}
+            className="pointer-events-none fixed z-[60] -translate-y-1/2 whitespace-nowrap"
+          >
+            <span className="tip-in motion-reduce:animate-none block rounded-md border border-border-subtle bg-bg-deep/95 px-2.5 py-1.5 text-xs text-fg shadow-lg backdrop-blur-md">
+              {tip.label}
+            </span>
+          </span>,
+          document.body,
+        )}
 
       {/* Footer —— 控制区(主题 / 语言)+ 折叠开关 + build 标记。 */}
       {collapsed ? (

--- a/packages/orchestration/src/mastra/memory.ts
+++ b/packages/orchestration/src/mastra/memory.ts
@@ -50,12 +50,37 @@ export const memoryStore = new LibSQLStore({
 
 export const sharedMemory = new Memory({
   storage: memoryStore,
-  // D-8a 默认配置：保留最近 50 条 history 给 LLM；不开 semanticRecall（要 vector）
+  // D-8a 默认配置：保留最近 50 条 history 给 LLM；不开 semanticRecall
+  // （ADR-0049 决议：向量召回显式推迟，长期记忆走蒸馏策展路线）
   options: {
     lastMessages: 50,
     semanticRecall: false,
+    // ADR-0049 第 1 层 · 常驻小抄（先行试点）：跨线程按用户持久的 markdown 块，
+    // agent 经 mastra 内置 tool 自行更新，每轮自动注入 context。
+    // 只放"永远相关"的画像与活跃事项；长尾档案走第 2 层 memory.*（ADR-0049 待实施）。
+    // 聊天链路已传 resourceId（dashboard CONSOLE_SUBJECT，B11 隔离约束不变）。
     workingMemory: {
-      enabled: false,
+      enabled: true,
+      scope: "resource",
+      template: `# User Profile / 用户画像
+<!-- 纪律：内容跟随用户语言；整块 ≤2000 字符，放不下的精简或舍弃；
+     禁存裸行情数字当事实——结论必须带"截至 <日期>" -->
+
+## 偏好 / Preferences
+- **关注市场 / Markets**:
+- **风险口味 / Risk appetite**:
+- **基准货币与语言 / Base currency & language**:
+
+## 活跃论点 / Active theses
+<!-- 每条一行：标的 — 方向 — 一句话核心 — 建档日期 -->
+-
+
+## 进行中研究 / Ongoing research
+-
+
+## 其他长期相关 / Other long-lived facts
+-
+`,
     },
   },
 });


### PR DESCRIPTION
从主工作树的并行 WIP 里单独拆出的 4 组 dashboard / orchestration 改动，独立于 #75（D-12），基于 origin/main，**互不耦合、各自一个 commit**。

## 1. 对话栏工具输出结构化渲染（`chat/ToolOutput` + `tool-views/`）

agent 工具调用结果从裸 JSON 文本换成按形态自适应渲染：对象→键值行（嵌套折叠）、对象数组→紧凑表格（K 线 / run_log / 因子列表等高频形态）、标量数组→chip、长文本（策略代码）→折叠块；ISO 时间戳缩短、boolean 中性区分、mastra 错误封套 `{isError,output}`→红色 ERROR 标头。解析失败回退纯文本，深度/行列/chip 均有容量护栏 + 截断标注，完整数据由 raw 切换兜底。tool-views 按工具分组（Market / Paper / Search）+ resolveToolView 路由 + primitives 共用件。

## 2. 折叠侧栏 hover 气泡（`ConsoleSidebar` + `globals.css`）

折叠态导航的菜单名提示，从原生 title 改为 createPortal 挂 body 的 fixed 气泡——脱离 aside（z-10 + backdrop-blur）层叠上下文，否则会被外部 z-20+ 的活动日志条 / 对话栏压住。带 tip-in 右滑淡入。

## 3. RunnerChart 标题可覆盖（`RunnerChart` + `CandidateDetailClient`）

候选详情页同屏有「回测 K 线」+ 实时 RunnerChart，标题都叫「K 线」显重复。加可选 `title` prop，候选页传「K 线(最近 run)」点明语义。

## 4. 开启 Mastra workingMemory 常驻小抄（`mastra/memory.ts`，ADR-0049 第 1 层试点）

跨线程按用户持久的 markdown 画像块，agent 经 mastra 内置 tool 自更新、每轮注入 context；只放「永远相关」的画像与活跃事项，长尾走第 2 层 memory.*（待实施）。模板含纪律注释（跟随用户语言 / ≤2000 字符 / 禁裸行情数字当事实）。

> **与 #75 的关系**：本 PR 基于 origin/main，memory.ts 用 origin/main 的旧路径逻辑（不依赖 #75 db22bbb 引入的 `paths.js`）。两 PR 都改 memory.ts 但区域不同（#75 改路径区、本 PR 改 options 区），先后合并由 GitHub 三方合并自动处理；若提示冲突按区域各取即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
