### PR TITLE
fix(web): 首页移动端适配 + 09 序号统一 + 大屏容器加宽

### DIFF
--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -54,7 +54,7 @@ export default async function HomePage({
 
       <Hero />
 
-      <main className="mx-auto max-w-[88rem] space-y-28 px-6 py-24 md:space-y-40 md:px-14 md:py-28">
+      <main className="mx-auto max-w-[96rem] space-y-28 px-6 py-24 md:space-y-40 md:px-14 md:py-28">
         <CoreWedge />
         <AgentIntelligence />
         <ResearchFloor />

--- a/apps/web/src/components/primitives/CopyableCommand.tsx
+++ b/apps/web/src/components/primitives/CopyableCommand.tsx
@@ -38,7 +38,10 @@ export function CopyableCommand({
       )}
     >
       <span className="select-none text-cyan/70">$</span>
-      <code className="flex-1 truncate text-fg">{command}</code>
+      {/* 移动端命令完整可读（断行），sm 起单行截断交给 Copy 按钮兜底 */}
+      <code className="min-w-0 flex-1 break-all text-[12.5px] leading-snug text-fg sm:truncate sm:text-sm">
+        {command}
+      </code>
       <button
         type="button"
         onClick={handleCopy}

--- a/apps/web/src/components/sections/CTAFooter.tsx
+++ b/apps/web/src/components/sections/CTAFooter.tsx
@@ -32,14 +32,15 @@ export function CTAFooter({ stats = null }: CTAFooterProps = {}) {
 
   return (
     <section className="group relative isolate overflow-hidden border-t border-fg/12">
-      <span
-        aria-hidden
-        className="pointer-events-none absolute right-2 top-2 -z-10 select-none font-display italic leading-none text-fg/[0.04] transition-colors duration-500 group-hover:text-gold/25"
-        style={{ fontSize: "clamp(7rem, 20vw, 18rem)" }}
-      >
-        09
-      </span>
-      <div className="mx-auto max-w-[88rem] px-6 pt-16 pb-20 md:px-12 md:pt-20 md:pb-24">
+      <div className="relative mx-auto max-w-[96rem] px-6 pt-16 pb-20 md:px-14 md:pt-20 md:pb-24">
+        {/* 序号锚定内容区右缘（right = 容器 padding − 0.5rem），与 main 内各 section 的 -right-2 -top-16 同基准 */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -top-16 right-4 -z-10 select-none font-display italic leading-none text-fg/[0.04] transition-colors duration-500 group-hover:text-gold/25 md:right-12"
+          style={{ fontSize: "clamp(8rem, 24vw, 22rem)" }}
+        >
+          09
+        </span>
         {/* Bracketed header */}
         <div className="border-y border-fg/15">
           <div className="flex items-center justify-between gap-6 py-3 font-mono text-[11px] uppercase tracking-[0.22em] text-fg-muted">
@@ -128,7 +129,7 @@ export function CTAFooter({ stats = null }: CTAFooterProps = {}) {
 
       {/* Footer colophon */}
       <footer className="border-t border-fg/12">
-        <div className="mx-auto grid max-w-[88rem] grid-cols-12 gap-x-6 gap-y-4 px-6 py-10 font-mono text-[10px] uppercase tracking-[0.26em] text-fg-muted/70 md:px-12">
+        <div className="mx-auto grid max-w-[96rem] grid-cols-12 gap-x-6 gap-y-4 px-6 py-10 font-mono text-[10px] uppercase tracking-[0.26em] text-fg-muted/70 md:px-14">
           <div className="col-span-6 md:col-span-3">
             <p className="text-fg/40">file</p>
             <p className="mt-1.5 text-fg-muted">inalpha.dev</p>

--- a/apps/web/src/components/sections/GlobalCoverage.tsx
+++ b/apps/web/src/components/sections/GlobalCoverage.tsx
@@ -47,7 +47,7 @@ export function GlobalCoverage() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: "-80px" }}
           transition={{ duration: 0.5 }}
-          className="grid items-center gap-6 md:grid-cols-[1fr_auto_auto_auto_1fr]"
+          className="grid items-center gap-4 md:grid-cols-[1fr_auto_auto_auto_1fr] md:gap-6"
         >
           {/* venues */}
           <div className="grid grid-cols-3 gap-1.5 sm:grid-cols-4 md:grid-cols-3">
@@ -72,21 +72,22 @@ export function GlobalCoverage() {
             })}
           </div>
 
-          {/* arrow */}
-          <ArrowRight className="mx-auto hidden size-4 text-seal/70 md:block" aria-hidden />
+          {/* arrow —— 移动端纵向流转 90° 朝下，保住 venue → orchestrator 的路由叙事 */}
+          <ArrowRight className="mx-auto size-4 rotate-90 text-seal/70 md:rotate-0" aria-hidden />
 
-          {/* orchestrator */}
-          <div className="mx-auto flex items-center justify-center rounded-md border border-seal/40 bg-seal/[0.06] px-4 py-6 text-center">
-            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-seal [writing-mode:vertical-rl] md:[writing-mode:horizontal-tb]">
+          {/* orchestrator —— 移动端横排紧凑药丸，md 起恢复立柱比例 */}
+          <div className="mx-auto flex items-center justify-center rounded-md border border-seal/40 bg-seal/[0.06] px-6 py-2.5 text-center md:px-4 md:py-6">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-seal">
               orchestrator
             </span>
           </div>
 
           {/* arrow */}
-          <ArrowRight className="mx-auto hidden size-4 text-seal/70 md:block" aria-hidden />
+          <ArrowRight className="mx-auto size-4 rotate-90 text-seal/70 md:rotate-0" aria-hidden />
 
-          {/* agents — venue 一变，全部闪一下（每个 agent 都拿到新 venue） */}
-          <div className="space-y-1.5">
+          {/* agents — venue 一变，全部闪一下（每个 agent 都拿到新 venue）
+              移动端 2×2 收紧纵向空间，md 起恢复右列纵排 */}
+          <div className="grid grid-cols-2 gap-1.5 md:grid-cols-1">
             {AGENTS.map((a) => (
               <motion.div
                 key={`${a}-${live}`}

--- a/apps/web/src/components/sections/Hero.tsx
+++ b/apps/web/src/components/sections/Hero.tsx
@@ -90,7 +90,7 @@ export function Hero() {
         <LocaleSwitcher />
       </div>
 
-      <div className="relative z-10 mx-auto flex min-h-160 max-w-[88rem] flex-col justify-center px-4 py-24 md:min-h-[86vh] md:px-14">
+      <div className="relative z-10 mx-auto flex min-h-160 max-w-[96rem] flex-col justify-center px-6 py-24 md:min-h-[86vh] md:px-14">
         <motion.div
           className="w-full max-w-132 md:max-w-180"
           initial="hidden"

--- a/apps/web/src/components/sections/ResearchFloor.tsx
+++ b/apps/web/src/components/sections/ResearchFloor.tsx
@@ -127,7 +127,9 @@ export function ResearchFloor() {
                       layout
                       initial={{ opacity: 0, x: bear ? 12 : panel ? 0 : -12 }}
                       animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0 }}
+                      /* exit 只发生在循环重置（全部消息同时退出），popLayout 会把退出项
+                         绝对定位叠在新一轮消息上 —— 必须瞬时移除，否则整框文字重影 */
+                      exit={{ opacity: 0, transition: { duration: 0 } }}
                       transition={{ duration: 0.28 }}
                       className={
                         panel

--- a/apps/web/src/components/sections/TrustBoundary.tsx
+++ b/apps/web/src/components/sections/TrustBoundary.tsx
@@ -112,12 +112,22 @@ export function TrustBoundary() {
         className="mt-16"
       >
         <div className="relative">
-          {/* 轨道基线（暗）—— 点亮交给下面的行进轨迹 */}
+          {/* 轨道基线（暗）—— 点亮交给下面的行进轨迹；移动端管道转纵向，横轨隐藏 */}
           <div
-            className="absolute left-0 right-0 top-[7px] h-px"
+            className="absolute left-0 right-0 top-[7px] hidden h-px md:block"
             style={{
               background:
                 "linear-gradient(to right, color-mix(in oklab, var(--ink-muted) 35%, transparent), var(--accent), color-mix(in oklab, var(--bull) 70%, transparent))",
+              opacity: 0.35,
+            }}
+            aria-hidden
+          />
+          {/* 移动端纵向轨道：沿节点圆点中心垂落 */}
+          <div
+            className="absolute bottom-2 left-[6px] top-2 w-px md:hidden"
+            style={{
+              background:
+                "linear-gradient(to bottom, color-mix(in oklab, var(--ink-muted) 35%, transparent), var(--accent), color-mix(in oklab, var(--bull) 70%, transparent))",
               opacity: 0.35,
             }}
             aria-hidden
@@ -202,17 +212,17 @@ export function TrustBoundary() {
             </span>
           )}
 
-          {/* 节点 + 标签 */}
-          <div className="relative flex items-start justify-between gap-3">
+          {/* 节点 + 标签：移动端纵排（圆点在左、文字在右），md 起恢复横向等距 */}
+          <div className="relative flex flex-col gap-7 md:flex-row md:items-start md:justify-between md:gap-3">
             {FLOW.map((n) => (
               <motion.div
                 key={n.key}
                 variants={fadeUp}
-                className="flex max-w-[10rem] flex-col items-center text-center"
+                className="flex items-start gap-4 md:max-w-[10rem] md:flex-col md:items-center md:gap-0 md:text-center"
               >
                 <span
                   className={
-                    "size-3.5 rounded-full ring-4 ring-bg " +
+                    "mt-0.5 size-3.5 shrink-0 rounded-full ring-4 ring-bg md:mt-0 " +
                     (n.tone === "bull"
                       ? "bg-bull"
                       : n.tone === "muted"
@@ -220,23 +230,26 @@ export function TrustBoundary() {
                         : "bg-cyan")
                   }
                 />
-                <span
-                  className={
-                    "mt-4 font-mono text-[12px] " +
-                    (n.tone === "bull"
-                      ? "text-bull"
-                      : n.tone === "muted"
-                        ? "text-fg-muted"
-                        : "text-cyan")
-                  }
-                >
-                  {n.tool}
-                </span>
-                {n.desc ? (
-                  <span className="mt-1.5 text-[12.5px] leading-snug text-fg-muted/80">
-                    {n.desc}
+                {/* md:contents —— 桌面端解散包裹层，让标签/描述直接成为纵列 flex 子项 */}
+                <div className="md:contents">
+                  <span
+                    className={
+                      "font-mono text-[12px] md:mt-4 " +
+                      (n.tone === "bull"
+                        ? "text-bull"
+                        : n.tone === "muted"
+                          ? "text-fg-muted"
+                          : "text-cyan")
+                    }
+                  >
+                    {n.tool}
                   </span>
-                ) : null}
+                  {n.desc ? (
+                    <span className="mt-1 block text-[12.5px] leading-snug text-fg-muted/80 md:mt-1.5">
+                      {n.desc}
+                    </span>
+                  ) : null}
+                </div>
               </motion.div>
             ))}
           </div>
@@ -277,19 +290,28 @@ export function TrustBoundary() {
           )}
         </motion.div>
 
-        {/* LLM 直连被 deny 拦截：红点加速撞墙、✕ 闪烁抖动、弹回 */}
-        <motion.div variants={fadeUp} className="mt-12 flex items-center gap-4">
-          <span className="shrink-0 font-mono text-[11px] uppercase tracking-[0.16em] text-fg-muted">
-            {t("agentLabel")}
-          </span>
-          <div className="relative h-5 flex-1">
+        {/* LLM 直连被 deny 拦截：红点加速撞墙、✕ 闪烁抖动、弹回
+            移动端两段式（标签一行 + 拦截线一行），md 起恢复 agent—✕—order 单行 */}
+        <motion.div
+          variants={fadeUp}
+          className="mt-12 flex flex-col gap-3 md:flex-row md:items-center md:gap-4"
+        >
+          <div className="flex items-center justify-between gap-4 md:contents">
+            <span className="shrink-0 font-mono text-[11px] uppercase tracking-[0.16em] text-fg-muted">
+              {t("agentLabel")}
+            </span>
+            <span className="shrink-0 font-mono text-[11px] uppercase tracking-[0.16em] text-fg-muted/40 line-through md:order-last">
+              {t("orderLabel")}
+            </span>
+          </div>
+          <div className="relative h-5 md:flex-1">
             <div
               className="absolute left-0 right-0 top-1/2 h-px -translate-y-1/2 border-t border-dashed border-fox-red/35"
               aria-hidden
             />
             {/* ✕ 拦截点：撞击瞬间放大闪烁 + 标签微抖 */}
             <motion.span
-              className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center gap-1.5 bg-bg px-2 font-mono text-[11px] uppercase tracking-[0.14em] text-fox-red/85"
+              className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center gap-1.5 whitespace-nowrap bg-bg px-2 font-mono text-[11px] uppercase tracking-[0.14em] text-fox-red/85"
               animate={reduce ? undefined : { x: [0, 0, -1.5, 1.5, 0, 0] }}
               transition={
                 reduce
@@ -339,9 +361,6 @@ export function TrustBoundary() {
               />
             ) : null}
           </div>
-          <span className="shrink-0 font-mono text-[11px] uppercase tracking-[0.16em] text-fg-muted/40 line-through">
-            {t("orderLabel")}
-          </span>
         </motion.div>
       </motion.div>
     </section>


### PR DESCRIPTION
## 概要

inalpha.dev 首页三类展示问题的修复，4 个独立 commit：

### 移动端适配（390px 视口逐屏排查）
- **TrustBoundary**：审批管道 5 节点横排被 `overflow-hidden` 裁剪 → 移动端改纵向时间线（圆点+纵轨），`md` 起恢复横向等距；deny 行改两段式（标签一行 + 拦截线一行），✕ 标签 `whitespace-nowrap`
- **ResearchFloor**：辩论循环重置时 `popLayout` 把退出消息绝对定位叠成重影 → exit 瞬时移除
- **CopyableCommand**：git clone 命令移动端从省略号截断改完整断行
- **GlobalCoverage**：路由演示箭头移动端 `rotate-90` 朝下成纵向流，orchestrator 改横排药丸，agents 2×2

### 09 序号统一
CTAFooter 通栏序号原先钉视口角（`right-2 top-2`、字号偏小），与 main 内各 section 的 `-right-2 -top-16` + `clamp(8rem,24vw,22rem)` 基准不一致 → 移入容器内以内容右缘锚定。已量化验证：06/07/09 右缘坐标与字号完全一致

### 大屏加宽
全站容器 `88rem→96rem`（1408→1536px），Hero/main/CTA/footer 四处统一；Hero 移动端 `px-4→px-6`、CTA `md:px-12→md:px-14` 对齐

## 验证
- 移动端 390px / 桌面 1680 / 2560 三档截图核对，无横向溢出，无控制台新报错
- orchestration `typecheck` + `vitest`（331/331）、data/paper/research `ruff`、`check-consistency.sh` 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)