### PR TITLE
chore(web): release-meta 更新至 0.12-D12，借重建复核 CTA GitHub 数字

### DIFF
--- a/apps/web/src/lib/release-meta.ts
+++ b/apps/web/src/lib/release-meta.ts
@@ -9,12 +9,12 @@
  */
 
 export const RELEASE = {
-  rev: "0.11",
-  phase: "D-11",
+  rev: "0.12",
+  phase: "D-12",
   /** Broadsheet 点号写法，供 UI 展示。 */
-  dateDot: "2026.06.05",
+  dateDot: "2026.06.12",
   /** ISO，供 <time dateTime> 或后续 schema.org。 */
-  dateIso: "2026-06-05",
+  dateIso: "2026-06-12",
 } as const;
 
 /** 复合短串，如 "rev 0.11 · D-11"。 */


### PR DESCRIPTION
## 概要

- `release-meta.ts` 单点更新：`0.11 / D-11 / 2026.06.05` → `0.12 / D-12 / 2026.06.12`。D-12 因子库闭环已随 PR #75 合入 main，footer colophon / TickerStrip 仍显示 D-11 属陈旧。
- 同时借本次合并触发的 Cloudflare Pages 生产重建，复核 CTA 区 GitHub stars/contributors/commits：当前线上构建拉取失败整组隐藏（GitHub API 三端点本地带 token 验证均 200，怀疑构建时 token 失效或网络抖动；若重建后仍缺失则确认需在 CF 控制台更换 `GITHUB_TOKEN`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)