### PR TITLE
feat(research): 争议判定门槛进 config + 三方×软早停组合回归（PR #81 follow-up）

### DIFF
--- a/services/research/src/inalpha_research/config.py
+++ b/services/research/src/inalpha_research/config.py
@@ -166,6 +166,16 @@ class ResearchSettings(BaseSettings):
         description="research-hub #6：辩论是否加入 Risk 风险官第三方（每轮在 Bull/Bear "
         "之后压测双方论点）。关掉退回 Bull/Bear 两方制，省 1/3 辩论 LLM 开销。",
     )
+    debate_min_confidence: float = Field(
+        default=0.35,
+        ge=0.0,
+        le=1.0,
+        alias="RESEARCH_DEBATE_MIN_CONFIDENCE",
+        description="research-hub #6：争议判定的立场置信门槛——bullish/bearish brief 的 "
+        "confidence ≥ 此值才算「有信心的对立方」（assess_disagreement）。失败 brief "
+        "恒为 0.0 天然被排除；数据质量差 / 失败 brief 多的环境可调低。"
+        "（PR #81 CR follow-up：与其余辩论旋钮一样走 env，不再内嵌代码。）",
+    )
     debate_convergence_threshold: float = Field(
         default=0.6,
         ge=0.0,

--- a/services/research/src/inalpha_research/runner.py
+++ b/services/research/src/inalpha_research/runner.py
@@ -93,7 +93,9 @@ async def run_deep_dive(
     debate_trigger: str | None = None
     debate_stop_reason: str | None = None
     if settings.max_debate_rounds > 0:
-        contested, detail = assess_disagreement(briefs)
+        contested, detail = assess_disagreement(
+            briefs, min_confidence=settings.debate_min_confidence
+        )
         should_debate = settings.debate_trigger == "always" or contested
         # 前缀固定三选一（contested:/skipped:/always:），扁平结构供下游 startswith 解析
         debate_trigger = (

--- a/services/research/tests/test_debate.py
+++ b/services/research/tests/test_debate.py
@@ -441,7 +441,6 @@ async def test_run_debate_three_way_converges_despite_risk_turns() -> None:
     锚点成立的关键：Risk **每轮返回完全不同的文本**（词集不相交，Jaccard≈0）。
     若 role 过滤被改坏（把 risk 也纳入判定），round 2 的 Risk 相似度过不了阈，
     收敛永不触发 → 本测试 turns 变 12 条 / stop_reason 变 completed 而失败。"""
-    llm = _three_way_llm()
     risk_texts = iter(
         [
             "Risk flags crowded positioning and thin liquidity beneath spot",
@@ -451,11 +450,19 @@ async def test_run_debate_three_way_converges_despite_risk_turns() -> None:
         ]
     )
 
+    # 闭包晚绑定 llm：on_call 经构造器传入（公共 API），在响应匹配前触发，
+    # 每次 risk 发言前 set_response 换词
     async def _rotate_risk(*, system: str, user: str) -> None:
         if "risk officer" in system.lower():
             llm.set_response("you are a risk officer", {"argument": next(risk_texts)})
 
-    llm._on_call = _rotate_risk  # on_call 在响应匹配前触发（client.py），每轮换词
+    llm = FakeLLMClient(
+        {
+            "you are a bull analyst": {"argument": "Bull says up"},
+            "you are a bear analyst": {"argument": "Bear says down"},
+        },
+        on_call=_rotate_risk,
+    )
 
     outcome = await run_debate(
         bull=BullResearcher(llm=llm),

--- a/services/research/tests/test_debate.py
+++ b/services/research/tests/test_debate.py
@@ -436,9 +436,26 @@ async def test_run_debate_converges_early_when_arguments_repeat() -> None:
 
 async def test_run_debate_three_way_converges_despite_risk_turns() -> None:
     """三方制 × 软早停组合（PR #81 CR follow-up）：收敛判定只看 Bull/Bear，
-    Risk 轮（每轮压测对象不同、内容天然多变）不得干扰早停——这是 _converged
-    role 过滤的回归锚点，过滤被改坏会导致三方制下几乎永不收敛。"""
+    Risk 轮不得干扰早停——这是 _converged role 过滤的回归锚点。
+
+    锚点成立的关键：Risk **每轮返回完全不同的文本**（词集不相交，Jaccard≈0）。
+    若 role 过滤被改坏（把 risk 也纳入判定），round 2 的 Risk 相似度过不了阈，
+    收敛永不触发 → 本测试 turns 变 12 条 / stop_reason 变 completed 而失败。"""
     llm = _three_way_llm()
+    risk_texts = iter(
+        [
+            "Risk flags crowded positioning and thin liquidity beneath spot",
+            "Tail scenario: correlated unwind invalidates either thesis overnight",
+            "Sizing discipline caps exposure regardless of directional conviction",
+            "Regime dependence makes both arguments fragile to a vol spike",
+        ]
+    )
+
+    async def _rotate_risk(*, system: str, user: str) -> None:
+        if "risk officer" in system.lower():
+            llm.set_response("you are a risk officer", {"argument": next(risk_texts)})
+
+    llm._on_call = _rotate_risk  # on_call 在响应匹配前触发（client.py），每轮换词
 
     outcome = await run_debate(
         bull=BullResearcher(llm=llm),

--- a/services/research/tests/test_debate.py
+++ b/services/research/tests/test_debate.py
@@ -434,6 +434,50 @@ async def test_run_debate_converges_early_when_arguments_repeat() -> None:
     assert outcome.stop_reason.startswith("converged: round 2")
 
 
+async def test_run_debate_three_way_converges_despite_risk_turns() -> None:
+    """三方制 × 软早停组合（PR #81 CR follow-up）：收敛判定只看 Bull/Bear，
+    Risk 轮（每轮压测对象不同、内容天然多变）不得干扰早停——这是 _converged
+    role 过滤的回归锚点，过滤被改坏会导致三方制下几乎永不收敛。"""
+    llm = _three_way_llm()
+
+    outcome = await run_debate(
+        bull=BullResearcher(llm=llm),
+        bear=BearResearcher(llm=llm),
+        risk=RiskResearcher(llm=llm),
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        as_of=_as_of(),
+        briefs=[_brief("technical")],
+        max_rounds=4,
+        convergence_threshold=0.6,
+    )
+
+    # Bull/Bear 第 2 轮复读 → 收敛停；Risk 两轮都殿后发言、不阻止早停
+    assert [(t.role, t.round) for t in outcome.turns] == [
+        ("bull", 1),
+        ("bear", 1),
+        ("risk", 1),
+        ("bull", 2),
+        ("bear", 2),
+        ("risk", 2),
+    ]
+    assert outcome.stop_reason.startswith("converged: round 2")
+
+
+def test_assess_disagreement_min_confidence_configurable() -> None:
+    """门槛可调（PR #81 CR follow-up）：同一组 briefs，调高 min_confidence
+    会把弱对立判成 aligned——runner 从 settings.debate_min_confidence 透传。"""
+    briefs = [
+        _brief("technical", "bullish", confidence=0.7),
+        _brief("macro", "bearish", confidence=0.5),
+    ]
+    contested_default, _ = assess_disagreement(briefs, min_confidence=0.35)
+    contested_strict, _ = assess_disagreement(briefs, min_confidence=0.6)
+    assert contested_default is True
+    assert contested_strict is False  # bearish 0.5 低于 0.6 门槛 → 无有信心对立方
+
+
 async def test_run_debate_convergence_disabled_at_threshold_one() -> None:
     """阈值 1.0 = 实际禁用：即使逐字复读也跑满轮数（保留旧行为）。"""
     llm = _three_way_llm()


### PR DESCRIPTION
PR #81 收口时记下的两条 medium follow-up：

1. **`RESEARCH_DEBATE_MIN_CONFIDENCE`**（默认 0.35 不变）：争议判定的立场置信门槛原内嵌代码，与其余辩论旋钮全走 env 的设计不一致；进 `ResearchSettings` 后 runner 透传 `assess_disagreement`。失败 brief 恒 0.0 天然被排除的语义不变
2. **三方制 × 软早停组合用例**：收敛判定只看 Bull/Bear、Risk 轮（每轮压测对象不同天然多变）不得阻止早停——`_converged` role 过滤的回归锚点，过滤被改坏会导致三方制下几乎永不收敛且现有用例测不出
3. 顺带：门槛可调性用例（调高把弱对立判成 aligned）

## 验证

research 112 测试全过（110 + 2 新增）；ruff 绿；行为零变化（默认值不变，纯设计面对齐）

🤖 Generated with [Claude Code](https://claude.com/claude-code)