### PR TITLE
feat(research): 辩论三方制 + 争议触发 + 软早停 + 决策链路落盘（research-hub #6 收口）

### DIFF
--- a/docs/04-current-state.md
+++ b/docs/04-current-state.md
@@ -4,7 +4,7 @@
 > live runner（promoted 候选按行情自动跑 + 决策复盘日志），在 D-10（web 搜索 +
 > 财报基本面 + 多市场数据）/ D-9（Plan/Exec 闭环 + LLM 自创策略 + 风控引擎）/
 > D-9.1a 收口基础上落地。
-> 下一里程碑：research-hub（issue #6）/ E2 多代演化（issue #7）。
+> 下一里程碑：E2 多代演化（issue #7）；research-hub（issue #6）已于 2026-06-12 收口（见下）。
 >
 > 本文回答的问题：**clone 仓库后，"现在到底做到哪里、决策链路长什么样"。**
 > 详细架构与设计取舍见 [`docs/03-kernel-design.md`](./03-kernel-design.md)；
@@ -368,13 +368,34 @@ live runner 跑起来后的运维 / 正确性收尾，把"无人值守长驻"剩
   新 tools：`factor.evaluate_candidate` / `factor.propose` /
   `factor.list_candidates` / `factor.run_discovery`。
 
+## research-hub（2026-06-12）辩论三方制 + 争议触发 + 决策链路落盘（issue #6 收口）
+
+issue #6 启动前复核发现其大部分提议已被 D-9/D-10 顺手实现（6 analyst 并行 /
+LLM manager 综合 / bull-bear 多轮辩论 / 限时限轮）；本次落收敛后的真实增量：
+
+- **三方制**：辩论加入 `RiskResearcher` 风险官（`researchers/risk.py`）——不站
+  多空，每轮在 Bull/Bear 之后压测双方最薄弱假设 + 失效条件 + 仓位纪律；
+  `RESEARCH_DEBATE_RISK_ENABLED`（默认开）可退回两方制。
+- **争议触发**：`RESEARCH_DEBATE_TRIGGER` 默认 `contested`——briefs 同时存在
+  有信心（confidence ≥ 0.35）的多空对立才辩，全员同向跳过省 token
+  （`debate.assess_disagreement`，确定性规则不走 LLM）；`always` 保留旧行为。
+- **软早停**：从第 2 轮起 Bull/Bear 论证与各自上轮词汇 Jaccard 重合度都过阈
+  （`RESEARCH_DEBATE_CONVERGENCE_THRESHOLD` 默认 0.6）= 没有新论点，提前结束；
+  与硬超时并存。
+- **决策链路落盘**（ResearchPlan 三个新字段，复盘"为什么是这个 rating"）：
+  `debate_trigger`（为什么辩/为什么跳过）、`debate_stop_reason`（completed /
+  converged / timeout）、`synthesis_reasoning`（manager 权衡自述，LLM 输出新增
+  `reasoning` 键）。`run_debate` 返回值升级 `DebateOutcome`（turns + stop_reason）。
+
+不在范围（issue #6 余项后续单独评估）：supervisor 显式编排（当前隐式并行 +
+manager 综合已覆盖）、debate 轮内并行化、reasoning 进活动流前端高亮。
+
 ---
 
 ## 未完成 / 下一步
 
 > 重心：模拟盘（paper）先于实盘（live）。
 
-- **research-hub** 嵌套 supervisor（4 analyst + bull/bear/risk debate，issue #6）尚未落地
 - **E2 多代演化**（issue #7 · ADR-0020）：MAP-Elites / Island Model（E1 MVP 已上）
 - **delegation hop**（issue #5 · ADR-0012 补丁）：sub-strategy 派生计划的转授权链
 

--- a/services/research/src/inalpha_research/config.py
+++ b/services/research/src/inalpha_research/config.py
@@ -173,7 +173,8 @@ class ResearchSettings(BaseSettings):
         alias="RESEARCH_DEBATE_CONVERGENCE_THRESHOLD",
         description="research-hub #6：软早停阈值。从第 2 轮起 Bull/Bear 论证与各自上轮"
         "的词汇 Jaccard 重合度都 ≥ 此值 = 没有新论点，提前结束。1.0 = 实际禁用"
-        "（只有逐字相同才触发）。",
+        "（只有逐字相同才触发）。注：软早停仅对 max_debate_rounds >= 3 有实际效果"
+        "——早停只在「还有下一轮可省」时检查，1~2 轮没有可省空间，本配置无作用。",
     )
 
 

--- a/services/research/src/inalpha_research/config.py
+++ b/services/research/src/inalpha_research/config.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import Literal
 
 from inalpha_shared.config import Settings as BaseSettings
 from pydantic import Field
@@ -150,6 +151,29 @@ class ResearchSettings(BaseSettings):
         alias="RESEARCH_DEBATE_TIMEOUT_SECONDS",
         description="整个辩论阶段的总时限（#4 韧性）。超时返回**已完成**的部分 debate_log，"
         "不抛错、不拖满下游 tool 预算；配合 manager 兜底保证 deep_dive 端到端不挂。",
+    )
+    debate_trigger: Literal["contested", "always"] = Field(
+        default="contested",
+        alias="RESEARCH_DEBATE_TRIGGER",
+        description="research-hub #6：debate 触发策略。contested = analyst briefs 出现"
+        "有信心的多空对立才辩（一致则跳过省 token，判定见 debate.assess_disagreement）；"
+        "always = 只要 max_debate_rounds>0 就辩（保留旧 D-9 行为）。"
+        "判定结果原样落 ResearchPlan.debate_trigger 供复盘。",
+    )
+    debate_risk_enabled: bool = Field(
+        default=True,
+        alias="RESEARCH_DEBATE_RISK_ENABLED",
+        description="research-hub #6：辩论是否加入 Risk 风险官第三方（每轮在 Bull/Bear "
+        "之后压测双方论点）。关掉退回 Bull/Bear 两方制，省 1/3 辩论 LLM 开销。",
+    )
+    debate_convergence_threshold: float = Field(
+        default=0.6,
+        ge=0.0,
+        le=1.0,
+        alias="RESEARCH_DEBATE_CONVERGENCE_THRESHOLD",
+        description="research-hub #6：软早停阈值。从第 2 轮起 Bull/Bear 论证与各自上轮"
+        "的词汇 Jaccard 重合度都 ≥ 此值 = 没有新论点，提前结束。1.0 = 实际禁用"
+        "（只有逐字相同才触发）。",
     )
 
 

