### PR TITLE
fix(factor/data): D-12 CR 第七轮收尾——macro 单因子隔离 + SSRF rebinding 注释

### DIFF
--- a/services/data/src/inalpha_data/connectors/web_fetch.py
+++ b/services/data/src/inalpha_data/connectors/web_fetch.py
@@ -38,6 +38,12 @@ def _is_private_host(host: str) -> bool:
     """主机名解析后任一地址是回环 / 私网 / 链路本地 / 保留地址 → True。
 
     解析失败按"非私网"放行——连接阶段自然会失败，错误语义更准确。
+
+    已知局限·DNS rebinding（TOCTOU）：这里解析一次、httpx 建连时再解析一次，
+    攻击者控 NS + 短 TTL 可在两次之间把公网 IP 换成内网 IP 绕过本检查。当前缓解：
+    data 服务不对外暴露（调用方须持 JWT）+ 逐跳重定向校验 + content-type 白名单，
+    实际风险低。若将来 data 对外暴露，应升级为 httpx custom transport 在 TCP 连接
+    层（拿到实际 socket peer IP）拦截，彻底消除 TOCTOU。
     """
     try:
         infos = socket.getaddrinfo(host, None)

--- a/services/factor/src/inalpha_factor/adapters/macro_adapter.py
+++ b/services/factor/src/inalpha_factor/adapters/macro_adapter.py
@@ -24,12 +24,15 @@ engine 走 ``compute_with_macro``。
 """
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 import numpy as np
 import pandas as pd
 
 from .base import FactorSpec
+
+logger = logging.getLogger(__name__)
 
 #: 宏观因子允许的 timeframe（engine 守门用）
 MACRO_TIMEFRAMES: frozenset[str] = frozenset({"1d", "1wk", "1w"})
@@ -259,11 +262,19 @@ class MacroAdapter:
         for fid, fn in formulas.items():
             if not need(fid):
                 continue
-            native = fn()
-            if native is None:
-                continue
-            lag, staleness = _factor_align_params(fid)
-            out[fid] = _align_to_bars(native, df.index, lag=lag, max_staleness=staleness)
+            # 单因子隔离：formulas 与 _SPECS 漏同步会让 _factor_align_params 抛
+            # KeyError，若不隔离会被 engine 的 except 吞掉、14 个宏观因子一起静默消失
+            # 且无归因。逐 fid try/except，坏一条只丢一条并记下具体 fid。
+            try:
+                native = fn()
+                if native is None:
+                    continue
+                lag, staleness = _factor_align_params(fid)
+                out[fid] = _align_to_bars(
+                    native, df.index, lag=lag, max_staleness=staleness
+                )
+            except Exception:
+                logger.warning("macro factor %s 计算失败（已跳过）", fid, exc_info=True)
         return out
 
 

--- a/services/factor/src/inalpha_factor/adapters/macro_adapter.py
+++ b/services/factor/src/inalpha_factor/adapters/macro_adapter.py
@@ -263,7 +263,7 @@ class MacroAdapter:
             if not need(fid):
                 continue
             # 单因子隔离：formulas 与 _SPECS 漏同步会让 _factor_align_params 抛
-            # KeyError，若不隔离会被 engine 的 except 吞掉、14 个宏观因子一起静默消失
+            # KeyError，若不隔离会被 engine 的 except 吞掉、整批宏观因子一起静默消失
             # 且无归因。逐 fid try/except，坏一条只丢一条并记下具体 fid。
             try:
                 native = fn()


### PR DESCRIPTION
PR #75（D-12 因子库闭环）已 rebase 合并。这两条是该 PR 第七轮 auto-review 的 medium 修复，因推送晚于合并落在原分支上没进 main，单独收尾。两者 reviewer 均注明**当前无实际 bug**，属加固/文档级。

## 改动

- **fix(factor)** `macro_adapter.py` · `compute_with_macro` 逐 `fid` try/except 隔离：`formulas` 与 `_SPECS` 漏同步会让 `_factor_align_params` 抛 `KeyError`，被 engine 的 `except` 吞掉 → 整批 14 个宏观因子返 `{}` 且无归因。隔离后坏一条只丢一条并 warn 记下具体 `fid`。
- **docs(data)** `web_fetch.py` · `_is_private_host` 注释标明 DNS rebinding(TOCTOU) 已知局限：解析一次、httpx 建连再解析一次，攻击者控 NS+短 TTL 可绕过。注明当前缓解（data 不对外暴露 + JWT + 逐跳重定向校验 + content-type 白名单，风险低）与未来彻底解法（httpx custom transport 在 TCP 层拦截）。

## 验证

- `cd services/factor && uv run ruff check . && uv run pytest` ✅（95）
- `cd services/data && uv run ruff check . && uv run pytest tests/test_web_fetch.py` ✅（11）

🤖 Generated with [Claude Code](https://claude.com/claude-code)