### PR TITLE
fix: symbol_search 路由——语言≠市场（agent 显式传 venue + auto 并行合并）

### DIFF
--- a/packages/orchestration/src/mastra/agents/orchestrator.ts
+++ b/packages/orchestration/src/mastra/agents/orchestrator.ts
@@ -47,6 +47,8 @@ const INSTRUCTIONS = `
 - **data.search_symbol —— 公司名 → ticker 解析**。从新闻 / 研究里拿到公司名要落
   行情 / 财报前先解析；**禁止凭训练记忆猜代码**（可能错 / 过时）。A股返 sh./sz. 格式，
   其他市场返 yahoo 格式（venue 字段标明配哪个数据源）。
+  **你已判断出市场分类时显式传 venue**（美股/港股/全球 → yfinance，A股 → akshare）；
+  query 的语言 ≠ 市场——中文名问美股公司极常见，别把市场判断丢给 auto 兜底。
 
 **Web 搜索**（D-10 新 · 零 key，ddgs 聚合多引擎）：
 - web.search —— 搜索互联网。query 用自然语言；backend 默认 auto，中文自动走 bing。

--- a/packages/orchestration/src/tools/data.ts
+++ b/packages/orchestration/src/tools/data.ts
@@ -353,13 +353,18 @@ export const dataSearchSymbolTool = createTool({
     - 加密货币对（BTC/USDT 这类）→ 不是股票检索范围
 
     坑：
-    - venue=auto：中文 query 先查 A股表再补 Yahoo；纯英文只走 Yahoo
+    - **已能判断出市场时显式传 venue**（美股 / 港股 / 全球 → yfinance；A股 → akshare）。
+      query 的语言 ≠ 市场：中文名问美股公司极常见，别让 auto 的兜底逻辑替你判断
+    - venue=auto：中文 query 会 A股表与 Yahoo 并行都查、轮替合并；纯英文只走 Yahoo
     - 北交所代码暂不支持（会被过滤）；返回空 ≠ 公司不存在，可换关键词再试
     - 返回的 venue 字段标明该 symbol 该配哪个数据源，喂 get_fundamentals 时带上
   `.trim(),
   inputSchema: z.object({
     query: z.string().min(1).max(80).describe("公司名 / 代码片段，如公司中文名或英文名"),
-    venue: z.enum(["auto", "akshare", "yfinance"]).default("auto"),
+    venue: z
+      .enum(["auto", "akshare", "yfinance"])
+      .default("auto")
+      .describe("已判断出市场就显式传（语言≠市场）；auto 仅在市场未知时兜底"),
     maxResults: z.number().int().min(1).max(20).default(10),
   }),
   execute: async (inputData, ctx) => {

--- a/services/data/src/inalpha_data/connectors/symbol_search.py
+++ b/services/data/src/inalpha_data/connectors/symbol_search.py
@@ -11,7 +11,10 @@ get_fundamentals 必须先有 symbol——靠 LLM 训练记忆猜代码会撞时
 - yfinance ``Search``：Yahoo 全球检索（美 / 港 / 日韩欧等），输出原生 yahoo
   symbol（``AAPL`` / ``0700.HK``），与 yfinance connector 直接可用。
 
-venue="auto"：query 含 CJK → 先 A股表再 yahoo；纯 ASCII → 只走 yahoo。
+venue="auto"：query 含 CJK → A股表与 yahoo **并行都查、轮替合并**；纯 ASCII →
+只走 yahoo。语言只决定"是否多查一路 A股"，**不决定市场**——中文用户问美股 /
+港股公司（中文名）极常见，串行补位会让 A股结果挤掉 yahoo 候选、跨市场同名
+歧义时单边呈现（§3 不预设语言/市场）。
 失败语义：尽力而为，异常一律返 []。
 """
 
@@ -19,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from itertools import zip_longest
 from typing import Any
 
 from inalpha_shared import get_logger
@@ -50,6 +54,19 @@ def _load_a_share_table_sync() -> list[dict[str, str]]:
     return raw.to_dict(orient="records")  # type: ignore[no-any-return]
 
 
+def _merge_round_robin(
+    a: list[dict[str, Any]], b: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """两来源轮替合并（a1, b1, a2, b2, ...），保留各自内部相关性排序。"""
+    out: list[dict[str, Any]] = []
+    for x, y in zip_longest(a, b):
+        if x is not None:
+            out.append(x)
+        if y is not None:
+            out.append(y)
+    return out
+
+
 def _yahoo_search_sync(query: str, max_results: int) -> list[dict[str, Any]]:
     import yfinance as yf
 
@@ -78,12 +95,19 @@ class SymbolSearchConnector:
 
         results: list[dict[str, Any]] = []
         try:
-            if venue in ("akshare", "auto") and (venue == "akshare" or has_cjk):
-                results.extend(await self._search_a_share(query, max_results))
-            if venue in ("yfinance", "auto") and len(results) < max_results:
-                results.extend(
-                    await self._search_yahoo(query, max_results - len(results))
+            if venue == "akshare":
+                results = await self._search_a_share(query, max_results)
+            elif venue == "yfinance" or not has_cjk:
+                results = await self._search_yahoo(query, max_results)
+            else:
+                # auto + CJK：两路并行都查、轮替合并。A股表是本地缓存、yahoo 有
+                # 5s 超时，并行无额外延迟；轮替保证任一来源不会把另一来源挤出
+                # max_results（跨市场同名歧义时两边都呈现，由 agent 按 venue 选）
+                a_share, yahoo = await asyncio.gather(
+                    self._search_a_share(query, max_results),
+                    self._search_yahoo(query, max_results),
                 )
+                results = _merge_round_robin(a_share, yahoo)
         except Exception as exc:
             _logger.warning("symbol_search_error", query=query[:80], error=str(exc))
         return results[:max_results]

--- a/services/data/tests/test_symbol_search.py
+++ b/services/data/tests/test_symbol_search.py
@@ -45,6 +45,51 @@ async def test_cjk_query_hits_a_share_table(monkeypatch: pytest.MonkeyPatch) -> 
     ]
 
 
+async def test_cjk_auto_queries_both_sources_round_robin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """auto + 中文：A股表与 Yahoo 并行都查、轮替合并——语言≠市场，
+    任一来源不得把另一来源挤出 max_results（跨市场同名歧义两边都呈现）。"""
+    yahoo_calls: list[tuple[str, int]] = []
+
+    def fake_yahoo(query: str, max_results: int):
+        yahoo_calls.append((query, max_results))
+        return _FAKE_YAHOO
+
+    monkeypatch.setattr(ss, "_load_a_share_table_sync", lambda: _FAKE_A_SHARE)
+    monkeypatch.setattr(ss, "_yahoo_search_sync", fake_yahoo)
+    conn = SymbolSearchConnector()
+
+    out = await conn.search("平安", max_results=4)
+
+    # Yahoo 以完整 max_results 被查（不是 A股填剩的余额）
+    assert yahoo_calls == [("平安", 4)]
+    # 轮替合并：a1, y1, a2(无), y2 → A股命中 1 条时 Yahoo 两条都进结果
+    assert [r["venue"] for r in out] == ["akshare", "yfinance", "yfinance"]
+    assert out[0]["symbol"] == "sz.000001"
+    assert {r["symbol"] for r in out if r["venue"] == "yfinance"} == {"AAPL", "0700.HK"}
+
+
+async def test_cjk_with_explicit_yfinance_venue_skips_a_share(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """显式 venue=yfinance 时即使 query 是中文也不碰 A股表（agent 已判断市场）。"""
+    table_loads: list[int] = []
+
+    def fake_load():
+        table_loads.append(1)
+        return _FAKE_A_SHARE
+
+    monkeypatch.setattr(ss, "_load_a_share_table_sync", fake_load)
+    monkeypatch.setattr(ss, "_yahoo_search_sync", lambda q, n: _FAKE_YAHOO)
+    conn = SymbolSearchConnector()
+
+    out = await conn.search("特斯拉", venue="yfinance")
+
+    assert table_loads == []  # A股表一次都没加载
+    assert [r["venue"] for r in out] == ["yfinance", "yfinance"]
+
+
 async def test_code_prefix_match_and_bj_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ss, "_load_a_share_table_sync", lambda: _FAKE_A_SHARE)
     conn = SymbolSearchConnector()


### PR DESCRIPTION
## 背景

实测：用户中文问美股公司深度研究，agent 已正确判断「是美股走 yfinance」，却先去查了 A股表、播报「A股没有」。两层根因：

1. agent 没把市场判断传给 tool（`venue` 入参存在但用了默认 auto）——prompt/描述没教
2. connector 的 auto 档用 query 语言猜市场：中文 → 先 A股表、不满才补 Yahoo 的**串行补位**，A股命中会把 Yahoo 候选挤出 max_results，跨市场同名歧义单边呈现（违反 §3「不预设语言/市场」精神）

## 改动

- **P1 指引层**（orchestration）：tool 描述坑段 + `venue` 参数 describe + orchestrator prompt 三处补「已判断出市场显式传 venue；语言≠市场，auto 仅在市场未知时兜底」
- **P2 connector 层**（data）：auto + 中文改为 A股表与 Yahoo **并行都查**（asyncio.gather）+ **轮替合并**（zip_longest），任一来源不再挤掉另一来源；A股表本地缓存 + Yahoo 已有 5s 超时，并行无额外延迟。显式 venue 行为不变

不动的：「禁止凭训练记忆猜代码」纪律保持——解析调用本身是对的，错的只是路由方式。A股表数据源（akshare）未动，不影响 a-stock-data 配方迁移。

## 验证

- data 106 测试全过（新增：auto+中文双路轮替合并 + Yahoo 拿完整 max_results / 显式 yfinance 不碰 A股表）
- orchestration typecheck + 388 vitest 全过；ruff 绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)