--- a/services/research/src/inalpha_research/debate.py
+++ b/services/research/src/inalpha_research/debate.py
@@ -57,19 +57,21 @@ def assess_disagreement(
     反方都没信心 → aligned，跳过辩论。
 
     Returns:
-        ``(contested, verdict)``——verdict 是人读得懂的判定描述（英文，机器/
-        日志语境；面向用户的语言由 orchestrator 按用户语言呈现），原样落进
-        ``ResearchPlan.debate_trigger``。
+        ``(contested, detail)``——detail 是**不带前缀**的判定描述（英文，机器/
+        日志语境；面向用户的语言由 orchestrator 按用户语言呈现）。runner 据此
+        组装 ``ResearchPlan.debate_trigger``，前缀固定三选一
+        ``contested: / skipped: / always:``（PR #81 CR：扁平契约，下游可安全
+        ``startswith`` 解析）。
     """
     bulls = [b for b in briefs if b.stance == "bullish" and b.confidence >= min_confidence]
     bears = [b for b in briefs if b.stance == "bearish" and b.confidence >= min_confidence]
     if bulls and bears:
         return True, (
-            f"contested: {len(bulls)} bullish vs {len(bears)} bearish analysts "
+            f"{len(bulls)} bullish vs {len(bears)} bearish analysts "
             f"(confidence >= {min_confidence:.2f})"
         )
     stance_mix = dict(Counter(b.stance for b in briefs))
-    return False, f"aligned: no confident opposing stances (stance mix: {stance_mix})"
+    return False, f"no confident opposing stances (stance mix: {stance_mix})"
 
 
 async def run_debate(

--- a/services/research/src/inalpha_research/debate.py
+++ b/services/research/src/inalpha_research/debate.py
@@ -5,7 +5,9 @@
 - **completed**：跑满 ``max_rounds`` 轮（每轮 = Bull + Bear（+ Risk）各一次）
 - **converged 软早停**：从第 2 轮起，若 Bull 与 Bear 本轮论证与各自上一轮的
   词汇重合度（Jaccard）都 ≥ ``convergence_threshold``，视为没有新论点，提前
-  结束省 token（阈值 1.0 = 实际禁用，只有逐字相同才触发）
+  结束省 token（阈值 1.0 = 实际禁用，只有逐字相同才触发）。
+  注：仅对 ``max_rounds >= 3`` 有实际效果——只在「还有下一轮可省」时检查
+  （``r >= 2 and r < max_rounds``），1~2 轮没有可省空间
 - **timeout**：整段超时返回**已完成**的部分 log（in-flight 那轮被取消）
 
 0 轮直接返空 outcome（runner 在 ``settings.max_debate_rounds=0`` 时不会调本函数）。
@@ -97,7 +99,8 @@ async def run_debate(
         max_tokens: 每次发言输出上限（#2）。
         timeout_seconds: 整个辩论阶段总时限（#4）；None = 不限时。超时返回部分 log。
         convergence_threshold: 软早停阈值 [0,1]；从第 2 轮起 Bull/Bear 与各自上轮
-            的 Jaccard 重合度都 ≥ 此值则提前停。1.0 = 实际禁用。
+            的 Jaccard 重合度都 ≥ 此值则提前停。1.0 = 实际禁用；
+            ``max_rounds <= 2`` 时无可省轮次，本参数无作用。
 
     Returns:
         ``DebateOutcome``——``turns`` 按发言顺序：[R1-Bull, R1-Bear, (R1-Risk),

--- a/services/research/src/inalpha_research/debate.py
+++ b/services/research/src/inalpha_research/debate.py
@@ -1,15 +1,23 @@
-"""辩论协调器 —— 轮换调 Bull / Bear，输出 ``list[DebateTurn]``。
+"""辩论协调器 —— 轮换调 Bull / Bear（/ Risk），输出 ``DebateOutcome``。
 
-终止条件：完成 ``max_rounds`` 轮（每轮 = Bull 一次 + Bear 一次）。
-0 轮直接返空列表（runner 在 ``settings.max_debate_rounds=0`` 时不会调本函数）。
+终止条件（research-hub #6 起三选一，落 ``DebateOutcome.stop_reason``）：
+
+- **completed**：跑满 ``max_rounds`` 轮（每轮 = Bull + Bear（+ Risk）各一次）
+- **converged 软早停**：从第 2 轮起，若 Bull 与 Bear 本轮论证与各自上一轮的
+  词汇重合度（Jaccard）都 ≥ ``convergence_threshold``，视为没有新论点，提前
+  结束省 token（阈值 1.0 = 实际禁用，只有逐字相同才触发）
+- **timeout**：整段超时返回**已完成**的部分 log（in-flight 那轮被取消）
+
+0 轮直接返空 outcome（runner 在 ``settings.max_debate_rounds=0`` 时不会调本函数）。
 
 容错 / 性能（D-10）：
 
 - **单轮失败兜底**（`_safe_speak`）：单个 researcher LLM 抽风一次不让整条 deep_dive
   500，失败那轮 content 落 "(researcher failed: <err>)"，manager 仍能继续。
 - **#1 开场并行**：``max_rounds >= 2`` 时第 1 轮 Bull/Bear 是**独立开场**（互不读对方），
-  并行跑省一次串行延迟；第 2 轮起才是"看对方上一轮再反驳"的串行 rebuttal。
-  ``max_rounds == 1`` 时保持串行（Bull 开场 → Bear 反驳），不牺牲那唯一一次反驳的价值。
+  并行跑省一次串行延迟；Risk（如启用）在两者之后串行发言（它必须读到双方开场）。
+  ``max_rounds == 1`` 时保持串行（Bull 开场 → Bear 反驳 → Risk 压测），
+  不牺牲那唯一一次反驳的价值。
 - **#2 输出限长**：``max_tokens`` 透传到每次发言（默认调小，论证更紧凑、延迟更低）。
 - **#4 总时限**：``timeout_seconds`` 限整个辩论阶段；超时返回**已完成**的部分 log，
   不抛、不拖满下游 tool 预算（配合 manager 兜底保证 deep_dive 端到端不挂）。
@@ -17,20 +25,58 @@
 from __future__ import annotations
 
 import asyncio
+from collections import Counter
+from dataclasses import dataclass, field
 from datetime import datetime
 
 from inalpha_shared import get_logger
 
-from .researchers import BearResearcher, BullResearcher
+from .researchers import Researcher
 from .schemas import AnalystBrief, DebateTurn
 
 _logger = get_logger(__name__)
 
 
+@dataclass
+class DebateOutcome:
+    """一次辩论的完整结果：发言序列 + 为什么停（决策链路可观测，#6）。"""
+
+    turns: list[DebateTurn] = field(default_factory=list)
+    stop_reason: str = "completed"
+
+
+def assess_disagreement(
+    briefs: list[AnalystBrief],
+    *,
+    min_confidence: float = 0.35,
+) -> tuple[bool, str]:
+    """briefs 分歧度判定 —— 争议大才值得花 token 辩论（research-hub #6）。
+
+    规则（确定性，不走 LLM）：同时存在 confidence ≥ ``min_confidence`` 的
+    bullish 与 bearish brief 即视为 contested。全员同向 / 全员 neutral /
+    反方都没信心 → aligned，跳过辩论。
+
+    Returns:
+        ``(contested, verdict)``——verdict 是人读得懂的判定描述（英文，机器/
+        日志语境；面向用户的语言由 orchestrator 按用户语言呈现），原样落进
+        ``ResearchPlan.debate_trigger``。
+    """
+    bulls = [b for b in briefs if b.stance == "bullish" and b.confidence >= min_confidence]
+    bears = [b for b in briefs if b.stance == "bearish" and b.confidence >= min_confidence]
+    if bulls and bears:
+        return True, (
+            f"contested: {len(bulls)} bullish vs {len(bears)} bearish analysts "
+            f"(confidence >= {min_confidence:.2f})"
+        )
+    stance_mix = dict(Counter(b.stance for b in briefs))
+    return False, f"aligned: no confident opposing stances (stance mix: {stance_mix})"
+
+
 async def run_debate(
     *,
-    bull: BullResearcher,
-    bear: BearResearcher,
+    bull: Researcher,
+    bear: Researcher,
+    risk: Researcher | None = None,
     venue: str,
     symbol: str,
     timeframe: str,
@@ -39,22 +85,42 @@ async def run_debate(
     max_rounds: int,
     max_tokens: int = 2048,
     timeout_seconds: float | None = None,
-) -> list[DebateTurn]:
-    """跑 ``max_rounds`` 轮 Bull/Bear 对喷，返回完整 debate log。
+    convergence_threshold: float = 1.0,
+) -> DebateOutcome:
+    """跑至多 ``max_rounds`` 轮辩论，返回 ``DebateOutcome``。
 
     Args:
-        max_rounds: 轮数；<= 0 直接返空列表。
+        risk: 风险官（research-hub #6 三方制）；None = 维持 Bull/Bear 两方。
+        max_rounds: 轮数；<= 0 直接返空 outcome。
         max_tokens: 每次发言输出上限（#2）。
         timeout_seconds: 整个辩论阶段总时限（#4）；None = 不限时。超时返回部分 log。
+        convergence_threshold: 软早停阈值 [0,1]；从第 2 轮起 Bull/Bear 与各自上轮
+            的 Jaccard 重合度都 ≥ 此值则提前停。1.0 = 实际禁用。
 
     Returns:
-        ``list[DebateTurn]`` 按发言顺序：[R1-Bull, R1-Bear, R2-Bull, R2-Bear, ...]
-        （即使第 1 轮并行执行，落 log 顺序仍固定 Bull 在前。）
+        ``DebateOutcome``——``turns`` 按发言顺序：[R1-Bull, R1-Bear, (R1-Risk),
+        R2-Bull, ...]（即使第 1 轮 Bull/Bear 并行执行，落 log 顺序仍固定 Bull 在前）。
     """
     if max_rounds <= 0:
-        return []
+        return DebateOutcome(turns=[], stop_reason="skipped: max_rounds <= 0")
 
-    log: list[DebateTurn] = []
+    outcome = DebateOutcome()
+    log = outcome.turns
+
+    async def _speak_and_log(researcher: Researcher, r: int) -> str:
+        text = await _safe_speak(
+            researcher=researcher,
+            venue=venue,
+            symbol=symbol,
+            timeframe=timeframe,
+            as_of=as_of,
+            briefs=briefs,
+            history=log,
+            round_no=r,
+            max_tokens=max_tokens,
+        )
+        log.append(DebateTurn(role=researcher.role, round=r, content=text))
+        return text
 
     async def _run_all_rounds() -> None:
         for r in range(1, max_rounds + 1):
@@ -88,57 +154,87 @@ async def run_debate(
                 # 落 log 顺序固定 Bull 在前（与完成顺序无关）
                 log.append(DebateTurn(role="bull", round=r, content=bull_text))
                 log.append(DebateTurn(role="bear", round=r, content=bear_text))
-                continue
+            else:
+                # 串行：Bull 先发言（max_rounds==1 时即开场；>=2 时为 rebuttal 轮），
+                # Bear 看到 Bull 后再回（rebut）
+                await _speak_and_log(bull, r)
+                await _speak_and_log(bear, r)
 
-            # 串行：Bull 先发言（max_rounds==1 时即开场；>=2 时为 rebuttal 轮）
-            bull_text = await _safe_speak(
-                researcher=bull,
-                venue=venue,
-                symbol=symbol,
-                timeframe=timeframe,
-                as_of=as_of,
-                briefs=briefs,
-                history=log,
-                round_no=r,
-                max_tokens=max_tokens,
-            )
-            log.append(DebateTurn(role="bull", round=r, content=bull_text))
+            # Risk 风险官压测双方——必须读到本轮 Bull/Bear 之后才发言，永远串行殿后
+            if risk is not None:
+                await _speak_and_log(risk, r)
 
-            # Bear 看到 Bull 的发言后再回（rebut）
-            bear_text = await _safe_speak(
-                researcher=bear,
-                venue=venue,
-                symbol=symbol,
-                timeframe=timeframe,
-                as_of=as_of,
-                briefs=briefs,
-                history=log,
-                round_no=r,
-                max_tokens=max_tokens,
-            )
-            log.append(DebateTurn(role="bear", round=r, content=bear_text))
+            # 软早停（#6）：本轮与上一轮 Bull/Bear 各自重合度都过阈 = 没有新论点。
+            # 只在还有下一轮时才检查——最后一轮停不停都一样，别污染 completed 语义。
+            if r >= 2 and r < max_rounds and _converged(log, r, convergence_threshold):
+                outcome.stop_reason = (
+                    f"converged: round {r} bull/bear arguments overlap >= "
+                    f"{convergence_threshold:.2f} with round {r - 1} "
+                    f"(stopped {max_rounds - r} round(s) early)"
+                )
+                _logger.info(
+                    "debate_converged",
+                    symbol=symbol,
+                    round=r,
+                    max_rounds=max_rounds,
+                    threshold=convergence_threshold,
+                )
+                return
+
+        outcome.stop_reason = f"completed {max_rounds} round(s)"
 
     if timeout_seconds is None:
         await _run_all_rounds()
-        return log
+        return outcome
 
     # #4 总时限：超时返回已完成的部分 log（in-flight 那轮被取消、不落 log）
     try:
         async with asyncio.timeout(timeout_seconds):
             await _run_all_rounds()
     except TimeoutError:
+        outcome.stop_reason = (
+            f"timeout: {timeout_seconds:.0f}s elapsed after {len(log)} turn(s)"
+        )
         _logger.warning(
             "debate_timeout",
             symbol=symbol,
             timeout_seconds=timeout_seconds,
             completed_turns=len(log),
         )
-    return log
+    return outcome
+
+
+def _converged(log: list[DebateTurn], round_no: int, threshold: float) -> bool:
+    """Bull 与 Bear 本轮 vs 上轮的词汇 Jaccard 都 ≥ threshold 即收敛。
+
+    纯词面启发式（零 LLM 开销）：辩论无新论点时双方会复述既有词汇，重合度高；
+    阈值 ≥ 1.0 直接短路禁用。Risk 轮不参与判定——它每轮压测对象不同，天然多变。
+    """
+    if threshold >= 1.0:
+        return False
+    for role in ("bull", "bear"):
+        cur = next((t.content for t in log if t.role == role and t.round == round_no), None)
+        prev = next(
+            (t.content for t in log if t.role == role and t.round == round_no - 1), None
+        )
+        if cur is None or prev is None:
+            return False
+        if _jaccard(cur, prev) < threshold:
+            return False
+    return True
+
+
+def _jaccard(a: str, b: str) -> float:
+    """小写分词集合的 Jaccard 相似度；空文本视为 0（永不触发收敛）。"""
+    ta, tb = set(a.lower().split()), set(b.lower().split())
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
 
 
 async def _safe_speak(
     *,
-    researcher: BullResearcher | BearResearcher,
+    researcher: Researcher,
     venue: str,
     symbol: str,
     timeframe: str,

--- a/services/research/src/inalpha_research/manager.py
+++ b/services/research/src/inalpha_research/manager.py
@@ -43,18 +43,22 @@ Bull/Bear debate into a final research plan.
 
 You receive 1+ analyst briefs. Each brief has stance / confidence / summary /
 key_points and may include structured "factors" (kind / value / strength / explanation).
-You may also receive a debate_log (Bull/Bear turns) — if present, the Bull and Bear
-researchers have already argued over the same briefs; weight the side whose argument
-better withstood the rebuttals.
+You may also receive a debate_log (Bull/Bear turns, possibly with a third "risk"
+voice stress-testing both sides) — if present, the researchers have already argued
+over the same briefs; weight the side whose argument better withstood the rebuttals,
+and treat the risk officer's unanswered challenges as live risks.
 
 Your job is to:
 1. Reconcile disagreements between analysts (favor the one with more concrete evidence)
-2. Judge the Bull/Bear debate (when present) — note which side conceded points or
-   handled rebuttals better; reflect that in rating + confidence
+2. Judge the debate (when present) — note which side conceded points or
+   handled rebuttals better; reflect that in rating + confidence. Risk-officer
+   challenges that neither side answered belong in "risks"
 3. Output a final rating, thesis, risks, and a suggested action for the trader
 4. **Synthesize factors and pick a strategy family** —— machine-readable hand-off to the
    downstream `paper.compose_strategy` engine
 5. Stay **grounded in the briefs / debate** — do not invent factors that no analyst raised
+6. **Show your weighing** in "reasoning": which analysts you trusted and why, who won
+   the debate and on what point — this is the audit trail for "why this rating"
 
 Return ONLY a JSON object with this exact shape:
 
@@ -62,6 +66,7 @@ Return ONLY a JSON object with this exact shape:
   "rating": "overweight" | "neutral" | "underweight",
   "confidence": float in [0, 1],
   "thesis": "3-5 sentences of core conclusion",
+  "reasoning": "2-4 sentences: how you weighed the analysts and judged the debate",
   "risks": ["risk 1", "risk 2", ...],
   "suggested_action": "open_long 0.X | open_short 0.X | hold | reduce | wait",
   "horizon": "intraday" | "swing" | "position",
@@ -136,7 +141,14 @@ class ResearchManager:
         briefs: list[AnalystBrief],
         debate_log: list[DebateTurn] | None = None,
         user_question: str | None = None,
+        debate_trigger: str | None = None,
+        debate_stop_reason: str | None = None,
     ) -> ResearchPlan:
+        """综合 briefs(+debate) 出 plan。
+
+        ``debate_trigger`` / ``debate_stop_reason`` 由 runner 传入、原样落进
+        plan（research-hub #6 决策链路可观测）——manager 不消费它们。
+        """
         user_prompt = _format_user_prompt(
             venue=venue,
             symbol=symbol,
@@ -164,6 +176,8 @@ class ResearchManager:
             as_of=as_of,
             briefs=briefs,
             debate_log=debate_log or [],
+            debate_trigger=debate_trigger,
+            debate_stop_reason=debate_stop_reason,
         )
 
 
@@ -248,6 +262,10 @@ def _fallback_raw(error: str) -> dict[str, Any]:
             "solely on the individual analyst briefs below — judge accordingly. "
             f"detail: {error[:200]}"
         ),
+        "reasoning": (
+            "no weighing performed: the synthesis LLM call failed, so neither analyst "
+            "reconciliation nor debate adjudication happened"
+        ),
         "risks": [
             "Manager synthesis failed — no cross-analyst reconciliation / debate "
             "adjudication was performed"
@@ -269,6 +287,8 @@ def _build_plan(
     as_of: datetime,
     briefs: list[AnalystBrief],
     debate_log: list[DebateTurn] | None = None,
+    debate_trigger: str | None = None,
+    debate_stop_reason: str | None = None,
 ) -> ResearchPlan:
     """LLM JSON → ResearchPlan，缺字段兜底。``debate_log`` 原样落进 plan 字段。"""
     rating = str(raw.get("rating", "neutral")).lower()
@@ -308,6 +328,10 @@ def _build_plan(
         "briefs": briefs,
         "debate_log": [t.model_dump(mode="json") for t in (debate_log or [])],
         "horizon": horizon,
+        # research-hub #6 决策链路：trigger/stop 来自 runner，reasoning 来自 LLM 自述
+        "debate_trigger": debate_trigger,
+        "debate_stop_reason": debate_stop_reason,
+        "synthesis_reasoning": str(raw.get("reasoning") or "").strip() or None,
     }
     # 用 model_validate 而不是构造器，让 Pydantic 把 dict→model 一次校验
     return ResearchPlan.model_validate(payload)
@@ -439,6 +463,8 @@ def build_plan_from_raw(
     as_of: datetime,
     briefs: list[AnalystBrief],
     debate_log: list[DebateTurn] | None = None,
+    debate_trigger: str | None = None,
+    debate_stop_reason: str | None = None,
 ) -> ResearchPlan:
     """测试 entrypoint。生产代码走 ``ResearchManager.synthesize``。"""
     return _build_plan(
@@ -449,6 +475,8 @@ def build_plan_from_raw(
         as_of=as_of,
         briefs=briefs,
         debate_log=debate_log,
+        debate_trigger=debate_trigger,
+        debate_stop_reason=debate_stop_reason,
     )
 
 

--- a/services/research/src/inalpha_research/researchers/__init__.py
+++ b/services/research/src/inalpha_research/researchers/__init__.py
@@ -1,18 +1,21 @@
-"""Bull/Bear researcher 与辩论协调器。
+"""Bull/Bear/Risk researcher 与辩论协调器。
 
-辩论是 6 个 analyst 出完 brief 之后的环节：让 Bull / Bear 两个 LLM 角色
-**轮换发言**，每轮可以读到对方上一轮论点 + 全部 6 个 analyst brief。
-最终把发言序列（``list[DebateTurn]``）传给 Manager 做综合 rating。
+辩论是 6 个 analyst 出完 brief 之后的环节：让 Bull / Bear（及可选的 Risk
+风险官，research-hub #6）**轮换发言**，每轮可以读到此前全部论点 + 全部
+analyst brief。最终把发言序列（``list[DebateTurn]``）传给 Manager 做综合 rating。
 
-灵感：``TauricResearch/TradingAgents`` 的 ``InvestDebateState`` 双方对喷拓扑，
-去掉 LangGraph 依赖、用纯 asyncio 协调（保持 Inalpha 的极简栈）。
+灵感：``TauricResearch/TradingAgents`` 的 ``InvestDebateState`` 对喷拓扑 +
+risk-management debator 三方制，去掉 LangGraph 依赖、用纯 asyncio 协调
+（保持 Inalpha 的极简栈）。
 """
 from .base import Researcher
 from .bear import BearResearcher
 from .bull import BullResearcher
+from .risk import RiskResearcher
 
 __all__ = [
     "BearResearcher",
     "BullResearcher",
     "Researcher",
+    "RiskResearcher",
 ]

--- a/services/research/src/inalpha_research/researchers/base.py
+++ b/services/research/src/inalpha_research/researchers/base.py
@@ -242,8 +242,12 @@ def _format_user_prompt(
             if latest_bear is not None:
                 parts.append(f"  BEAR latest: {latest_bear.content}")
         else:
+            # 对手 = 多空直接对立方（显式指名）。不能用 t.role != role：Risk 每轮
+            # 殿后，第 2 轮起 history 末尾必是 Risk，Bull 会被要求驳斥中立压测
+            # 内容而不是 Bear 的看空论据（PR #81 CR major）
+            opponent_role = "bear" if role == "bull" else "bull"
             last_opponent = next(
-                (t for t in reversed(history) if t.role != role),
+                (t for t in reversed(history) if t.role == opponent_role),
                 None,
             )
             if last_opponent is not None:

--- a/services/research/src/inalpha_research/researchers/base.py
+++ b/services/research/src/inalpha_research/researchers/base.py
@@ -24,10 +24,10 @@ AssetType = Literal["crypto", "us_stock", "cn_stock", "hk_stock", "global_stock"
 
 
 class Researcher(ABC):
-    """Bull / Bear researcher 共同接口。"""
+    """Bull / Bear / Risk researcher 共同接口。"""
 
     #: 角色字符串，落进 ``DebateTurn.role``。子类必须 override。
-    role: Literal["bull", "bear"] = "bull"
+    role: Literal["bull", "bear", "risk"] = "bull"
 
     def __init__(self, *, llm: LLMClient) -> None:
         self._llm = llm
@@ -183,7 +183,7 @@ def fundamental_note_for(asset_type: AssetType) -> str:
 
 def _format_user_prompt(
     *,
-    role: Literal["bull", "bear"],
+    role: Literal["bull", "bear", "risk"],
     venue: str,
     symbol: str,
     timeframe: str,

--- a/services/research/src/inalpha_research/researchers/base.py
+++ b/services/research/src/inalpha_research/researchers/base.py
@@ -227,15 +227,30 @@ def _format_user_prompt(
         parts.append("debate_history (oldest first):")
         for turn in history:
             parts.append(f"  Round {turn.round} {turn.role.upper()}: {turn.content}")
-        last_opponent = next(
-            (t for t in reversed(history) if t.role != role),
-            None,
-        )
-        if last_opponent is not None:
+        if role == "risk":
+            # 风险官中立：不给"驳斥对手"指令（那会让它偏向某一方），改为对称
+            # 列出双方最新论点，明确两边都要压测（PR #81 CR）
+            latest_bull = next((t for t in reversed(history) if t.role == "bull"), None)
+            latest_bear = next((t for t in reversed(history) if t.role == "bear"), None)
             parts.append("")
             parts.append(
-                f"opponent_last_turn (rebut this directly!): {last_opponent.content}"
+                "latest arguments to stress-test (challenge BOTH sides symmetrically, "
+                "do not take either side):"
             )
+            if latest_bull is not None:
+                parts.append(f"  BULL latest: {latest_bull.content}")
+            if latest_bear is not None:
+                parts.append(f"  BEAR latest: {latest_bear.content}")
+        else:
+            last_opponent = next(
+                (t for t in reversed(history) if t.role != role),
+                None,
+            )
+            if last_opponent is not None:
+                parts.append("")
+                parts.append(
+                    f"opponent_last_turn (rebut this directly!): {last_opponent.content}"
+                )
     else:
         parts.append("")
         parts.append("debate_history: (this is the first turn — make your opening case)")

--- a/services/research/src/inalpha_research/researchers/risk.py
+++ b/services/research/src/inalpha_research/researchers/risk.py
@@ -1,0 +1,65 @@
+"""Risk Researcher —— 辩论第三方风险官（research-hub #6）。
+
+不站多空任何一边：每轮读 Bull / Bear 的最新论证，压测双方论点的最薄弱环节、
+尾部风险与失效条件，并给出仓位纪律视角。借鉴 TradingAgents 的
+risk-management debator 三方制，融合 Inalpha 既有 RiskAnalyst 的证据锚定纪律
+（analyst 出 brief，risk researcher 在辩论里**用** brief，二者职责不同）。
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from .base import AssetType, Researcher
+
+_ASSET_LABEL: dict[AssetType, str] = {
+    "crypto": "asset",
+    "us_stock": "stock",
+    "cn_stock": "A-share / 个股",
+    "hk_stock": "HK stock / 港股",
+    "global_stock": "stock",
+}
+
+
+def _system_template(asset_type: AssetType) -> str:
+    asset_word = _ASSET_LABEL[asset_type]
+    return f"""
+You are a Risk Officer — the third voice in a Bull/Bear investment debate about
+the {asset_word}. You do NOT advocate a direction. Your task is to stress-test
+BOTH sides so the final judge sees what each thesis is silently assuming.
+
+Key points to focus on:
+- Weakest link: for the latest Bull argument AND the latest Bear argument,
+  identify the single most fragile assumption (data gap, crowded positioning,
+  regime dependence, stale evidence)
+- Invalidation: what specific, observable condition would falsify each thesis
+  (a level, a data release direction, a flow reversal — concrete, not vague)
+- Tail risk: scenarios both sides are ignoring (liquidity gaps, correlated
+  unwinds, venue/instrument-specific mechanics)
+- Position discipline: what the analyst briefs imply for sizing / drawdown
+  tolerance, regardless of direction
+
+Style rules:
+- One paragraph, 150–250 words, no bullet lists
+- Anchor every claim to a specific analyst brief or a specific debate turn
+  (e.g. "the bull's reliance on the macro analyst's dovish read")
+- Do not invent data not present in the briefs
+- HARD: do NOT cite specific calendar dates for macro / event-driven items
+  from your training memory. Your training cutoff is earlier than `as_of`,
+  so what was "upcoming" in your training is now history. Reference such
+  events only if they appear in an analyst_brief with their date.
+- Stay symmetric: if you challenge only one side, you have failed the task
+
+Return ONLY a JSON object:
+{{"argument": "<your full risk challenge as one paragraph>"}}
+
+Do not add any other keys.
+""".strip()
+
+
+class RiskResearcher(Researcher):
+    """风险官 researcher —— 三方辩论的第三声部。"""
+
+    role: Literal["bull", "bear", "risk"] = "risk"
+
+    def system_prompt(self, *, asset_type: AssetType) -> str:
+        return _system_template(asset_type)

--- a/services/research/src/inalpha_research/runner.py
+++ b/services/research/src/inalpha_research/runner.py
@@ -93,12 +93,14 @@ async def run_deep_dive(
     debate_trigger: str | None = None
     debate_stop_reason: str | None = None
     if settings.max_debate_rounds > 0:
-        contested, verdict = assess_disagreement(briefs)
+        contested, detail = assess_disagreement(briefs)
         should_debate = settings.debate_trigger == "always" or contested
+        # 前缀固定三选一（contested:/skipped:/always:），扁平结构供下游 startswith 解析
         debate_trigger = (
-            f"always: {verdict}" if settings.debate_trigger == "always"
-            else verdict if contested
-            else f"skipped: {verdict}"
+            f"always: debate forced regardless of disagreement ({detail})"
+            if settings.debate_trigger == "always"
+            else f"contested: {detail}" if contested
+            else f"skipped: {detail}"
         )
         _logger.info(
             "debate_trigger",

--- a/services/research/src/inalpha_research/runner.py
+++ b/services/research/src/inalpha_research/runner.py
@@ -1,11 +1,12 @@
 """把 ``DeepDiveRequest`` 翻成 analysts → debate → manager → ``ResearchPlan`` 的胶水。
 
-D-9 起新增 Bull/Bear 辩论阶段（``settings.max_debate_rounds`` 控制）：
+D-9 起新增辩论阶段（``settings.max_debate_rounds`` 控制），research-hub #6 升级三方制：
 
 1. 核心 analyst 并行出 ``AnalystBrief``（ADR-0037 §A：若 ``req.personas`` 指定，
    再追加对应投资大师人格 analyst，一并并行）
-2. **Bull/Bear 辩论 N 轮**（N=0 时跳过，保留旧 D-8c 直连行为）
-3. Manager 综合 briefs + debate_log → ``ResearchPlan``
+2. **Bull/Bear(/Risk) 辩论 ≤N 轮**（N=0 跳过；默认「争议触发」——briefs 多空对立
+   才辩，软早停见 debate.run_debate；触发判定与终止原因落 plan 供复盘）
+3. Manager 综合 briefs + debate_log → ``ResearchPlan``（含 synthesis_reasoning）
 
 把"实例化 analyst / 并行调 LLM / 辩论 / 综合"的所有粘合代码集中在这里，让 api 层薄。
 """
@@ -14,13 +15,17 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, get_args
 
+from inalpha_shared import get_logger
+
 from .analysts import ALL_ANALYSTS
 from .analysts.personas import PERSONA_ANALYSTS
 from .config import get_research_settings
-from .debate import run_debate
+from .debate import assess_disagreement, run_debate
 from .manager import ResearchManager
-from .researchers import BearResearcher, BullResearcher
+from .researchers import BearResearcher, BullResearcher, RiskResearcher
 from .schemas import AnalystBrief, DebateTurn, DeepDiveRequest, ResearchPlan
+
+_logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from .data_client import DataClient
@@ -81,24 +86,45 @@ async def run_deep_dive(
         else:
             briefs.append(result)
 
-    # ─── 2) Bull/Bear 辩论（max_debate_rounds=0 跳过）───────────────
+    # ─── 2) Bull/Bear(/Risk) 辩论（max_debate_rounds=0 跳过）────────
+    # research-hub #6：默认「争议触发」——analyst 同向时辩论只是复读 briefs，
+    # 跳过省 token；判定结果 + 终止原因落 plan 供复盘（决策链路可观测）。
     debate_log: list[DebateTurn] = []
+    debate_trigger: str | None = None
+    debate_stop_reason: str | None = None
     if settings.max_debate_rounds > 0:
-        bull = BullResearcher(llm=llm)
-        bear = BearResearcher(llm=llm)
-        debate_log = await run_debate(
-            bull=bull,
-            bear=bear,
-            venue=req.venue,
-            symbol=req.symbol,
-            timeframe=req.timeframe,
-            as_of=req.as_of,
-            briefs=briefs,
-            max_rounds=settings.max_debate_rounds,
-            # #2 限输出长度 + #4 总时限（debate.run_debate 内部超时返部分 log）
-            max_tokens=settings.debate_max_tokens,
-            timeout_seconds=settings.debate_timeout_seconds,
+        contested, verdict = assess_disagreement(briefs)
+        should_debate = settings.debate_trigger == "always" or contested
+        debate_trigger = (
+            f"always: {verdict}" if settings.debate_trigger == "always"
+            else verdict if contested
+            else f"skipped: {verdict}"
         )
+        _logger.info(
+            "debate_trigger",
+            symbol=req.symbol,
+            trigger_mode=settings.debate_trigger,
+            contested=contested,
+            should_debate=should_debate,
+        )
+        if should_debate:
+            outcome = await run_debate(
+                bull=BullResearcher(llm=llm),
+                bear=BearResearcher(llm=llm),
+                risk=RiskResearcher(llm=llm) if settings.debate_risk_enabled else None,
+                venue=req.venue,
+                symbol=req.symbol,
+                timeframe=req.timeframe,
+                as_of=req.as_of,
+                briefs=briefs,
+                max_rounds=settings.max_debate_rounds,
+                # #2 限输出长度 + #4 总时限（debate.run_debate 内部超时返部分 log）
+                max_tokens=settings.debate_max_tokens,
+                timeout_seconds=settings.debate_timeout_seconds,
+                convergence_threshold=settings.debate_convergence_threshold,
+            )
+            debate_log = outcome.turns
+            debate_stop_reason = outcome.stop_reason
 
     # ─── 3) Manager 综合 ────────────────────────────────────────────
     manager = ResearchManager(llm=llm)
@@ -110,6 +136,8 @@ async def run_deep_dive(
         briefs=briefs,
         debate_log=debate_log,
         user_question=req.user_question,
+        debate_trigger=debate_trigger,
+        debate_stop_reason=debate_stop_reason,
     )
     return plan
 

--- a/services/research/src/inalpha_research/schemas.py
+++ b/services/research/src/inalpha_research/schemas.py
@@ -146,16 +146,19 @@ class StrategyHint(BaseModel):
 
 
 class DebateTurn(BaseModel):
-    """Bull 或 Bear 一轮发言。
+    """Bull / Bear / Risk 一轮发言。
 
-    辩论协调器轮换调用 Bull/Bear；每次发言追加一条 ``DebateTurn`` 到
+    辩论协调器轮换调用各 researcher；每次发言追加一条 ``DebateTurn`` 到
     ``ResearchPlan.debate_log``，按时间顺序组成完整辩论史。
     """
 
-    role: Literal["bull", "bear"] = Field(
-        ..., description="发言角色：bull 看多 / bear 看空"
+    role: Literal["bull", "bear", "risk"] = Field(
+        ...,
+        description="发言角色：bull 看多 / bear 看空 / risk 风险官（research-hub #6 三方制）",
     )
-    round: int = Field(..., ge=1, description="第几轮（1-based）；同轮内 bull 先 bear 后")
+    round: int = Field(
+        ..., ge=1, description="第几轮（1-based）；同轮内 bull → bear → risk 固定顺序"
+    )
     content: str = Field(..., min_length=1, description="LLM 该轮发言原文")
 
 
@@ -260,12 +263,29 @@ class ResearchPlan(BaseModel):
     )
     debate_log: list[DebateTurn] = Field(
         default_factory=list,
-        description="D-9 起：Bull/Bear 辩论日志（每轮 2 条），manager 综合时已读过；"
+        description="D-9 起：Bull/Bear(/Risk) 辩论日志，manager 综合时已读过；"
         "下游 trader / UI 可重现辩论过程",
     )
     horizon: Horizon = Field(
         default="swing",
         description="建议持仓周期：日内 / 波段（几天-2周）/ 中长线",
+    )
+
+    # ── research-hub #6：决策链路可观测（为什么辩了 / 为什么停 / 怎么权衡的）──
+    debate_trigger: str | None = Field(
+        default=None,
+        description="research-hub #6：debate 触发判定结果——contested 描述 / skipped 原因 / "
+        "always 直跑；None = max_debate_rounds=0 未启用辩论",
+    )
+    debate_stop_reason: str | None = Field(
+        default=None,
+        description="research-hub #6：辩论终止原因（completed / converged 软早停 / timeout）；"
+        "None = 本次没跑辩论",
+    )
+    synthesis_reasoning: str | None = Field(
+        default=None,
+        description="research-hub #6：manager 综合的权衡自述（怎么调和分歧、辩论谁占上风），"
+        "复盘「为什么是这个 rating」的第一证据；LLM 没给则为 None",
     )
 
 

--- a/services/research/src/inalpha_research/schemas.py
+++ b/services/research/src/inalpha_research/schemas.py
@@ -274,8 +274,9 @@ class ResearchPlan(BaseModel):
     # ── research-hub #6：决策链路可观测（为什么辩了 / 为什么停 / 怎么权衡的）──
     debate_trigger: str | None = Field(
         default=None,
-        description="research-hub #6：debate 触发判定结果——contested 描述 / skipped 原因 / "
-        "always 直跑；None = max_debate_rounds=0 未启用辩论",
+        description="research-hub #6：debate 触发判定结果。前缀固定三选一——"
+        "'contested: '（分歧触发）/ 'skipped: '（同向跳过）/ 'always: '（强制直跑），"
+        "下游可安全 startswith 解析；None = max_debate_rounds=0 未启用辩论",
     )
     debate_stop_reason: str | None = Field(
         default=None,

--- a/services/research/tests/conftest.py
+++ b/services/research/tests/conftest.py
@@ -169,6 +169,10 @@ def fake_llm() -> FakeLLMClient:
                     "Technicals show clean upcross + room before overbought; "
                     "macro is neutral but with a halving tailwind. Net positive bias."
                 ),
+                "reasoning": (
+                    "Weighted the technical analyst highest (concrete SMA/RSI readings); "
+                    "the bear's macro-uncertainty case did not survive the bull's rebuttal."
+                ),
                 "risks": [
                     "If RSI > 70 quickly, mean reversion likely",
                     "Macro risk if rate cuts get postponed further",
@@ -193,6 +197,16 @@ def fake_llm() -> FakeLLMClient:
                     "fundamental brief admits halving tailwind is already priced; without "
                     "fresh catalyst, vol z-score can flip negative quickly. RSI 58 is closer "
                     "to overbought than to the buy-the-dip zone bulls pretend."
+                ),
+            },
+            # 三方制风险官（research-hub #6）—— 仅在 RESEARCH_DEBATE_RISK_ENABLED 时被消费
+            "you are a risk officer": {
+                "argument": (
+                    "The bull leans on a single technical brief whose RSI headroom evaporates "
+                    "on one strong candle; invalidation is a close back below SMA50. The bear's "
+                    "macro-uncertainty case cites no dated catalyst from the briefs — it is "
+                    "unfalsifiable as argued. Risk brief shows normal vol, so sizing beyond "
+                    "0.02 is unjustified either way."
                 ),
             },
         }

--- a/services/research/tests/test_debate.py
+++ b/services/research/tests/test_debate.py
@@ -1,27 +1,33 @@
-"""辩论协调器单测 —— 不打外部网络，用 FakeLLMClient 跑 Bull/Bear 轮换。"""
+"""辩论协调器单测 —— 不打外部网络，用 FakeLLMClient 跑 Bull/Bear(/Risk) 轮换。"""
 from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from typing import Any
 
-from inalpha_research.debate import run_debate
+from inalpha_research.debate import assess_disagreement, run_debate
 from inalpha_research.llm.client import FakeLLMClient
-from inalpha_research.researchers import BearResearcher, BullResearcher
-from inalpha_research.schemas import AnalystBrief
+from inalpha_research.researchers import BearResearcher, BullResearcher, RiskResearcher
+from inalpha_research.schemas import AnalystBrief, DebateTurn
 
 
 def _as_of() -> datetime:
     return datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
 
 
-def _brief(analyst: str, stance: str = "neutral") -> AnalystBrief:
+def _brief(analyst: str, stance: str = "neutral", confidence: float = 0.5) -> AnalystBrief:
     return AnalystBrief(
         analyst=analyst,  # type: ignore[arg-type]
         stance=stance,  # type: ignore[arg-type]
-        confidence=0.5,
+        confidence=confidence,
         summary=f"{analyst} brief",
         key_points=[f"{analyst} kp1"],
     )
+
+
+async def _debate_turns(**kwargs: Any) -> list[DebateTurn]:
+    """旧断言风格适配层：只关心发言序列的用例直接取 ``outcome.turns``。"""
+    return (await run_debate(**kwargs)).turns
 
 
 def _bull_bear_llm() -> FakeLLMClient:
@@ -39,7 +45,7 @@ async def test_run_debate_zero_rounds_returns_empty() -> None:
     bull = BullResearcher(llm=llm)
     bear = BearResearcher(llm=llm)
 
-    log = await run_debate(
+    log = await _debate_turns(
         bull=bull,
         bear=bear,
         venue="binance",
@@ -59,7 +65,7 @@ async def test_run_debate_one_round_alternates_bull_then_bear() -> None:
     bull = BullResearcher(llm=llm)
     bear = BearResearcher(llm=llm)
 
-    log = await run_debate(
+    log = await _debate_turns(
         bull=bull,
         bear=bear,
         venue="binance",
@@ -94,7 +100,7 @@ async def test_run_debate_multi_round_grows_history() -> None:
     bull = BullResearcher(llm=llm)
     bear = BearResearcher(llm=llm)
 
-    log = await run_debate(
+    log = await _debate_turns(
         bull=bull,
         bear=bear,
         venue="binance",
@@ -131,7 +137,7 @@ async def test_run_debate_round1_parallel_openings_when_multi_round() -> None:
     bull = BullResearcher(llm=llm)
     bear = BearResearcher(llm=llm)
 
-    log = await run_debate(
+    log = await _debate_turns(
         bull=bull,
         bear=bear,
         venue="binance",
@@ -164,7 +170,7 @@ async def test_run_debate_one_round_stays_serial_preserves_rebuttal() -> None:
     bull = BullResearcher(llm=llm)
     bear = BearResearcher(llm=llm)
 
-    await run_debate(
+    await _debate_turns(
         bull=bull,
         bear=bear,
         venue="binance",
@@ -187,7 +193,7 @@ async def test_run_debate_passes_max_tokens_to_llm() -> None:
     bull = BullResearcher(llm=llm)
     bear = BearResearcher(llm=llm)
 
-    await run_debate(
+    await _debate_turns(
         bull=bull,
         bear=bear,
         venue="binance",
@@ -223,7 +229,7 @@ async def test_run_debate_timeout_returns_partial_log_without_raising() -> None:
     bull = BullResearcher(llm=llm)
     bear = BearResearcher(llm=llm)
 
-    log = await run_debate(
+    log = await _debate_turns(
         bull=bull,
         bear=bear,
         venue="binance",
@@ -250,7 +256,7 @@ async def test_run_debate_swallows_researcher_failure() -> None:
     bull = BullResearcher(llm=llm)
     bear = BearResearcher(llm=llm)
 
-    log = await run_debate(
+    log = await _debate_turns(
         bull=bull,
         bear=bear,
         venue="binance",
@@ -323,6 +329,175 @@ def test_bull_system_prompt_adjusts_for_crypto_vs_stock() -> None:
 
     # 港股谈 Southbound / 互联互通
     assert "Southbound" in hk_prompt or "HKMA" in hk_prompt
+
+
+# ────────────────────────────────────────────────────────────────────
+# research-hub #6：三方制 / stop_reason / 软早停 / 争议判定
+# ────────────────────────────────────────────────────────────────────
+
+
+def _three_way_llm() -> FakeLLMClient:
+    return FakeLLMClient(
+        {
+            "you are a bull analyst": {"argument": "Bull says up"},
+            "you are a bear analyst": {"argument": "Bear says down"},
+            "you are a risk officer": {"argument": "Risk challenges both"},
+        }
+    )
+
+
+async def test_run_debate_risk_speaks_last_each_round() -> None:
+    """三方制：Risk 每轮在 Bull/Bear 之后殿后发言，且能读到双方本轮论点。"""
+    llm = _three_way_llm()
+
+    outcome = await run_debate(
+        bull=BullResearcher(llm=llm),
+        bear=BearResearcher(llm=llm),
+        risk=RiskResearcher(llm=llm),
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical", "bullish")],
+        max_rounds=2,
+    )
+
+    assert [(t.role, t.round) for t in outcome.turns] == [
+        ("bull", 1),
+        ("bear", 1),
+        ("risk", 1),
+        ("bull", 2),
+        ("bear", 2),
+        ("risk", 2),
+    ]
+    assert outcome.stop_reason == "completed 2 round(s)"
+
+    # Risk 第 1 轮（即使 Bull/Bear 并行开场）也必须读到双方开场论点
+    risk_r1 = next(c for c in llm.calls if "risk officer" in c["system"].lower())
+    assert "Bull says up" in risk_r1["user"]
+    assert "Bear says down" in risk_r1["user"]
+
+
+async def test_run_debate_without_risk_keeps_two_way() -> None:
+    """``risk=None``（RESEARCH_DEBATE_RISK_ENABLED=false）退回 Bull/Bear 两方制。"""
+    llm = _three_way_llm()
+
+    outcome = await run_debate(
+        bull=BullResearcher(llm=llm),
+        bear=BearResearcher(llm=llm),
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        max_rounds=1,
+    )
+
+    assert [t.role for t in outcome.turns] == ["bull", "bear"]
+    assert outcome.stop_reason == "completed 1 round(s)"
+
+
+async def test_run_debate_converges_early_when_arguments_repeat() -> None:
+    """软早停：双方从第 2 轮起复读同样论点 → 不跑满 max_rounds。"""
+    llm = _three_way_llm()  # FakeLLM 每轮返回相同文本 = 重合度 1.0
+
+    outcome = await run_debate(
+        bull=BullResearcher(llm=llm),
+        bear=BearResearcher(llm=llm),
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        max_rounds=4,
+        convergence_threshold=0.6,
+    )
+
+    # 第 2 轮发现与第 1 轮逐字相同 → 停，省掉第 3/4 轮
+    assert [(t.role, t.round) for t in outcome.turns] == [
+        ("bull", 1),
+        ("bear", 1),
+        ("bull", 2),
+        ("bear", 2),
+    ]
+    assert outcome.stop_reason.startswith("converged: round 2")
+
+
+async def test_run_debate_convergence_disabled_at_threshold_one() -> None:
+    """阈值 1.0 = 实际禁用：即使逐字复读也跑满轮数（保留旧行为）。"""
+    llm = _three_way_llm()
+
+    outcome = await run_debate(
+        bull=BullResearcher(llm=llm),
+        bear=BearResearcher(llm=llm),
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        max_rounds=3,
+        convergence_threshold=1.0,
+    )
+
+    assert len(outcome.turns) == 6
+    assert outcome.stop_reason == "completed 3 round(s)"
+
+
+async def test_run_debate_timeout_stop_reason() -> None:
+    """超时时 stop_reason 落 timeout（决策链路可观测）。"""
+
+    async def _slow(*, system: str, user: str) -> None:
+        await asyncio.sleep(5.0)
+
+    llm = FakeLLMClient(
+        {"you are a bull analyst": {"argument": "Bull says up"}},
+        on_call=_slow,
+    )
+
+    outcome = await run_debate(
+        bull=BullResearcher(llm=llm),
+        bear=BearResearcher(llm=llm),
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        max_rounds=1,
+        timeout_seconds=0.05,
+    )
+
+    assert outcome.turns == []
+    assert outcome.stop_reason.startswith("timeout:")
+
+
+def test_assess_disagreement_contested_on_confident_opposition() -> None:
+    """有信心的多空对立 → contested；verdict 描述双方数量。"""
+    contested, verdict = assess_disagreement(
+        [
+            _brief("technical", "bullish", confidence=0.7),
+            _brief("macro", "bearish", confidence=0.6),
+            _brief("sentiment", "neutral", confidence=0.9),
+        ]
+    )
+    assert contested is True
+    assert verdict.startswith("contested:")
+    assert "1 bullish vs 1 bearish" in verdict
+
+
+def test_assess_disagreement_aligned_when_same_direction() -> None:
+    """全员同向（或反方没信心）→ aligned，不值得辩。"""
+    aligned_cases = [
+        # 全 bullish
+        [_brief("technical", "bullish", 0.8), _brief("macro", "bullish", 0.6)],
+        # 反方存在但 confidence 低于门槛（失败 brief 的 0.0 也归于此）
+        [_brief("technical", "bullish", 0.8), _brief("macro", "bearish", 0.1)],
+        # 全 neutral
+        [_brief("technical", "neutral", 0.9), _brief("macro", "neutral", 0.9)],
+    ]
+    for briefs in aligned_cases:
+        contested, verdict = assess_disagreement(briefs)
+        assert contested is False
+        assert verdict.startswith("aligned:")
 
 
 def test_infer_asset_type_classifies_all_venues() -> None:

--- a/services/research/tests/test_debate.py
+++ b/services/research/tests/test_debate.py
@@ -380,9 +380,13 @@ async def test_run_debate_risk_speaks_last_each_round() -> None:
     # 而是对称的双向压测提示
     assert "rebut this directly!" not in risk_r1["user"]
     assert "challenge BOTH sides symmetrically" in risk_r1["user"]
-    # Bull/Bear 的 rebuttal 指令不受影响（round 2 串行）
+    # PR #81 CR major：Risk 殿后导致 history 末尾是 Risk——Round 2 Bull 的
+    # rebuttal 对象必须仍是 Bear 的论据，不能错指到 Risk 的中立压测内容
     bull_r2 = [c for c in llm.calls if "bull analyst" in c["system"].lower()][-1]
-    assert "rebut this directly!" in bull_r2["user"]
+    assert "opponent_last_turn (rebut this directly!): Bear says down" in bull_r2["user"]
+    assert "rebut this directly!): Risk challenges both" not in bull_r2["user"]
+    bear_r2 = [c for c in llm.calls if "bear analyst" in c["system"].lower()][-1]
+    assert "opponent_last_turn (rebut this directly!): Bull says up" in bear_r2["user"]
 
 
 async def test_run_debate_without_risk_keeps_two_way() -> None:

--- a/services/research/tests/test_debate.py
+++ b/services/research/tests/test_debate.py
@@ -376,6 +376,13 @@ async def test_run_debate_risk_speaks_last_each_round() -> None:
     risk_r1 = next(c for c in llm.calls if "risk officer" in c["system"].lower())
     assert "Bull says up" in risk_r1["user"]
     assert "Bear says down" in risk_r1["user"]
+    # PR #81 CR：风险官中立——不应收到"驳斥对手"指令（那会偏向一方），
+    # 而是对称的双向压测提示
+    assert "rebut this directly!" not in risk_r1["user"]
+    assert "challenge BOTH sides symmetrically" in risk_r1["user"]
+    # Bull/Bear 的 rebuttal 指令不受影响（round 2 串行）
+    bull_r2 = [c for c in llm.calls if "bull analyst" in c["system"].lower()][-1]
+    assert "rebut this directly!" in bull_r2["user"]
 
 
 async def test_run_debate_without_risk_keeps_two_way() -> None:
@@ -471,8 +478,8 @@ async def test_run_debate_timeout_stop_reason() -> None:
 
 
 def test_assess_disagreement_contested_on_confident_opposition() -> None:
-    """有信心的多空对立 → contested；verdict 描述双方数量。"""
-    contested, verdict = assess_disagreement(
+    """有信心的多空对立 → contested；detail 不带前缀（前缀由 runner 组装）。"""
+    contested, detail = assess_disagreement(
         [
             _brief("technical", "bullish", confidence=0.7),
             _brief("macro", "bearish", confidence=0.6),
@@ -480,8 +487,8 @@ def test_assess_disagreement_contested_on_confident_opposition() -> None:
         ]
     )
     assert contested is True
-    assert verdict.startswith("contested:")
-    assert "1 bullish vs 1 bearish" in verdict
+    assert "1 bullish vs 1 bearish" in detail
+    assert not detail.startswith("contested:")  # 扁平契约：前缀只在 runner 加一层
 
 
 def test_assess_disagreement_aligned_when_same_direction() -> None:
@@ -495,9 +502,9 @@ def test_assess_disagreement_aligned_when_same_direction() -> None:
         [_brief("technical", "neutral", 0.9), _brief("macro", "neutral", 0.9)],
     ]
     for briefs in aligned_cases:
-        contested, verdict = assess_disagreement(briefs)
+        contested, detail = assess_disagreement(briefs)
         assert contested is False
-        assert verdict.startswith("aligned:")
+        assert "no confident opposing stances" in detail
 
 
 def test_infer_asset_type_classifies_all_venues() -> None:

--- a/services/research/tests/test_runner.py
+++ b/services/research/tests/test_runner.py
@@ -416,7 +416,7 @@ async def test_deep_dive_aligned_briefs_skip_debate(
         assert len(fake_llm.calls) == 7
         assert plan.debate_log == []
         assert plan.debate_trigger is not None
-        assert plan.debate_trigger.startswith("skipped: aligned")
+        assert plan.debate_trigger.startswith("skipped: no confident opposing stances")
         assert plan.debate_stop_reason is None
     finally:
         get_research_settings.cache_clear()

--- a/services/research/tests/test_runner.py
+++ b/services/research/tests/test_runner.py
@@ -264,37 +264,47 @@ async def test_deep_dive_continues_when_some_analysts_fail() -> None:
         assert b.summary.startswith("(analyst failed)")
 
 
+def _mock_bars_and_fng() -> None:
+    """辩论类用例共用的数据源 mock：60 根缓涨 bar + FNG 极恐（喂出 fixture 预设 briefs）。"""
+    bars = [
+        make_bar_row((_as_of() - timedelta(hours=60 - i)).isoformat(), close=100 + i * 0.1)
+        for i in range(60)
+    ]
+    respx.get("http://data-mock.test/bars").mock(return_value=Response(200, json=bars))
+    respx.get("https://api.alternative.me/fng/").mock(
+        return_value=Response(
+            200,
+            json={
+                "data": [
+                    {"value": "22", "value_classification": "Extreme Fear", "timestamp": "1716163200"},
+                    *[
+                        {"value": str(30 + i % 10), "value_classification": "Fear", "timestamp": str(1716163200 - i * 86400)}
+                        for i in range(1, 30)
+                    ],
+                ]
+            },
+        )
+    )
+
+
 @respx.mock
 async def test_deep_dive_with_debate_includes_bull_bear_log(
     fake_llm: FakeLLMClient,
     monkeypatch: Any,
 ) -> None:
-    """开启 1 轮辩论：6 analyst + Bull + Bear + manager = 9 次 LLM 调用，
-    且 ``plan.debate_log`` 落 2 条 turn。"""
+    """trigger=always + 两方制（旧 D-9 行为保留档）：6 analyst + Bull + Bear +
+    manager = 9 次 LLM 调用，且 ``plan.debate_log`` 落 2 条 turn。
+
+    fixture briefs 全员 bullish/neutral（aligned），默认 contested 触发会跳过辩论——
+    本用例显式 always 验证旧行为开关仍可用；新默认路径见下两个用例。"""
     from inalpha_research.config import get_research_settings
 
     monkeypatch.setenv("RESEARCH_MAX_DEBATE_ROUNDS", "1")
+    monkeypatch.setenv("RESEARCH_DEBATE_TRIGGER", "always")
+    monkeypatch.setenv("RESEARCH_DEBATE_RISK_ENABLED", "false")
     get_research_settings.cache_clear()
     try:
-        bars = [
-            make_bar_row((_as_of() - timedelta(hours=60 - i)).isoformat(), close=100 + i * 0.1)
-            for i in range(60)
-        ]
-        respx.get("http://data-mock.test/bars").mock(return_value=Response(200, json=bars))
-        respx.get("https://api.alternative.me/fng/").mock(
-            return_value=Response(
-                200,
-                json={
-                    "data": [
-                        {"value": "22", "value_classification": "Extreme Fear", "timestamp": "1716163200"},
-                        *[
-                            {"value": str(30 + i % 10), "value_classification": "Fear", "timestamp": str(1716163200 - i * 86400)}
-                            for i in range(1, 30)
-                        ],
-                    ]
-                },
-            )
-        )
+        _mock_bars_and_fng()
 
         req = DeepDiveRequest(
             venue="binance",
@@ -322,8 +332,93 @@ async def test_deep_dive_with_debate_includes_bull_bear_log(
         assert "debate_log" in manager_call["user"]
         assert "Round 1 BULL" in manager_call["user"]
         assert "Round 1 BEAR" in manager_call["user"]
+        # 决策链路字段（#6）：always 模式如实落盘
+        assert plan.debate_trigger is not None and plan.debate_trigger.startswith("always:")
+        assert plan.debate_stop_reason == "completed 1 round(s)"
     finally:
         # 还原 env 避免污染后续测试
+        get_research_settings.cache_clear()
+
+
+@respx.mock
+async def test_deep_dive_contested_triggers_three_way_debate(
+    fake_llm: FakeLLMClient,
+    monkeypatch: Any,
+) -> None:
+    """research-hub #6 默认路径：briefs 出现多空对立（persona burry 提供 bearish）
+    → 触发三方辩论（Bull/Bear/Risk），决策链路字段全落盘。"""
+    from inalpha_research.config import get_research_settings
+
+    monkeypatch.setenv("RESEARCH_MAX_DEBATE_ROUNDS", "1")
+    get_research_settings.cache_clear()
+    try:
+        _mock_bars_and_fng()
+
+        req = DeepDiveRequest(
+            venue="binance",
+            symbol="BTC/USDT",
+            timeframe="1h",
+            as_of=_as_of(),
+            lookback_days=7,
+            personas=["burry"],  # bearish 0.55 ↔ technical bullish 0.7 → contested
+        )
+
+        async with DataClient("http://data-mock.test", "t") as data:
+            plan = await run_deep_dive(req, llm=fake_llm, data=data)
+
+        # 11 = 6 analyst + 1 persona + Bull + Bear + Risk + manager
+        assert len(fake_llm.calls) == 11
+        assert [(t.role, t.round) for t in plan.debate_log] == [
+            ("bull", 1),
+            ("bear", 1),
+            ("risk", 1),
+        ]
+        # 决策链路（#6）：为什么辩了 / 为什么停 / manager 怎么权衡
+        assert plan.debate_trigger is not None and plan.debate_trigger.startswith("contested:")
+        assert plan.debate_stop_reason == "completed 1 round(s)"
+        assert plan.synthesis_reasoning is not None
+        assert "technical analyst" in plan.synthesis_reasoning
+        # manager 能读到 Risk 的发言
+        manager_call = next(
+            c for c in fake_llm.calls if "research manager" in c["system"].lower()
+        )
+        assert "Round 1 RISK" in manager_call["user"]
+    finally:
+        get_research_settings.cache_clear()
+
+
+@respx.mock
+async def test_deep_dive_aligned_briefs_skip_debate(
+    fake_llm: FakeLLMClient,
+    monkeypatch: Any,
+) -> None:
+    """research-hub #6：fixture briefs 全员 bullish/neutral（aligned）→ 默认
+    contested 触发下跳过辩论省 token，跳过原因落 ``plan.debate_trigger``。"""
+    from inalpha_research.config import get_research_settings
+
+    monkeypatch.setenv("RESEARCH_MAX_DEBATE_ROUNDS", "1")
+    get_research_settings.cache_clear()
+    try:
+        _mock_bars_and_fng()
+
+        req = DeepDiveRequest(
+            venue="binance",
+            symbol="BTC/USDT",
+            timeframe="1h",
+            as_of=_as_of(),
+            lookback_days=7,
+        )
+
+        async with DataClient("http://data-mock.test", "t") as data:
+            plan = await run_deep_dive(req, llm=fake_llm, data=data)
+
+        # 7 = 6 analyst + manager（Bull/Bear/Risk 都没起跑）
+        assert len(fake_llm.calls) == 7
+        assert plan.debate_log == []
+        assert plan.debate_trigger is not None
+        assert plan.debate_trigger.startswith("skipped: aligned")
+        assert plan.debate_stop_reason is None
+    finally:
         get_research_settings.cache_clear()
 
 


### PR DESCRIPTION
Closes #6

## 背景

issue #6（research-hub 嵌套 supervisor）启动前复核：大部分原提议已被 D-9/D-10 顺手实现（6 analyst 并行 / LLM manager 综合 / bull-bear 多轮辩论 / 限时限轮 / 统一 schema）。本 PR 落收敛后的真实增量四项。

## 改动

1. **三方制**：`RiskResearcher` 风险官进辩论轮序（`researchers/risk.py`）——不站多空，每轮在 Bull/Bear 之后压测双方最薄弱假设、失效条件、仓位纪律；`RESEARCH_DEBATE_RISK_ENABLED`（默认开）可退回两方制
2. **争议触发**：`RESEARCH_DEBATE_TRIGGER` 默认 `contested`——briefs 同时存在有信心（confidence ≥ 0.35）的多空对立才辩（`debate.assess_disagreement` 确定性规则，零 LLM 开销），全员同向跳过省 token；`always` 保留旧 D-9 行为
3. **软早停**：第 2 轮起 Bull/Bear 论证与各自上轮词汇 Jaccard 重合度都 ≥ 阈值（`RESEARCH_DEBATE_CONVERGENCE_THRESHOLD` 默认 0.6，1.0=禁用）即收敛提前停，与硬超时并存；`run_debate` 返回值升级 `DebateOutcome`（turns + stop_reason）
4. **决策链路落盘**：`ResearchPlan` 新增 `debate_trigger`（为什么辩/跳过）/ `debate_stop_reason`（completed/converged/timeout）/ `synthesis_reasoning`（manager 权衡自述，LLM 输出新增 `reasoning` 键，fallback 同步）——复盘「为什么是这个 rating」有据可查

## 兼容性

- ResearchPlan 新字段全部 optional 带默认，orchestration 端 deep_dive 输出直通（无输出 zod 校验），向后兼容
- 行为变化：`max_debate_rounds>0` 时默认从「无条件辩」变「争议才辩」——这正是 issue #6 的诉求；`RESEARCH_DEBATE_TRIGGER=always` 一键回退

## 验证

- research 110 测试全过：debate 19（三方轮序 / Risk 殿后能读双方 / 早停 / 阈值 1.0 禁用 / 超时 stop_reason / 争议判定 3 组）+ runner 新增 contested 三方制与 aligned 跳过用例 + 旧用例改 always 两方制留作回退档
- `ruff` 过；`mypy` 16 错与 main 基线逐一对过，零新增
- check-consistency（含 C8）9 项通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)