### PR TITLE
feat(paper): 框架级持仓保护止损 Position Guard(ADR-0052)

### DIFF
--- a/packages/orchestration/src/clients/paper.ts
+++ b/packages/orchestration/src/clients/paper.ts
@@ -87,6 +87,12 @@ export type BacktestReport = {
   max_drawdown_pct: number;
   win_rate: number | null;
   /**
+   * ADR-0052：本次回测框架级持仓保护止损触发的平仓笔数（tag ∈
+   * stop_loss/take_profit/trailing_stop_loss）。>0 说明灾难兜底生效过几次——
+   * 回测如实反映未来 live 也会有的兜底，agent 可据此向用户说明风险被框架封住了几次。
+   */
+  protective_exits?: number;
+  /**
    * D-9 起：账户是否穿仓（任意时点 equity ≤ -1%×initial_cash）。true 表示本次
    * 回测物理上不可信，agent 必须显式告警而非直接展示 Sharpe / 收益率。
    */

--- a/packages/orchestration/src/clients/paper.ts
+++ b/packages/orchestration/src/clients/paper.ts
@@ -90,8 +90,9 @@ export type BacktestReport = {
    * ADR-0052：本次回测框架级持仓保护止损触发的平仓笔数（tag ∈
    * stop_loss/take_profit/trailing_stop_loss）。>0 说明灾难兜底生效过几次——
    * 回测如实反映未来 live 也会有的兜底，agent 可据此向用户说明风险被框架封住了几次。
+   * 非 optional：Python BacktestResponse 有 default=0，响应恒带该字段。
    */
-  protective_exits?: number;
+  protective_exits: number;
   /**
    * D-9 起：账户是否穿仓（任意时点 equity ≤ -1%×initial_cash）。true 表示本次
    * 回测物理上不可信，agent 必须显式告警而非直接展示 Sharpe / 收益率。

--- a/packages/orchestration/src/tools/paper.ts
+++ b/packages/orchestration/src/tools/paper.ts
@@ -88,6 +88,9 @@ export const paperRunBacktestTool = createTool({
     报告字段（D-7+）：
     - 基础：total_return_pct / num_trades / total_fees / final_equity / num_bars_processed
     - 绩效：sharpe / sortino / max_drawdown_pct / win_rate（数据不足时为 null）
+    - 框架兜底：protective_exits（ADR-0052 框架级持仓保护止损本次触发的平仓笔数）——
+      >0 说明灾难兜底生效过几次；这是回测对"未来 live 也会有的兜底"的如实反映，
+      可向用户说明风险被框架封住了几次（默认 -20% 硬止损，非策略自带）
     - D-9：fitness（多目标合成，ADR-0020）—— 排序候选用这个，不要用裸 Sharpe
     - equity_curve：[(ts, equity)] 序列；**超 120 点会等距降采样**（带
       equity_curve_downsampled_from 标原始点数），看形状趋势用，精确逐点分析

--- a/services/paper/src/inalpha_paper/config.py
+++ b/services/paper/src/inalpha_paper/config.py
@@ -148,6 +148,31 @@ class PaperSettings(BaseSettings):
         "无人值守长驻兜底：策略卡死 / 无限空跑也能自动收场。",
     )
 
+    # ─── ADR-0052 · 框架级持仓保护止损（Position Guard）────────────────
+
+    protective_stop_loss_pct: float | None = Field(
+        default=0.20,
+        alias="INALPHA_PROTECTIVE_STOP_LOSS_PCT",
+        gt=0.0,
+        le=1.0,
+        description="框架级持仓灾难性兜底止损：单仓浮亏穿 -X → 全平（回测 + live 共用同一"
+        "阈值，行为一致）。默认 0.20 = 宽兜底（封尾部风险而非切正常波动；贴行情的紧止损"
+        "是策略层 alpha 的事）。None / 0 视为关闭硬止损闸。",
+    )
+    protective_take_profit_pct: float | None = Field(
+        default=None,
+        alias="INALPHA_PROTECTIVE_TAKE_PROFIT_PCT",
+        gt=0.0,
+        description="框架级止盈：单仓浮盈穿 +X → 全平。默认 None = 关（封上行偏 alpha 决策，"
+        "会伤趋势策略，框架层默认不做）。",
+    )
+    protective_trailing_stop_pct: float | None = Field(
+        default=None,
+        alias="INALPHA_PROTECTIVE_TRAILING_STOP_PCT",
+        gt=0.0,
+        description="框架级移动止损：自峰值浮盈回撤 X → 全平（锁大利润）。默认 None = 关。",
+    )
+
     # ─── D-12 · 因子衰减巡检（ADR-0047）────────────────────────────────
 
     factor_service_url: str = Field(

--- a/services/paper/src/inalpha_paper/config.py
+++ b/services/paper/src/inalpha_paper/config.py
@@ -157,7 +157,7 @@ class PaperSettings(BaseSettings):
         le=1.0,
         description="框架级持仓灾难性兜底止损：单仓浮亏穿 -X → 全平（回测 + live 共用同一"
         "阈值，行为一致）。默认 0.20 = 宽兜底（封尾部风险而非切正常波动；贴行情的紧止损"
-        "是策略层 alpha 的事）。None / 0 视为关闭硬止损闸。",
+        "是策略层 alpha 的事）。关闭硬止损闸 = 不设该环境变量（None）；0 不合法（gt=0）。",
     )
     protective_take_profit_pct: float | None = Field(
         default=None,
@@ -170,7 +170,8 @@ class PaperSettings(BaseSettings):
         default=None,
         alias="INALPHA_PROTECTIVE_TRAILING_STOP_PCT",
         gt=0.0,
-        description="框架级移动止损：自峰值浮盈回撤 X → 全平（锁大利润）。默认 None = 关。",
+        description="框架级移动止损：仓位进入盈利区后，自【峰值价格】回撤 X → 全平（锁大利润，"
+        "口径是价格自峰值的跌幅，非成本收益率降幅）。默认 None = 关（设 0 不合法，gt=0）。",
     )
 
     # ─── D-12 · 因子衰减巡检（ADR-0047）────────────────────────────────

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -99,7 +99,17 @@ class BacktestEngine:
         self._num_bars: int = 0
 
     def add_strategy(self, strategy: Strategy) -> None:
-        """挂载策略。strategy 构造时必须传 ``engine.clock`` / ``engine.msgbus``。"""
+        """挂载策略。strategy 构造时必须传 ``engine.clock`` / ``engine.msgbus``。
+
+        启用了 PositionGuard（protective_* 阈值非空）时**只允许单策略**：guard 只持一个
+        strategy_id，多策略会让保护性出场归属错误（前策略 on_position_closed 不触发、状态
+        不归零）。挂第二个策略即抛 RuntimeError（CR #88）。需多策略回测请关闭 protective_*。
+        """
+        if self._guard is not None and self._strategies:
+            raise RuntimeError(
+                "PositionGuard 启用时只支持单策略 per engine（多策略需先完成引擎多策略化，"
+                "CR #88 / ADR-0052 已知限制）；多策略回测请置 protective_* 阈值为 None。"
+            )
         self._strategies.append(strategy)
         # guard 出场单用策略自身 id 提交（确保 on_position_closed 回到策略让其状态归零）
         if self._guard is not None:

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -166,7 +166,8 @@ class BacktestEngine:
         # 层整体未做项（CR #88 medium，与引擎多标的化一并推进，非本闸单独修）。
         if self._guard is not None and bars_list:
             if self.exchange.flush_protective_at_close(bars_list[-1]) > 0:
-                # 兜底平仓改变了持仓/现金（差一笔手续费），重记末点权益
+                # 兜底平仓改变了持仓/现金（差一笔手续费），重记末点权益。snapshot 对同 ts
+                # 是**覆盖**末点（见 Portfolio.snapshot），不会产生重复 ts / 多算一个 bar。
                 self.portfolio.snapshot(bars_list[-1].ts_event)
 
         for s in self._strategies:

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -33,6 +33,7 @@ from ..kernel.msgbus import MessageBus
 from ..model.data import Bar
 from ..strategy.base import Strategy
 from .portfolio import Portfolio
+from .position_guard import PositionGuard
 from .report import BacktestReport
 
 
@@ -46,6 +47,9 @@ class BacktestEngine:
         *,
         rules: list[RiskRule] | None = None,
         lock_store: LockStore | None = None,
+        protective_stop_loss_pct: float | None = None,
+        protective_take_profit_pct: float | None = None,
+        protective_trailing_stop_pct: float | None = None,
     ) -> None:
         """初始化。
 
@@ -56,6 +60,9 @@ class BacktestEngine:
             rules: ADR-0006 RiskRule 列表。``None`` 时 RiskEngine 退化为 pass-through
                 （向后兼容 D-5 ~ D-8 调用方）
             lock_store: 风控锁存储。None 时 RiskEngine 自动创建 InMemoryLockStore
+            protective_stop_loss_pct: ADR-0052 框架级持仓保护止损阈值（None = 关）
+            protective_take_profit_pct: 框架级止盈阈值（None = 关）
+            protective_trailing_stop_pct: 框架级移动止损阈值（None = 关）
         """
         # 内核
         self.clock = TestClock(0)
@@ -77,12 +84,26 @@ class BacktestEngine:
         # （ADR-0032 BuyingPowerRule 撮合层兜底实现，旧 BTC -98% bug 同源防御）
         self.exchange.bind_portfolio(self.portfolio)
 
+        # ADR-0052：框架级持仓保护止损（与 live session 共用同一组件，行为一致）。
+        # 三阈值全 None → from_thresholds 返 None，退化为无 guard（向后兼容）。
+        self._guard = PositionGuard.from_thresholds(
+            self.msgbus,
+            self.clock,
+            self.portfolio,
+            stop_loss_pct=protective_stop_loss_pct,
+            take_profit_pct=protective_take_profit_pct,
+            trailing_stop_pct=protective_trailing_stop_pct,
+        )
+
         self._strategies: list[Strategy] = []
         self._num_bars: int = 0
 
     def add_strategy(self, strategy: Strategy) -> None:
         """挂载策略。strategy 构造时必须传 ``engine.clock`` / ``engine.msgbus``。"""
         self._strategies.append(strategy)
+        # guard 出场单用策略自身 id 提交（确保 on_position_closed 回到策略让其状态归零）
+        if self._guard is not None:
+            self._guard.bind_strategy(strategy.strategy_id)
 
     def run(self, bars: Iterable[Bar]) -> BacktestReport:
         """跑回测，返回 ``BacktestReport``。"""
@@ -106,6 +127,10 @@ class BacktestEngine:
                 self.clock.set_time(bar.ts_event)
             # 3. 更新 mark price（让 portfolio.equity() 准确）
             self.portfolio.update_mark(bar.instrument_id, bar.close)
+            # 3.5 ADR-0052：框架级持仓保护止损在 mark 更新后判定（与 live session 同点），
+            #     触发的保护性出场单进 pending，下一根 process_bar 撮合（不偷未来）。
+            if self._guard is not None:
+                self._guard.evaluate(bar)
             # 4. 发布 bar，触发 strategy.on_bar
             topic = (
                 f"data.bars.{bar.instrument_id.venue}."

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -146,6 +146,9 @@ class BacktestEngine:
         # open 防 look-ahead）。收尾按末根 close 兜底成交——close 是决策时已知价、非
         # look-ahead，且与 live runner 同根 close 撮合对齐，避免「末根触发 → 漏计 /
         # 持仓显示未平」的回测/live 不一致（CR #88）。只动保护性单，策略单不收盘强平。
+        # 限制：按 bars_list[-1] 的 instrument 收尾（沿用引擎「单 instrument per session」
+        # 契约）；多标的回测末端非末根 instrument 的保护单不在此 flush——多标的支持是引擎
+        # 层整体未做项（CR #88 medium，与引擎多标的化一并推进，非本闸单独修）。
         if self._guard is not None and bars_list:
             if self.exchange.flush_protective_at_close(bars_list[-1]) > 0:
                 # 兜底平仓改变了持仓/现金（差一笔手续费），重记末点权益

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -139,6 +139,11 @@ class BacktestEngine:
             self.portfolio.update_mark(bar.instrument_id, bar.close)
             # 3.5 ADR-0052：框架级持仓保护止损在 mark 更新后判定（与 live session 同点），
             #     触发的保护性出场单进 pending，下一根 process_bar 撮合（不偷未来）。
+            #     已知限制（CR #88，仅显式传 rules 的回测受影响、生产 runner rules=None 不触达、
+            #     live 顺序路由不受影响）：guard 的 SELL 在 bar N 仅入 pending、bar N+1 才成交，
+            #     故同一 bar 内策略经 RiskEngine 提交的 BUY 看不到这次平仓 → CooldownRule 等
+            #     基于 closed_trades 的锁在该时间窗查不到记录，可能放过同 bar 重入单（"止损后
+            #     不回场"在此窗失效）。要严格联动 rules，用 live 路径（顺序路由先确认 guard 成交）。
             if self._guard is not None:
                 self._guard.evaluate(bar)
             # 4. 发布 bar，触发 strategy.on_bar

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -142,6 +142,15 @@ class BacktestEngine:
 
             self._num_bars += 1
 
+        # ADR-0052：末根 bar 触发的保护性出场单没有下一根可撮合（process_bar 用 next-bar
+        # open 防 look-ahead）。收尾按末根 close 兜底成交——close 是决策时已知价、非
+        # look-ahead，且与 live runner 同根 close 撮合对齐，避免「末根触发 → 漏计 /
+        # 持仓显示未平」的回测/live 不一致（CR #88）。只动保护性单，策略单不收盘强平。
+        if self._guard is not None and bars_list:
+            if self.exchange.flush_protective_at_close(bars_list[-1]) > 0:
+                # 兜底平仓改变了持仓/现金（差一笔手续费），重记末点权益
+                self.portfolio.snapshot(bars_list[-1].ts_event)
+
         for s in self._strategies:
             s.on_stop()
 

--- a/services/paper/src/inalpha_paper/engine/live_session.py
+++ b/services/paper/src/inalpha_paper/engine/live_session.py
@@ -33,6 +33,7 @@ from ..model.data import Bar
 from ..model.orders import Order, OrderSide, OrderType
 from ..strategy.base import RISK_ENGINE_ENDPOINT, Strategy
 from .portfolio import Portfolio
+from .position_guard import PositionGuard
 
 
 class _CaptureGateway(Gateway):
@@ -112,6 +113,9 @@ class LiveEngineSession:
         params: dict[str, Any],
         initial_cash: float,
         fee_rate: float,
+        protective_stop_loss_pct: float | None = None,
+        protective_take_profit_pct: float | None = None,
+        protective_trailing_stop_pct: float | None = None,
     ) -> None:
         self.clock = TestClock(0)
         self.msgbus = MessageBus()
@@ -128,6 +132,20 @@ class LiveEngineSession:
         self._initial_cash = initial_cash
         self._strategy = self._build_strategy(strategy_cls, params, initial_cash)
         self._strategy.on_start()  # 策略在此订阅 bars（subscribe_bars）
+
+        # ADR-0052：框架级持仓保护止损（与回测引擎共用同一组件，行为一致）。三阈值全
+        # None → None（退化为无 guard）。出场单直发 ExecutionEngine → 被 _CaptureGateway
+        # 收走，与策略单一起由 runner 走护栏 plan/exec 路由（runner 对保护性 tag 跳过开仓闸）。
+        self._guard = PositionGuard.from_thresholds(
+            self.msgbus,
+            self.clock,
+            self.portfolio,
+            stop_loss_pct=protective_stop_loss_pct,
+            take_profit_pct=protective_take_profit_pct,
+            trailing_stop_pct=protective_trailing_stop_pct,
+        )
+        if self._guard is not None:
+            self._guard.bind_strategy(self._strategy.strategy_id)
 
     # ─── 内部组装 ───
 
@@ -166,6 +184,10 @@ class LiveEngineSession:
         if bar.ts_event > self.clock.now_ns():
             self.clock.set_time(bar.ts_event)
         self.portfolio.update_mark(bar.instrument_id, bar.close)
+        # ADR-0052：框架级持仓保护止损在 mark 更新后判定（与回测引擎同点）；保护性出场单
+        # 被 _CaptureGateway 收走，与策略单一起在下方 take_collected 返回给 runner 路由。
+        if self._guard is not None:
+            self._guard.evaluate(bar)
         topic = (
             f"data.bars.{bar.instrument_id.venue}."
             f"{bar.instrument_id.symbol}.{bar.timeframe}"

--- a/services/paper/src/inalpha_paper/engine/live_session.py
+++ b/services/paper/src/inalpha_paper/engine/live_session.py
@@ -263,6 +263,11 @@ class LiveEngineSession:
         局限：策略若用非标准内部 flag（不订阅 position/fill 事件）跟踪持仓，无法还原其
         私有状态——但 Inalpha 契约 / 模板引导走 position/fill hook，主流策略可正确续跑。
         ``quantity_signed == 0`` 时 no-op。
+
+        **PositionGuard 移动止损 resume 限制（CR #88 medium）**：resume 不还原 guard 的
+        ``_peak_mark``（历史峰值价 DB 没存），续跑后峰值从首根 bar 的 close 重新起算。若
+        崩溃前价格曾远高于续跑价，``trailing_stop`` 触发会延迟（按续跑后新峰值算回撤）。
+        硬止损 / 止盈不受影响（按 avg 算，avg 已还原）；且 ``trailing`` 默认关，影响面小。
         """
         if quantity_signed == 0:
             return

--- a/services/paper/src/inalpha_paper/engine/portfolio.py
+++ b/services/paper/src/inalpha_paper/engine/portfolio.py
@@ -20,7 +20,7 @@ from uuid import UUID
 from ..kernel.identifiers import InstrumentId
 from ..kernel.msgbus import MessageBus
 from ..model.events import OrderFilled, PositionChanged, PositionClosed, PositionOpened
-from ..model.orders import OrderSide
+from ..model.orders import OrderSide, is_protective_signature
 from ..model.positions import Position
 from .close_detector import ClosedTradeStaging, detect_close
 from .report import FillRecord
@@ -262,6 +262,10 @@ class Portfolio:
                 realized_pnl=pos.realized_pnl - prev_realized,
                 intent=intent,
                 tag=msg.tag,
+                # 三因子判定是否框架 guard 兜底出场（区分策略自带 stop_loss tag，CR #88）
+                is_guard=is_protective_signature(
+                    msg.side, msg.tag, msg.client_order_id
+                ),
             )
         )
 

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -36,12 +36,6 @@ if TYPE_CHECKING:
     from ..kernel.clock import Clock
     from .portfolio import Portfolio
 
-#: 保护性出场 tag 集合（与 closed_trades.exit_reason CHECK 集合、StoplossGuardRule 对齐）。
-#: live_runner 据此判定一笔单是否为框架兜底出场（跳过开仓闸 enforce）。
-PROTECTIVE_EXIT_TAGS: frozenset[str] = frozenset(
-    {"stop_loss", "take_profit", "trailing_stop_loss"}
-)
-
 
 class PositionGuard:
     """框架级持仓保护止损。被回测引擎与 live session 实例化。
@@ -108,11 +102,16 @@ class PositionGuard:
     def bind_strategy(self, strategy_id: StrategyId) -> None:
         """绑定所属策略 id。出场单用它提交，确保 on_position_closed 回到策略让其状态归零。
 
-        **单值（last-bind wins）**：沿用引擎契约「单 strategy 单 instrument per session」
-        （见 ``BacktestEngine`` / ``Portfolio`` docstring）。多策略场景下 guard 出场单会
-        全部归属最后 bind 的策略——多策略支持是引擎层整体未做项（CR #88 medium，非本闸单独
-        修，需与引擎多策略化一并推进）。
+        **单策略约束**：guard 只持一个 ``_strategy_id``。绑第二个不同策略会让保护性出场
+        归属错误（前策略状态不归零），故直接断言拒绝——多策略支持是引擎层整体未做项
+        （CR #88，需与引擎多策略化一并推进）。调用方 ``BacktestEngine.add_strategy`` 也已
+        在挂第二个策略时抛 RuntimeError，双层防呆。
         """
+        if self._strategy_id is not None and self._strategy_id != strategy_id:
+            raise RuntimeError(
+                "PositionGuard 只支持单策略：不能绑定第二个不同的 strategy_id"
+                f"（已绑 {self._strategy_id}，又试图绑 {strategy_id}）"
+            )
         self._strategy_id = strategy_id
 
     def evaluate(self, bar: Bar) -> list[Order]:

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -1,0 +1,183 @@
+"""``PositionGuard`` —— 框架级持仓保护止损（ADR-0052）。
+
+独立于策略 alpha 的**灾难性兜底**：每根 bar 在 ``update_mark`` 之后检查当前持仓的浮盈率，
+穿越阈值即提交全仓保护性出场单。**回测引擎与 live session 共用同一组件、同一阈值、挂在
+同一逻辑点**，保证"回测≠模拟盘"的行为一致（这正是它存在的理由）。
+
+设计要点（详 ADR-0052 §D2）：
+
+- **宽兜底,不是紧止损**：默认硬止损放宽（0.20），封尾部风险而非切正常波动；贴行情的
+  紧止损是策略层 alpha 的事，框架层只做灾难兜底。
+- **默认只做亏损侧**：硬止损默认开；移动止损 / 止盈默认关（封上行偏 alpha，会伤趋势）。
+- **不偷未来**：在 bar close 的 mark 判定，出场单**下一根 bar 撮合**（与策略下单同语义），
+  与 live 只能在收盘 bar 行动完全对齐。
+- **绕过开仓闸**：保护性出场直接走 ``EXECUTION_ENGINE_ENDPOINT``，**不经 RiskEngine**——
+  guard 本身就是风控，不该被"挡开仓"的锁拦住（回撤熔断中恰恰最需要它平仓）。live 路径
+  里 runner 对带保护性 tag 的单跳过 ``risk_guard.enforce``（仍保留 notional 硬上限）。
+- **与既有 RiskRule 组合**：出场打 ``tag``（stop_loss / take_profit / trailing_stop_loss）
+  经 ``close_detector`` → ``exit_reason``，自动喂给 StoplossGuard / Cooldown，天然实现
+  "止损后不立刻回场"，无需新建再入场抑制。
+
+局限：仅 spot long；short / 合约对称版留待后续（short 当前 no-op）。
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from ..execution.exchange import EXECUTION_ENGINE_ENDPOINT
+from ..kernel.identifiers import ClientOrderId, InstrumentId, StrategyId
+from ..kernel.msgbus import MessageBus
+from ..model.commands import SubmitOrderCommand
+from ..model.data import Bar
+from ..model.orders import Order, OrderSide, OrderType
+
+if TYPE_CHECKING:
+    from ..kernel.clock import Clock
+    from .portfolio import Portfolio
+
+#: 保护性出场 tag 集合（与 closed_trades.exit_reason CHECK 集合、StoplossGuardRule 对齐）。
+#: live_runner 据此判定一笔单是否为框架兜底出场（跳过开仓闸 enforce）。
+PROTECTIVE_EXIT_TAGS: frozenset[str] = frozenset(
+    {"stop_loss", "take_profit", "trailing_stop_loss"}
+)
+
+
+class PositionGuard:
+    """框架级持仓保护止损。被回测引擎与 live session 实例化。
+
+    Args:
+        msgbus: 与所属引擎共享的 MessageBus
+        clock: 引擎时钟（出场单 ts_init 用）
+        portfolio: 引擎的 Portfolio（只读当前持仓 + avg_open_price）
+        stop_loss_pct: 单仓浮亏穿 ``-stop_loss_pct`` → 全平（None = 关）
+        take_profit_pct: 单仓浮盈穿 ``+take_profit_pct`` → 全平（None = 关）
+        trailing_stop_pct: 自峰值浮盈回撤 ``trailing_stop_pct`` → 全平（None = 关）
+    """
+
+    def __init__(
+        self,
+        msgbus: MessageBus,
+        clock: Clock,
+        portfolio: Portfolio,
+        *,
+        stop_loss_pct: float | None = None,
+        take_profit_pct: float | None = None,
+        trailing_stop_pct: float | None = None,
+    ) -> None:
+        for name, val in (
+            ("stop_loss_pct", stop_loss_pct),
+            ("take_profit_pct", take_profit_pct),
+            ("trailing_stop_pct", trailing_stop_pct),
+        ):
+            if val is not None and val <= 0:
+                raise ValueError(f"{name} must be positive or None, got {val}")
+
+        self._msgbus = msgbus
+        self._clock = clock
+        self._portfolio = portfolio
+        self._stop_loss_pct = stop_loss_pct
+        self._take_profit_pct = take_profit_pct
+        self._trailing_stop_pct = trailing_stop_pct
+        self._strategy_id: StrategyId | None = None
+        # 每 instrument 的峰值浮盈率（trailing 用）；持仓转 flat 时清除
+        self._peak_pct: dict[InstrumentId, float] = {}
+
+    @staticmethod
+    def from_thresholds(
+        msgbus: MessageBus,
+        clock: Clock,
+        portfolio: Portfolio,
+        *,
+        stop_loss_pct: float | None,
+        take_profit_pct: float | None,
+        trailing_stop_pct: float | None,
+    ) -> PositionGuard | None:
+        """工厂：三个阈值全为 None → 返 None（引擎据此退化为无 guard，向后兼容）。"""
+        if stop_loss_pct is None and take_profit_pct is None and trailing_stop_pct is None:
+            return None
+        return PositionGuard(
+            msgbus,
+            clock,
+            portfolio,
+            stop_loss_pct=stop_loss_pct,
+            take_profit_pct=take_profit_pct,
+            trailing_stop_pct=trailing_stop_pct,
+        )
+
+    def bind_strategy(self, strategy_id: StrategyId) -> None:
+        """绑定所属策略 id。出场单用它提交，确保 on_position_closed 回到策略让其状态归零。"""
+        self._strategy_id = strategy_id
+
+    def evaluate(self, bar: Bar) -> list[Order]:
+        """检查 ``bar`` 对应 instrument 的持仓；触发则提交保护性出场并返回该单（否则空 list）。
+
+        在引擎主循环 ``update_mark`` 之后调用，用 ``bar.close`` 作 mark。出场单经
+        ``EXECUTION_ENGINE_ENDPOINT`` 进入 pending，**下一根 bar 撮合**（不偷未来）。
+        """
+        if self._strategy_id is None:
+            return []
+
+        inst = bar.instrument_id
+        pos = self._portfolio.position(inst)
+        if pos is None or pos.is_flat:
+            self._peak_pct.pop(inst, None)
+            return []
+
+        # 仅 spot long；short 留待合约阶段（no-op，避免对 short 误平）
+        if pos.quantity <= 0:
+            return []
+
+        avg = pos.avg_open_price
+        if avg <= 0:
+            return []
+
+        mark = bar.close
+        pct = (mark - avg) / avg
+        peak = max(self._peak_pct.get(inst, pct), pct)
+        self._peak_pct[inst] = peak
+
+        tag = self._triggered_tag(pct, peak)
+        if tag is None:
+            return []
+
+        order = self._build_exit(inst, pos.quantity, tag)
+        self._submit(order, bar.ts_event)
+        # 出场单已下，清峰值（持仓将于下一根平掉；防同 instrument 状态泄漏）
+        self._peak_pct.pop(inst, None)
+        return [order]
+
+    # ─── 内部 ───
+
+    def _triggered_tag(self, pct: float, peak: float) -> str | None:
+        """按优先级判定触发的保护性 tag：硬止损 > 移动止损 > 止盈（None = 不触发）。"""
+        if self._stop_loss_pct is not None and pct <= -self._stop_loss_pct:
+            return "stop_loss"
+        if self._trailing_stop_pct is not None and (peak - pct) >= self._trailing_stop_pct:
+            return "trailing_stop_loss"
+        if self._take_profit_pct is not None and pct >= self._take_profit_pct:
+            return "take_profit"
+        return None
+
+    def _build_exit(self, inst: InstrumentId, quantity: float, tag: str) -> Order:
+        return Order(
+            client_order_id=ClientOrderId(f"guard-{inst.symbol}-{uuid4().hex[:8]}"),
+            instrument_id=inst,
+            side=OrderSide.SELL,  # spot long-only：平多 = 卖出
+            type=OrderType.MARKET,
+            quantity=quantity,
+            tag=tag,
+        )
+
+    def _submit(self, order: Order, ts_event: int) -> None:
+        # 直发 ExecutionEngine：绕过 in-process RiskEngine 的"挡开仓"锁——保护性平仓
+        # 必须能在回撤熔断锁期内执行（ADR-0052 §D4）。
+        assert self._strategy_id is not None  # evaluate 已守门
+        self._msgbus.send(
+            EXECUTION_ENGINE_ENDPOINT,
+            SubmitOrderCommand(
+                order=order,
+                strategy_id=self._strategy_id,
+                ts_init=ts_event,
+            ),
+        )

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -30,7 +30,7 @@ from ..kernel.identifiers import ClientOrderId, InstrumentId, StrategyId
 from ..kernel.msgbus import MessageBus
 from ..model.commands import SubmitOrderCommand
 from ..model.data import Bar
-from ..model.orders import Order, OrderSide, OrderType
+from ..model.orders import GUARD_ORDER_PREFIX, Order, OrderSide, OrderType
 
 if TYPE_CHECKING:
     from ..kernel.clock import Clock
@@ -177,7 +177,8 @@ class PositionGuard:
 
     def _build_exit(self, inst: InstrumentId, quantity: float, tag: str) -> Order:
         return Order(
-            client_order_id=ClientOrderId(f"guard-{inst.symbol}-{uuid4().hex[:8]}"),
+            # GUARD_ORDER_PREFIX 是风控豁免的「不可仿冒」第二因子（见 is_protective_order）
+            client_order_id=ClientOrderId(f"{GUARD_ORDER_PREFIX}{inst.symbol}-{uuid4().hex[:8]}"),
             instrument_id=inst,
             side=OrderSide.SELL,  # spot long-only：平多 = 卖出
             type=OrderType.MARKET,

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -80,8 +80,8 @@ class PositionGuard:
         self._take_profit_pct = take_profit_pct
         self._trailing_stop_pct = trailing_stop_pct
         self._strategy_id: StrategyId | None = None
-        # 每 instrument 的峰值浮盈率（trailing 用）；持仓转 flat 时清除
-        self._peak_pct: dict[InstrumentId, float] = {}
+        # 每 instrument 的峰值 mark 价（trailing 用，自峰值价格回撤口径）；持仓转 flat 时清除
+        self._peak_mark: dict[InstrumentId, float] = {}
 
     @staticmethod
     def from_thresholds(
@@ -121,7 +121,7 @@ class PositionGuard:
         inst = bar.instrument_id
         pos = self._portfolio.position(inst)
         if pos is None or pos.is_flat:
-            self._peak_pct.pop(inst, None)
+            self._peak_mark.pop(inst, None)
             return []
 
         # 仅 spot long；short 留待合约阶段（no-op，避免对 short 误平）
@@ -134,26 +134,37 @@ class PositionGuard:
 
         mark = bar.close
         pct = (mark - avg) / avg
-        peak = max(self._peak_pct.get(inst, pct), pct)
-        self._peak_pct[inst] = peak
+        # trailing 用「自峰值价格的回撤」口径（不是自成本基准的收益率降幅）：避免大盈利下
+        # 触发远比 trailing_stop_pct 直觉更激进（CR #88 medium）。峰值价跟 mark 走。
+        peak_mark = max(self._peak_mark.get(inst, mark), mark)
+        self._peak_mark[inst] = peak_mark
 
-        tag = self._triggered_tag(pct, peak)
+        tag = self._triggered_tag(pct, mark, peak_mark, avg)
         if tag is None:
             return []
 
         order = self._build_exit(inst, pos.quantity, tag)
         self._submit(order, bar.ts_event)
         # 出场单已下，清峰值（持仓将于下一根平掉；防同 instrument 状态泄漏）
-        self._peak_pct.pop(inst, None)
+        self._peak_mark.pop(inst, None)
         return [order]
 
     # ─── 内部 ───
 
-    def _triggered_tag(self, pct: float, peak: float) -> str | None:
+    def _triggered_tag(
+        self, pct: float, mark: float, peak_mark: float, avg: float
+    ) -> str | None:
         """按优先级判定触发的保护性 tag：硬止损 > 移动止损 > 止盈（None = 不触发）。"""
         if self._stop_loss_pct is not None and pct <= -self._stop_loss_pct:
             return "stop_loss"
-        if self._trailing_stop_pct is not None and (peak - pct) >= self._trailing_stop_pct:
+        # 移动止损：仅在仓位「曾进入盈利区」（峰值价 > 成本）后才生效——锁的是已有利润；
+        # 用自峰值价格的回撤幅度判定（peak_mark - mark) / peak_mark），不掺成本基准。
+        if (
+            self._trailing_stop_pct is not None
+            and peak_mark > avg
+            and peak_mark > 0
+            and (peak_mark - mark) / peak_mark >= self._trailing_stop_pct
+        ):
             return "trailing_stop_loss"
         if self._take_profit_pct is not None and pct >= self._take_profit_pct:
             return "take_profit"

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -106,7 +106,13 @@ class PositionGuard:
         )
 
     def bind_strategy(self, strategy_id: StrategyId) -> None:
-        """绑定所属策略 id。出场单用它提交，确保 on_position_closed 回到策略让其状态归零。"""
+        """绑定所属策略 id。出场单用它提交，确保 on_position_closed 回到策略让其状态归零。
+
+        **单值（last-bind wins）**：沿用引擎契约「单 strategy 单 instrument per session」
+        （见 ``BacktestEngine`` / ``Portfolio`` docstring）。多策略场景下 guard 出场单会
+        全部归属最后 bind 的策略——多策略支持是引擎层整体未做项（CR #88 medium，非本闸单独
+        修，需与引擎多策略化一并推进）。
+        """
         self._strategy_id = strategy_id
 
     def evaluate(self, bar: Bar) -> list[Order]:

--- a/services/paper/src/inalpha_paper/engine/report.py
+++ b/services/paper/src/inalpha_paper/engine/report.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 
 from ..kernel.clock import datetime_to_ns
 from ..kernel.identifiers import InstrumentId
-from ..model.orders import PROTECTIVE_EXIT_TAGS, OrderSide
+from ..model.orders import OrderSide
 from ..model.positions import Position
 from . import metrics
 
@@ -54,6 +54,9 @@ class FillRecord:
     realized_pnl: float
     intent: str | None = None
     tag: str | None = None
+    #: ADR-0052/CR #88：本笔是否为框架 PositionGuard 兜底出场（三因子 is_protective_signature
+    #: 判定）。与 ``tag`` 区分——策略也能自打 tag="stop_loss"，只有这个 bool 才真代表框架触发。
+    is_guard: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,7 +163,8 @@ class BacktestReport:
         max_dd = metrics.max_drawdown_pct(equity_values)
         trade_pnls = portfolio.closed_trade_pnls
         fills = list(portfolio.fills)
-        protective_exits = sum(1 for f in fills if f.tag in PROTECTIVE_EXIT_TAGS)
+        # 只数框架 guard 兜底出场（f.is_guard），不混入策略自带 stop_loss tag（CR #88 major）
+        protective_exits = sum(1 for f in fills if f.is_guard)
         # exposure 用回测窗口端点（datetime → ns,整数路径:float 对 2026 时间戳
         # 丢 ~100ns,会与 fill.ts_ns 的整数路径错位）;缺端点时为 None。
         start_ns = datetime_to_ns(period_start) if period_start else None

--- a/services/paper/src/inalpha_paper/engine/report.py
+++ b/services/paper/src/inalpha_paper/engine/report.py
@@ -24,10 +24,9 @@ from typing import TYPE_CHECKING
 
 from ..kernel.clock import datetime_to_ns
 from ..kernel.identifiers import InstrumentId
-from ..model.orders import OrderSide
+from ..model.orders import PROTECTIVE_EXIT_TAGS, OrderSide
 from ..model.positions import Position
 from . import metrics
-from .position_guard import PROTECTIVE_EXIT_TAGS
 
 if TYPE_CHECKING:
     from .portfolio import Portfolio

--- a/services/paper/src/inalpha_paper/engine/report.py
+++ b/services/paper/src/inalpha_paper/engine/report.py
@@ -27,6 +27,7 @@ from ..kernel.identifiers import InstrumentId
 from ..model.orders import OrderSide
 from ..model.positions import Position
 from . import metrics
+from .position_guard import PROTECTIVE_EXIT_TAGS
 
 if TYPE_CHECKING:
     from .portfolio import Portfolio
@@ -107,6 +108,10 @@ class BacktestReport:
     exposure_pct: float | None = None
     #: 逐笔成交（含每笔实现盈亏），落 ``backtest_trades`` 表用
     fills: list[FillRecord] = field(default_factory=list)
+    #: ADR-0052：框架级持仓保护止损触发的出场笔数（tag ∈ stop_loss/take_profit/
+    #: trailing_stop_loss）。> 0 表示回测期间灾难兜底生效过几次——agent / 前端可据此
+    #: 看到"如果未来这样跑，框架会在哪些点止血"，把回测对未来的兜底可见化。
+    protective_exits: int = 0
     #: 账户是否"穿仓"——任意时点 equity 跌破 -1% × initial_cash（物理上 spot
     #: 账户 equity 不应 < 0）。True 表示本次回测结果在物理上不可信，agent /
     #: 前端应当显式警告，不要直接渲染 Sharpe / 收益率（数学正确但语义无效）。
@@ -156,6 +161,7 @@ class BacktestReport:
         max_dd = metrics.max_drawdown_pct(equity_values)
         trade_pnls = portfolio.closed_trade_pnls
         fills = list(portfolio.fills)
+        protective_exits = sum(1 for f in fills if f.tag in PROTECTIVE_EXIT_TAGS)
         # exposure 用回测窗口端点（datetime → ns,整数路径:float 对 2026 时间戳
         # 丢 ~100ns,会与 fill.ts_ns 的整数路径错位）;缺端点时为 None。
         start_ns = datetime_to_ns(period_start) if period_start else None
@@ -199,6 +205,7 @@ class BacktestReport:
                 equity_values
             ),
             exposure_pct=metrics.exposure_pct(fill_events, start_ns, end_ns),
+            protective_exits=protective_exits,
             blew_up=blew_up,
             health_warnings=warnings,
         )

--- a/services/paper/src/inalpha_paper/execution/exchange.py
+++ b/services/paper/src/inalpha_paper/execution/exchange.py
@@ -27,7 +27,7 @@ from ..kernel.clock import Clock
 from ..kernel.identifiers import ClientOrderId, StrategyId, VenueOrderId
 from ..kernel.msgbus import MessageBus
 from ..model.data import Bar
-from ..model.orders import Order, OrderSide, OrderType
+from ..model.orders import PROTECTIVE_EXIT_TAGS, Order, OrderSide, OrderType
 from .gateway import Gateway
 
 if TYPE_CHECKING:
@@ -147,9 +147,6 @@ class SimulatedExchange(Gateway):
 
         **只动保护性单**：策略单维持「不收盘强平」语义不变。返回成交笔数。
         """
-        # 局部 import 防 execution↔engine 环（position_guard 反向依赖本模块的 endpoint）
-        from ..engine.position_guard import PROTECTIVE_EXIT_TAGS
-
         filled_count = 0
         remaining: list[tuple[Order, StrategyId]] = []
         for order, strategy_id in self._pending:

--- a/services/paper/src/inalpha_paper/execution/exchange.py
+++ b/services/paper/src/inalpha_paper/execution/exchange.py
@@ -27,7 +27,7 @@ from ..kernel.clock import Clock
 from ..kernel.identifiers import ClientOrderId, StrategyId, VenueOrderId
 from ..kernel.msgbus import MessageBus
 from ..model.data import Bar
-from ..model.orders import PROTECTIVE_EXIT_TAGS, Order, OrderSide, OrderType
+from ..model.orders import Order, OrderSide, OrderType, is_protective_order
 from .gateway import Gateway
 
 if TYPE_CHECKING:
@@ -150,7 +150,7 @@ class SimulatedExchange(Gateway):
         filled_count = 0
         remaining: list[tuple[Order, StrategyId]] = []
         for order, strategy_id in self._pending:
-            if order.instrument_id != bar.instrument_id or order.tag not in PROTECTIVE_EXIT_TAGS:
+            if order.instrument_id != bar.instrument_id or not is_protective_order(order):
                 remaining.append((order, strategy_id))
                 continue
             # spot 守门：SELL 平仓量不应超过持仓（保护性单按全仓发，正常恒满足）

--- a/services/paper/src/inalpha_paper/execution/exchange.py
+++ b/services/paper/src/inalpha_paper/execution/exchange.py
@@ -130,26 +130,70 @@ class SimulatedExchange(Gateway):
                 continue
 
             fill_qty, fill_price = fill
-            trade_id = f"trade-{self._next_id}"
-            self._next_id += 1
-
-            self._msgbus.publish(
-                "internal.venue.filled",
-                {
-                    "client_order_id": order.client_order_id,
-                    "strategy_id": strategy_id,
-                    "instrument_id": order.instrument_id,
-                    "side": order.side,
-                    "fill_qty": fill_qty,
-                    "fill_price": fill_price,
-                    "trade_id": trade_id,
-                    "ts": bar.ts_event,
-                },
-            )
+            self._publish_fill(order, strategy_id, fill_qty, fill_price, bar.ts_event)
             filled_count += 1
 
         self._pending = remaining
         return filled_count
+
+    def flush_protective_at_close(self, bar: Bar) -> int:
+        """收尾兜底：对仍 pending 的【保护性出场单】按 ``bar.close`` 成交（ADR-0052）。
+
+        保护性出场（stop_loss / take_profit / trailing_stop_loss）是框架兜底——末根
+        触发时没有下一根可撮合（``_try_fill`` 用 next-bar open 避免 look-ahead）。在此
+        按**决策那根的 close** 成交：close 是决策时已知价，非 look-ahead，且与 live
+        runner「同根按 bar.close 撮合」同口径，修掉「末根触发 → backtest 漏计 / 持仓
+        显示未平」的回测/live 不一致（CR #88 medium）。
+
+        **只动保护性单**：策略单维持「不收盘强平」语义不变。返回成交笔数。
+        """
+        # 局部 import 防 execution↔engine 环（position_guard 反向依赖本模块的 endpoint）
+        from ..engine.position_guard import PROTECTIVE_EXIT_TAGS
+
+        filled_count = 0
+        remaining: list[tuple[Order, StrategyId]] = []
+        for order, strategy_id in self._pending:
+            if order.instrument_id != bar.instrument_id or order.tag not in PROTECTIVE_EXIT_TAGS:
+                remaining.append((order, strategy_id))
+                continue
+            # spot 守门：SELL 平仓量不应超过持仓（保护性单按全仓发，正常恒满足）
+            if (
+                self._portfolio is not None
+                and order.side == OrderSide.SELL
+                and not self._portfolio.can_afford_sell(order.instrument_id, order.quantity)
+            ):
+                remaining.append((order, strategy_id))
+                continue
+            self._publish_fill(order, strategy_id, order.quantity, bar.close, bar.ts_event)
+            filled_count += 1
+
+        self._pending = remaining
+        return filled_count
+
+    def _publish_fill(
+        self,
+        order: Order,
+        strategy_id: StrategyId,
+        fill_qty: float,
+        fill_price: float,
+        ts_event: int,
+    ) -> None:
+        """发 ``internal.venue.filled`` → ExecutionEngine → Portfolio / 策略。"""
+        trade_id = f"trade-{self._next_id}"
+        self._next_id += 1
+        self._msgbus.publish(
+            "internal.venue.filled",
+            {
+                "client_order_id": order.client_order_id,
+                "strategy_id": strategy_id,
+                "instrument_id": order.instrument_id,
+                "side": order.side,
+                "fill_qty": fill_qty,
+                "fill_price": fill_price,
+                "trade_id": trade_id,
+                "ts": ts_event,
+            },
+        )
 
     def pending_count(self) -> int:
         return len(self._pending)

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -597,12 +597,21 @@ class LiveRunnerManager:
         # 措辞「触发 N 个信号（待撮合）」：此处 orders 是策略意图、尚未过风控/撮合，
         # 后续可能被 risk_rejected 全拦——不写「产生 N 个下单意图」以免与最终无成交割裂（CR）。
         if orders:
+            # 区分策略信号 vs 框架 guard 兜底出场（CR #88 medium）：混算会让运维误以为
+            # 策略产生了信号，实则可能是 guard 触发止损/止盈。
+            guard_n = sum(1 for o, _ in orders if is_protective_order(o))
+            strat_n = len(orders) - guard_n
+            parts = []
+            if strat_n:
+                parts.append(f"策略触发 {strat_n} 个信号")
+            if guard_n:
+                parts.append(f"框架 guard 触发 {guard_n} 个保护性出场")
             try:
                 async with get_conn() as conn:
                     await runs_store.append_log(
                         conn, run["id"], "info",
                         f"bar {_ns_to_dt(bar.ts_event):%Y-%m-%d %H:%M} · "
-                        f"策略触发 {len(orders)} 个信号（待撮合）",
+                        f"{' + '.join(parts)}（待撮合）",
                     )
             except Exception:
                 _logger.exception("live run %s: 写出单日志失败", run["id"])

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -29,7 +29,6 @@ from inalpha_shared.errors import ConflictError, InalphaError
 from .config import PaperSettings
 from .data_client import DataClient
 from .engine.live_session import LiveEngineSession
-from .engine.position_guard import PROTECTIVE_EXIT_TAGS
 from .execution import risk_guard as risk_guard_mod
 from .execution.currency_resolver import resolve_currency
 from .execution.order_executor import OrderExecutor
@@ -39,7 +38,7 @@ from .fills import apply_fill_to_positions_and_cash
 from .fx import BaseCurrencyConverter, needs_network
 from .kernel.identifiers import InstrumentId, StrategyId
 from .model.data import Bar
-from .model.orders import Order
+from .model.orders import PROTECTIVE_EXIT_TAGS, Order
 from .runner import _bar_from_dict
 from .storage import accounts as accounts_store
 from .storage import closed_trades as closed_trades_store

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -29,6 +29,7 @@ from inalpha_shared.errors import ConflictError, InalphaError
 from .config import PaperSettings
 from .data_client import DataClient
 from .engine.live_session import LiveEngineSession
+from .engine.position_guard import PROTECTIVE_EXIT_TAGS
 from .execution import risk_guard as risk_guard_mod
 from .execution.currency_resolver import resolve_currency
 from .execution.order_executor import OrderExecutor
@@ -461,6 +462,10 @@ class LiveRunnerManager:
             params=run.get("params") or {},
             initial_cash=_LIVE_INITIAL_CASH,
             fee_rate=_FEE_RATE,
+            # ADR-0052：框架级持仓保护止损（与回测共用同一阈值，行为一致）
+            protective_stop_loss_pct=self._settings.protective_stop_loss_pct,
+            protective_take_profit_pct=self._settings.protective_take_profit_pct,
+            protective_trailing_stop_pct=self._settings.protective_trailing_stop_pct,
         )
         warmup_ts = await self._warmup_session(session, run)
         # resume（last_bar_ts 非空 = 本 run 之前跑过）：把 DB 当前持仓灌回 session，让续跑
@@ -751,14 +756,20 @@ class LiveRunnerManager:
         # 1. 风控；命中 → 拒单 + 记 error_log，不杀 run。两道闸门同 except 处理：
         #    (a) 单笔 notional 硬上限（无状态，挡策略算错 quantity 的超大单，issue #42）；
         #    (b) DB-backed RiskGuard 行为型锁规则（drawdown / cooldown / ...）。
+        # ADR-0052：框架级保护性出场（stop_loss / take_profit / trailing_stop_loss）跳过
+        # "挡开仓"的行为型锁——回撤熔断锁期内恰恰最需要它平仓；guard 本身就是风控，不该
+        # 被开仓闸拦住。notional 硬上限仍保留（防 quantity 算错的超大单）。
+        is_protective_exit = order.tag in PROTECTIVE_EXIT_TAGS
         try:
             risk_guard_mod.check_order_notional(
                 self._factory, quantity=order.quantity, ref_price=float(bar.close),
                 venue=venue, symbol=symbol,
             )
-            await risk_guard_mod.enforce(
-                self._factory, account_id=account_id, venue=venue, symbol=symbol, side=side
-            )
+            if not is_protective_exit:
+                await risk_guard_mod.enforce(
+                    self._factory, account_id=account_id, venue=venue, symbol=symbol,
+                    side=side,
+                )
         except ConflictError as e:
             session.reject_order(
                 order=order, strategy_id=strategy_id,

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -38,7 +38,7 @@ from .fills import apply_fill_to_positions_and_cash
 from .fx import BaseCurrencyConverter, needs_network
 from .kernel.identifiers import InstrumentId, StrategyId
 from .model.data import Bar
-from .model.orders import PROTECTIVE_EXIT_TAGS, Order
+from .model.orders import Order, is_protective_order
 from .runner import _bar_from_dict
 from .storage import accounts as accounts_store
 from .storage import closed_trades as closed_trades_store
@@ -760,7 +760,9 @@ class LiveRunnerManager:
         # 仓）；② notional 硬上限（CR #88 major：保护性 SELL 量=实际持仓，价涨/累积建仓后仓位
         # notional 必然超单笔买入上限；若也卡 notional → 止损被静默拒 → 持仓不动 → 每根 bar
         # 重试又被拒 → 止损形同虚设。notional 上限是防"胖手指"超大开仓单，平实际持仓不属此列）。
-        is_protective_exit = order.tag in PROTECTIVE_EXIT_TAGS
+        # 双因子判定(tag + guard 专属 client_order_id 前缀)：策略代码可控 tag，单看 tag 会被
+        # 仿冒绕过风控（CR #88 major），故必须连 client_order_id 前缀一起校验。
+        is_protective_exit = is_protective_order(order)
         try:
             if not is_protective_exit:
                 risk_guard_mod.check_order_notional(

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -755,16 +755,18 @@ class LiveRunnerManager:
         # 1. 风控；命中 → 拒单 + 记 error_log，不杀 run。两道闸门同 except 处理：
         #    (a) 单笔 notional 硬上限（无状态，挡策略算错 quantity 的超大单，issue #42）；
         #    (b) DB-backed RiskGuard 行为型锁规则（drawdown / cooldown / ...）。
-        # ADR-0052：框架级保护性出场（stop_loss / take_profit / trailing_stop_loss）跳过
-        # "挡开仓"的行为型锁——回撤熔断锁期内恰恰最需要它平仓；guard 本身就是风控，不该
-        # 被开仓闸拦住。notional 硬上限仍保留（防 quantity 算错的超大单）。
+        # ADR-0052：框架级保护性出场（stop_loss / take_profit / trailing_stop_loss）**两道闸
+        # 全豁免**——guard 是风控兜底，必须能平仓：① 行为型锁（回撤熔断锁期内恰恰最需要它平
+        # 仓）；② notional 硬上限（CR #88 major：保护性 SELL 量=实际持仓，价涨/累积建仓后仓位
+        # notional 必然超单笔买入上限；若也卡 notional → 止损被静默拒 → 持仓不动 → 每根 bar
+        # 重试又被拒 → 止损形同虚设。notional 上限是防"胖手指"超大开仓单，平实际持仓不属此列）。
         is_protective_exit = order.tag in PROTECTIVE_EXIT_TAGS
         try:
-            risk_guard_mod.check_order_notional(
-                self._factory, quantity=order.quantity, ref_price=float(bar.close),
-                venue=venue, symbol=symbol,
-            )
             if not is_protective_exit:
+                risk_guard_mod.check_order_notional(
+                    self._factory, quantity=order.quantity, ref_price=float(bar.close),
+                    venue=venue, symbol=symbol,
+                )
                 await risk_guard_mod.enforce(
                     self._factory, account_id=account_id, venue=venue, symbol=symbol,
                     side=side,

--- a/services/paper/src/inalpha_paper/model/orders.py
+++ b/services/paper/src/inalpha_paper/model/orders.py
@@ -198,11 +198,14 @@ class Order:
 def is_protective_order(order: Order) -> bool:
     """是否为 ``PositionGuard`` 框架兜底出场单（享风控豁免：跳过开仓闸 + notional 上限）。
 
-    **双因子判定**（ADR-0052 / CR #88 major）：``tag`` ∈ ``PROTECTIVE_EXIT_TAGS`` **且**
-    ``client_order_id`` 以 ``GUARD_ORDER_PREFIX`` 开头。单看 tag 不够——策略代码能自由设
-    ``Order(tag="stop_loss")`` 仿冒以绕过风控；guard 出场单的 client_order_id 由框架按
-    ``GUARD_ORDER_PREFIX`` 生成，二者同时满足才认定为框架兜底单。
+    **三因子判定**（ADR-0052 / CR #88 major）：① ``side == SELL``（guard 只做 spot 多头
+    平仓，永不生成 BUY）② ``tag`` ∈ ``PROTECTIVE_EXIT_TAGS`` ③ ``client_order_id`` 以
+    ``GUARD_ORDER_PREFIX`` 开头。三者缺一不可——策略代码能自由设 ``tag`` 与 ``client_order_id``
+    仿冒以绕过风控豁免；尤其 ``side`` 守门挡掉「双因子都伪造的 BUY 单借豁免下超大开仓单」
+    （只看 tag+前缀会放行任意 BUY，CR #88 major）。
     """
-    return order.tag in PROTECTIVE_EXIT_TAGS and str(
-        order.client_order_id
-    ).startswith(GUARD_ORDER_PREFIX)
+    return (
+        order.side == OrderSide.SELL
+        and order.tag in PROTECTIVE_EXIT_TAGS
+        and str(order.client_order_id).startswith(GUARD_ORDER_PREFIX)
+    )

--- a/services/paper/src/inalpha_paper/model/orders.py
+++ b/services/paper/src/inalpha_paper/model/orders.py
@@ -43,6 +43,14 @@ class OrderStatus(Enum):
     REJECTED = "REJECTED"
 
 
+#: 框架级保护性出场的 ``Order.tag`` 集合（ADR-0052）。放在 model 中立层：engine
+#: （PositionGuard）与 execution（SimulatedExchange）都引它，避免 engine↔execution
+#: 循环依赖（与下方 ``Order.tag`` 约定值同源）。
+PROTECTIVE_EXIT_TAGS: frozenset[str] = frozenset(
+    {"stop_loss", "take_profit", "trailing_stop_loss"}
+)
+
+
 # 合法转移表，违反抛 ``ValueError``
 _VALID_TRANSITIONS: dict[OrderStatus, set[OrderStatus]] = {
     OrderStatus.NEW: {OrderStatus.SUBMITTED, OrderStatus.REJECTED},

--- a/services/paper/src/inalpha_paper/model/orders.py
+++ b/services/paper/src/inalpha_paper/model/orders.py
@@ -50,6 +50,10 @@ PROTECTIVE_EXIT_TAGS: frozenset[str] = frozenset(
     {"stop_loss", "take_profit", "trailing_stop_loss"}
 )
 
+#: ``PositionGuard`` 出场单 ``client_order_id`` 的专属前缀。与 ``PROTECTIVE_EXIT_TAGS``
+#: 一起构成「不可仅靠 tag 仿冒」的双因子判定（见 ``is_protective_order``）。
+GUARD_ORDER_PREFIX = "guard-"
+
 
 # 合法转移表，违反抛 ``ValueError``
 _VALID_TRANSITIONS: dict[OrderStatus, set[OrderStatus]] = {
@@ -189,3 +193,16 @@ class Order:
         if reason:
             self.reason = reason
         self._transition(OrderStatus.CANCELED, ts)
+
+
+def is_protective_order(order: Order) -> bool:
+    """是否为 ``PositionGuard`` 框架兜底出场单（享风控豁免：跳过开仓闸 + notional 上限）。
+
+    **双因子判定**（ADR-0052 / CR #88 major）：``tag`` ∈ ``PROTECTIVE_EXIT_TAGS`` **且**
+    ``client_order_id`` 以 ``GUARD_ORDER_PREFIX`` 开头。单看 tag 不够——策略代码能自由设
+    ``Order(tag="stop_loss")`` 仿冒以绕过风控；guard 出场单的 client_order_id 由框架按
+    ``GUARD_ORDER_PREFIX`` 生成，二者同时满足才认定为框架兜底单。
+    """
+    return order.tag in PROTECTIVE_EXIT_TAGS and str(
+        order.client_order_id
+    ).startswith(GUARD_ORDER_PREFIX)

--- a/services/paper/src/inalpha_paper/model/orders.py
+++ b/services/paper/src/inalpha_paper/model/orders.py
@@ -195,17 +195,28 @@ class Order:
         self._transition(OrderStatus.CANCELED, ts)
 
 
+def is_protective_signature(
+    side: OrderSide, tag: str | None, client_order_id: object
+) -> bool:
+    """三因子判定原语：``side==SELL`` + ``tag`` ∈ ``PROTECTIVE_EXIT_TAGS`` + ``client_order_id``
+    以 ``GUARD_ORDER_PREFIX`` 开头。供 :func:`is_protective_order`（拿 Order）与成交侧
+    （Portfolio 拿 OrderFilled 字段，无 Order 对象）共用，避免重复逻辑。
+
+    **安全前提（CR #88 medium）**：三个字段策略代码均可自设，故这层判定**不是**对抗性防伪，
+    用途是把「框架 guard 出场」与「策略普通单 / 策略自带 stop_loss」区分开（给 guard 出场
+    风控豁免 + 单独计数）。真正防伪依赖**策略源码 AST 审计 + 运行隔离**（audit_strategy_code；
+    当前策略不在 runtime 沙箱内，是已知攻击面，待后续补沙箱时收口——见 ADR-0052）。
+    """
+    return (
+        side == OrderSide.SELL
+        and tag in PROTECTIVE_EXIT_TAGS
+        and str(client_order_id).startswith(GUARD_ORDER_PREFIX)
+    )
+
+
 def is_protective_order(order: Order) -> bool:
     """是否为 ``PositionGuard`` 框架兜底出场单（享风控豁免：跳过开仓闸 + notional 上限）。
 
-    **三因子判定**（ADR-0052 / CR #88 major）：① ``side == SELL``（guard 只做 spot 多头
-    平仓，永不生成 BUY）② ``tag`` ∈ ``PROTECTIVE_EXIT_TAGS`` ③ ``client_order_id`` 以
-    ``GUARD_ORDER_PREFIX`` 开头。三者缺一不可——策略代码能自由设 ``tag`` 与 ``client_order_id``
-    仿冒以绕过风控豁免；尤其 ``side`` 守门挡掉「双因子都伪造的 BUY 单借豁免下超大开仓单」
-    （只看 tag+前缀会放行任意 BUY，CR #88 major）。
+    见 :func:`is_protective_signature`（三因子判定 + 安全前提说明）。
     """
-    return (
-        order.side == OrderSide.SELL
-        and order.tag in PROTECTIVE_EXIT_TAGS
-        and str(order.client_order_id).startswith(GUARD_ORDER_PREFIX)
-    )
+    return is_protective_signature(order.side, order.tag, order.client_order_id)

--- a/services/paper/src/inalpha_paper/runner.py
+++ b/services/paper/src/inalpha_paper/runner.py
@@ -340,6 +340,7 @@ async def run_backtest(
         equity_curve=equity_points,
         blew_up=report.blew_up,
         health_warnings=list(report.health_warnings),
+        protective_exits=report.protective_exits,
         final_positions=final_positions,
         validation=validation,
     )

--- a/services/paper/src/inalpha_paper/runner.py
+++ b/services/paper/src/inalpha_paper/runner.py
@@ -21,6 +21,7 @@ from uuid import UUID
 from inalpha_shared.errors import NotFoundError, ValidationError
 from psycopg import AsyncConnection
 
+from .config import get_paper_settings
 from .data_client import DataClient
 from .engine.backtest import BacktestEngine
 from .engine.metrics import (
@@ -563,6 +564,10 @@ async def _run_engine(
     except RuntimeError:
         pool = None
 
+    # ADR-0052：从 Settings 解析框架级持仓保护止损阈值（main 进程读，传给子进程；
+    # 回测与 live 共用同一阈值，保证行为一致）。
+    sl, tp, ts = _protective_thresholds()
+
     if pool is None:
         # 兜底：同进程跑（不真正 CPU 并行，但函数语义一致）
         return run_engine_in_subprocess(
@@ -574,6 +579,9 @@ async def _run_engine(
             params=params,
             initial_cash=initial_cash,
             fee_rate=fee_rate,
+            protective_stop_loss_pct=sl,
+            protective_take_profit_pct=tp,
+            protective_trailing_stop_pct=ts,
         )
 
     loop = asyncio.get_running_loop()
@@ -588,8 +596,21 @@ async def _run_engine(
         params=params,
         initial_cash=initial_cash,
         fee_rate=fee_rate,
+        protective_stop_loss_pct=sl,
+        protective_take_profit_pct=tp,
+        protective_trailing_stop_pct=ts,
     )
     return await loop.run_in_executor(pool, fn)
+
+
+def _protective_thresholds() -> tuple[float | None, float | None, float | None]:
+    """从 Settings 读 ADR-0052 框架级持仓保护止损三阈值 ``(stop_loss, take_profit, trailing)``。"""
+    s = get_paper_settings()
+    return (
+        s.protective_stop_loss_pct,
+        s.protective_take_profit_pct,
+        s.protective_trailing_stop_pct,
+    )
 
 
 def _make_pool_call(
@@ -602,6 +623,9 @@ def _make_pool_call(
     initial_cash: float,
     fee_rate: float,
     candidate_code: str | None = None,
+    protective_stop_loss_pct: float | None = None,
+    protective_take_profit_pct: float | None = None,
+    protective_trailing_stop_pct: float | None = None,
 ) -> Any:
     """生成一个无参 callable，丢给 ``run_in_executor``。
 
@@ -620,6 +644,9 @@ def _make_pool_call(
         params=params,
         initial_cash=initial_cash,
         fee_rate=fee_rate,
+        protective_stop_loss_pct=protective_stop_loss_pct,
+        protective_take_profit_pct=protective_take_profit_pct,
+        protective_trailing_stop_pct=protective_trailing_stop_pct,
     )
 
 
@@ -633,6 +660,9 @@ def run_engine_in_subprocess(
     initial_cash: float,
     fee_rate: float,
     candidate_code: str | None = None,
+    protective_stop_loss_pct: float | None = None,
+    protective_take_profit_pct: float | None = None,
+    protective_trailing_stop_pct: float | None = None,
 ) -> BacktestReport:
     """**Top-level 函数 = 可 pickle**：实例化 engine + strategy + 跑 bars，返 ``BacktestReport``。
 
@@ -651,7 +681,15 @@ def run_engine_in_subprocess(
       （main 进程已审过；这里只走 load + contract，避免再次 AST 浪费 CPU）
     - 否则走内置 ``get_strategy_class(strategy_id)``
     """
-    engine = BacktestEngine(initial_cash=initial_cash, fee_rate=fee_rate)
+    # ADR-0052：框架级持仓保护止损阈值由 main 进程从 Settings 解析后传入（子进程不读
+    # Settings 单例，保持 picklable + 纯）。三阈值全 None → BacktestEngine 不建 guard。
+    engine = BacktestEngine(
+        initial_cash=initial_cash,
+        fee_rate=fee_rate,
+        protective_stop_loss_pct=protective_stop_loss_pct,
+        protective_take_profit_pct=protective_take_profit_pct,
+        protective_trailing_stop_pct=protective_trailing_stop_pct,
+    )
 
     if candidate_code is not None:
         strategy_cls = load_strategy_class(candidate_code)

--- a/services/paper/src/inalpha_paper/schemas.py
+++ b/services/paper/src/inalpha_paper/schemas.py
@@ -318,6 +318,12 @@ class BacktestResponse(BaseModel):
         default=None,
         description="round-trip 胜率（百分比）；无 round-trip 时为 null",
     )
+    protective_exits: int = Field(
+        default=0,
+        description="ADR-0052：本次回测框架级持仓保护止损触发的平仓笔数（tag ∈ "
+        "stop_loss/take_profit/trailing_stop_loss）。>0 说明灾难兜底生效过几次——回测如实"
+        "反映未来 live 也会有的兜底,agent 可据此向用户说明风险被框架封住了几次。",
+    )
     equity_curve: list[EquityPoint] = Field(
         default_factory=list,
         description="每根 bar 的 (ts, equity)；前端可直接画图",

--- a/services/paper/tests/test_backtest_e2e.py
+++ b/services/paper/tests/test_backtest_e2e.py
@@ -327,3 +327,34 @@ def test_live_session_protective_stop_matches_backtest() -> None:
     tags_off, final_qty_off = _drive_live_with_guard(bars, stop_loss_pct=None)
     assert tags_off == []
     assert final_qty_off > 0.0  # 仍持有
+
+
+def test_backtest_protective_stop_on_last_bar_settles_at_close() -> None:
+    """末根 bar 触发兜底也如实成交+计数(按末根 close 兜底平仓),与 live 对齐(CR #88)。
+
+    价格在最后一根才砸穿 -20%：常规 next-bar 撮合没有下一根,会漏计/显示未平；
+    收尾 flush_protective_at_close 按末根 close 兜底平仓修正。
+    """
+    # 买入持有到末根(第5根 idx=4)才跌到 -30%
+    bars = _gen_bars([100.0, 100.0, 100.0, 100.0, 70.0])
+    engine = BacktestEngine(
+        initial_cash=10_000.0, fee_rate=0.0, protective_stop_loss_pct=0.20
+    )
+    strat = BuyAndHoldStrategy(
+        name="bh",
+        clock=engine.clock,
+        msgbus=engine.msgbus,
+        instrument_id=_btc(),
+        timeframe="1h",
+        trade_size=1.0,
+    )
+    engine.add_strategy(strat)
+    report = engine.run(bars)
+
+    # 末根触发也计入、也平仓（修复前是 0 / 持有）
+    assert report.protective_exits == 1
+    stop_fills = [f for f in report.fills if f.tag == "stop_loss"]
+    assert len(stop_fills) == 1
+    assert stop_fills[0].fill_price == 70.0  # 按末根 close 兜底成交
+    pos = report.positions.get(_btc())
+    assert pos is None or pos.is_flat

--- a/services/paper/tests/test_backtest_e2e.py
+++ b/services/paper/tests/test_backtest_e2e.py
@@ -6,15 +6,25 @@
 from __future__ import annotations
 
 import math
+from uuid import uuid4
 
 from inalpha_paper.engine.backtest import BacktestEngine
 from inalpha_paper.engine.live_session import LiveEngineSession
 from inalpha_paper.engine.report import BacktestReport
-from inalpha_paper.kernel.identifiers import InstrumentId
+from inalpha_paper.kernel.clock import Clock
+from inalpha_paper.kernel.identifiers import ClientOrderId, InstrumentId
+from inalpha_paper.kernel.msgbus import MessageBus
 from inalpha_paper.model.data import Bar
-from inalpha_paper.model.orders import PROTECTIVE_EXIT_TAGS
+from inalpha_paper.model.events import PositionClosed, PositionOpened
+from inalpha_paper.model.orders import (
+    PROTECTIVE_EXIT_TAGS,
+    Order,
+    OrderSide,
+    OrderType,
+)
 from inalpha_paper.strategies.buy_and_hold import BuyAndHoldStrategy
 from inalpha_paper.strategies.sma_cross import SMACrossStrategy
+from inalpha_paper.strategy.base import Strategy
 
 
 def _btc() -> InstrumentId:
@@ -398,3 +408,77 @@ def test_no_guard_allows_multiple_strategies() -> None:
             instrument_id=_btc(), timeframe="1h", trade_size=1.0,
         )
     )
+
+
+class _StrategyStopLossStrat(Strategy):
+    """测试用：bar1 买入，bar3 用 tag='stop_loss' 卖出（普通 client_order_id，非 guard）。"""
+
+    def __init__(
+        self,
+        name: str,
+        clock: Clock,
+        msgbus: MessageBus,
+        instrument_id: InstrumentId,
+        timeframe: str = "1h",
+        trade_size: float = 1.0,
+        **_: object,
+    ) -> None:
+        super().__init__(name, clock, msgbus)
+        self._iid = instrument_id
+        self._tf = timeframe
+        self._size = trade_size
+        self._n = 0
+        self._is_long = False
+        self._open_qty = 0.0
+
+    def on_start(self) -> None:
+        self.subscribe_bars(self._iid, self._tf)
+
+    def on_bar(self, bar: Bar) -> None:
+        self._n += 1
+        if self._n == 1:
+            self.submit_order(Order(
+                client_order_id=ClientOrderId(f"mystrat-{uuid4().hex[:8]}"),
+                instrument_id=self._iid, side=OrderSide.BUY,
+                type=OrderType.MARKET, quantity=self._size,
+            ))
+        elif self._n == 3 and self._is_long:
+            self.submit_order(Order(
+                client_order_id=ClientOrderId(f"mystrat-{uuid4().hex[:8]}"),
+                instrument_id=self._iid, side=OrderSide.SELL,
+                type=OrderType.MARKET, quantity=self._open_qty, tag="stop_loss",
+            ))
+
+    def on_position_opened(self, event: PositionOpened) -> None:
+        self._is_long = True
+        self._open_qty = abs(event.quantity)
+
+    def on_position_closed(self, event: PositionClosed) -> None:
+        self._is_long = False
+
+
+def test_strategy_own_stop_loss_tag_not_counted_as_guard() -> None:
+    """CR #88 major 回归：策略自打 tag='stop_loss' 的平仓不计入 protective_exits。
+
+    protective_exits 只数框架 guard 兜底（is_guard），策略自带止损 tag（client_order_id 非
+    'guard-' 前缀）不算——否则 agent 会把策略止损误报成"框架止损"。
+    """
+    # 价格平稳，guard 不会触发；关掉 guard 也行，这里关掉以纯测策略 tag 计数
+    bars = _gen_bars([100.0, 100.0, 100.0, 100.0, 100.0])
+    engine = BacktestEngine(
+        initial_cash=10_000.0, fee_rate=0.0, protective_stop_loss_pct=None
+    )
+    engine.add_strategy(
+        _StrategyStopLossStrat(
+            name="s", clock=engine.clock, msgbus=engine.msgbus,
+            instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+        )
+    )
+    report = engine.run(bars)
+
+    # 策略确实平了一笔且打了 stop_loss tag
+    stop_fills = [f for f in report.fills if f.tag == "stop_loss"]
+    assert len(stop_fills) == 1
+    assert stop_fills[0].is_guard is False  # 关键：不是框架 guard
+    # 框架 guard 计数为 0（不被策略自带 tag 污染）
+    assert report.protective_exits == 0

--- a/services/paper/tests/test_backtest_e2e.py
+++ b/services/paper/tests/test_backtest_e2e.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 import math
 
 from inalpha_paper.engine.backtest import BacktestEngine
+from inalpha_paper.engine.live_session import LiveEngineSession
+from inalpha_paper.engine.position_guard import PROTECTIVE_EXIT_TAGS
 from inalpha_paper.engine.report import BacktestReport
 from inalpha_paper.kernel.identifiers import InstrumentId
 from inalpha_paper.model.data import Bar
+from inalpha_paper.strategies.buy_and_hold import BuyAndHoldStrategy
 from inalpha_paper.strategies.sma_cross import SMACrossStrategy
 
 
@@ -213,3 +216,114 @@ def test_empty_bars_raises() -> None:
 
     with pytest.raises(ValueError, match="at least one bar"):
         engine.run([])
+
+
+# ─── ADR-0052 · 框架级持仓保护止损（回测 + live session 一致性） ───
+
+# buy-and-hold 在 bar0 买入、价格平稳后跌至 -30%。
+# 回测：bar0 下单 → bar1 成交建仓 @100 → bar4 mark=70 触发 → bar5 成交平仓。
+# 末段价格恒 70，使两套引擎的"触发判定"落在同一根（bar4 mark=70 穿 -20%）。
+_CRASH_PRICES = [100.0, 100.0, 100.0, 100.0, 70.0, 70.0, 70.0]
+
+
+def _drive_live_with_guard(
+    bars: list[Bar], *, stop_loss_pct: float | None
+) -> tuple[list[str], float]:
+    """逐根喂 live session 并即时回灌成交（模拟 runner 同 bar 撮合）。
+
+    返回 ``(protective_exit_tags, final_signed_qty)``：所有保护性出场的 tag 列表
+    + 末态持仓带符号数量（0 = 已平）。
+    """
+    session = LiveEngineSession(
+        strategy_cls=BuyAndHoldStrategy,
+        instrument_id=_btc(),
+        timeframe="1h",
+        params={},
+        initial_cash=10_000.0,
+        fee_rate=0.0,
+        protective_stop_loss_pct=stop_loss_pct,
+    )
+    protective_tags: list[str] = []
+    for bar in bars:
+        orders = session.feed_bar(bar)
+        session.take_unsupported_orders()
+        for order, sid in orders:
+            if order.tag in PROTECTIVE_EXIT_TAGS:
+                protective_tags.append(order.tag)
+            # runner 在同一 bar 以 ref_price=bar.close 撮合并回灌成交
+            session.confirm_fill(
+                order=order,
+                strategy_id=sid,
+                fill_qty=order.quantity,
+                fill_price=bar.close,
+                ts_event=bar.ts_event,
+            )
+    pos = session.portfolio.position(_btc())
+    return protective_tags, (pos.quantity if pos is not None else 0.0)
+
+
+def test_backtest_protective_stop_loss_caps_position() -> None:
+    """回测：单仓浮亏穿 -20% → 框架兜底平仓（tag=stop_loss），末态空仓。"""
+    bars = _gen_bars(_CRASH_PRICES)
+    engine = BacktestEngine(
+        initial_cash=10_000.0, fee_rate=0.0, protective_stop_loss_pct=0.20
+    )
+    strat = BuyAndHoldStrategy(
+        name="bh",
+        clock=engine.clock,
+        msgbus=engine.msgbus,
+        instrument_id=_btc(),
+        timeframe="1h",
+        trade_size=1.0,
+    )
+    engine.add_strategy(strat)
+    report = engine.run(bars)
+
+    # 框架兜底触发恰好一次
+    assert report.protective_exits == 1
+    stop_fills = [f for f in report.fills if f.tag == "stop_loss"]
+    assert len(stop_fills) == 1
+    assert stop_fills[0].side == "SELL"
+    # 兜底已平仓 → 末态无持仓
+    pos = report.positions.get(_btc())
+    assert pos is None or pos.is_flat
+
+
+def test_backtest_without_guard_holds_through_crash() -> None:
+    """无 guard（阈值 None）：同样的崩盘里不平仓，末态仍持有 —— 对照组。"""
+    bars = _gen_bars(_CRASH_PRICES)
+    engine = BacktestEngine(
+        initial_cash=10_000.0, fee_rate=0.0, protective_stop_loss_pct=None
+    )
+    strat = BuyAndHoldStrategy(
+        name="bh",
+        clock=engine.clock,
+        msgbus=engine.msgbus,
+        instrument_id=_btc(),
+        timeframe="1h",
+        trade_size=1.0,
+    )
+    engine.add_strategy(strat)
+    report = engine.run(bars)
+
+    assert report.protective_exits == 0
+    # 没兜底 → 一路持有到结束
+    pos = report.positions.get(_btc())
+    assert pos is not None and not pos.is_flat
+
+
+def test_live_session_protective_stop_matches_backtest() -> None:
+    """live session 走 feed_bar 路径同样触发框架兜底，与回测同口径（tag=stop_loss、平仓）。
+
+    一致性核心：同一 PositionGuard 组件、同一阈值、挂两套引擎"update_mark 之后"的同一
+    逻辑点；末段价格恒 70 使触发判定落在同一根 bar，两边都产出 stop_loss 出场并平仓。
+    """
+    bars = _gen_bars(_CRASH_PRICES)
+    tags, final_qty = _drive_live_with_guard(bars, stop_loss_pct=0.20)
+    assert tags == ["stop_loss"]
+    assert final_qty == 0.0  # 已平仓
+
+    # 对照：无 guard 时 live 不平仓
+    tags_off, final_qty_off = _drive_live_with_guard(bars, stop_loss_pct=None)
+    assert tags_off == []
+    assert final_qty_off > 0.0  # 仍持有

--- a/services/paper/tests/test_backtest_e2e.py
+++ b/services/paper/tests/test_backtest_e2e.py
@@ -9,10 +9,10 @@ import math
 
 from inalpha_paper.engine.backtest import BacktestEngine
 from inalpha_paper.engine.live_session import LiveEngineSession
-from inalpha_paper.engine.position_guard import PROTECTIVE_EXIT_TAGS
 from inalpha_paper.engine.report import BacktestReport
 from inalpha_paper.kernel.identifiers import InstrumentId
 from inalpha_paper.model.data import Bar
+from inalpha_paper.model.orders import PROTECTIVE_EXIT_TAGS
 from inalpha_paper.strategies.buy_and_hold import BuyAndHoldStrategy
 from inalpha_paper.strategies.sma_cross import SMACrossStrategy
 
@@ -358,3 +358,43 @@ def test_backtest_protective_stop_on_last_bar_settles_at_close() -> None:
     assert stop_fills[0].fill_price == 70.0  # 按末根 close 兜底成交
     pos = report.positions.get(_btc())
     assert pos is None or pos.is_flat
+
+
+def test_guard_enabled_rejects_second_strategy() -> None:
+    """启用 guard 时挂第二个策略 → RuntimeError(单策略约束,CR #88)。"""
+    import pytest
+
+    engine = BacktestEngine(
+        initial_cash=10_000.0, fee_rate=0.0, protective_stop_loss_pct=0.20
+    )
+    engine.add_strategy(
+        BuyAndHoldStrategy(
+            name="a", clock=engine.clock, msgbus=engine.msgbus,
+            instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+        )
+    )
+    with pytest.raises(RuntimeError, match="只支持单策略"):
+        engine.add_strategy(
+            BuyAndHoldStrategy(
+                name="b", clock=engine.clock, msgbus=engine.msgbus,
+                instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+            )
+        )
+
+
+def test_no_guard_allows_multiple_strategies() -> None:
+    """未启用 guard(阈值全 None)时多策略仍可挂(不破坏既有能力)。"""
+    engine = BacktestEngine(initial_cash=10_000.0, fee_rate=0.0)
+    engine.add_strategy(
+        BuyAndHoldStrategy(
+            name="a", clock=engine.clock, msgbus=engine.msgbus,
+            instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+        )
+    )
+    # 第二个策略不报错
+    engine.add_strategy(
+        BuyAndHoldStrategy(
+            name="b", clock=engine.clock, msgbus=engine.msgbus,
+            instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+        )
+    )

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from inalpha_paper.engine.portfolio import Portfolio
-from inalpha_paper.engine.position_guard import PROTECTIVE_EXIT_TAGS, PositionGuard
+from inalpha_paper.engine.position_guard import PositionGuard
 from inalpha_paper.execution.exchange import EXECUTION_ENGINE_ENDPOINT
 from inalpha_paper.kernel.clock import TestClock
 from inalpha_paper.kernel.identifiers import ClientOrderId, InstrumentId, StrategyId
@@ -14,7 +14,7 @@ from inalpha_paper.kernel.msgbus import MessageBus
 from inalpha_paper.model.commands import SubmitOrderCommand
 from inalpha_paper.model.data import Bar
 from inalpha_paper.model.events import OrderFilled
-from inalpha_paper.model.orders import OrderSide, OrderType
+from inalpha_paper.model.orders import PROTECTIVE_EXIT_TAGS, OrderSide, OrderType
 
 _SID = StrategyId("test")
 
@@ -239,3 +239,16 @@ def test_no_strategy_bound_returns_empty() -> None:
     # 没 bind
     assert guard.evaluate(_bar(50.0)) == []
     assert captured == []
+
+
+def test_bind_strategy_rejects_second_strategy() -> None:
+    """单策略约束：绑第二个不同 strategy_id → RuntimeError(CR #88)。"""
+    import pytest
+
+    msgbus = MessageBus()
+    pf = Portfolio(msgbus, initial_cash=10_000.0)
+    guard = PositionGuard(msgbus, TestClock(0), pf, stop_loss_pct=0.20)
+    guard.bind_strategy(StrategyId("A"))
+    guard.bind_strategy(StrategyId("A"))  # 同 id 重复绑定 ok（幂等）
+    with pytest.raises(RuntimeError, match="只支持单策略"):
+        guard.bind_strategy(StrategyId("B"))

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -14,7 +14,13 @@ from inalpha_paper.kernel.msgbus import MessageBus
 from inalpha_paper.model.commands import SubmitOrderCommand
 from inalpha_paper.model.data import Bar
 from inalpha_paper.model.events import OrderFilled
-from inalpha_paper.model.orders import PROTECTIVE_EXIT_TAGS, OrderSide, OrderType
+from inalpha_paper.model.orders import (
+    PROTECTIVE_EXIT_TAGS,
+    Order,
+    OrderSide,
+    OrderType,
+    is_protective_order,
+)
 
 _SID = StrategyId("test")
 
@@ -252,3 +258,39 @@ def test_bind_strategy_rejects_second_strategy() -> None:
     guard.bind_strategy(StrategyId("A"))  # 同 id 重复绑定 ok（幂等）
     with pytest.raises(RuntimeError, match="只支持单策略"):
         guard.bind_strategy(StrategyId("B"))
+
+
+def _order(tag: str | None, coid: str) -> Order:
+    return Order(
+        client_order_id=ClientOrderId(coid),
+        instrument_id=_btc(),
+        side=OrderSide.SELL,
+        type=OrderType.MARKET,
+        quantity=1.0,
+        tag=tag,
+    )
+
+
+def test_is_protective_order_requires_tag_and_guard_prefix() -> None:
+    """CR #88 major 回归：风控豁免双因子判定，策略仅靠 tag 仿冒无法绕过。
+
+    - guard 真出场单（tag ∈ 保护集 + client_order_id 以 'guard-' 开头）→ True
+    - 策略仿冒（tag='stop_loss' 但普通 client_order_id）→ False（仍走风控闸）
+    - guard 前缀但非保护性 tag → False
+    """
+    # guard 真单
+    real = _order("stop_loss", "guard-BTC/USDT-abc123")
+    assert is_protective_order(real) is True
+    # 策略仿冒：只改 tag，client_order_id 仍是策略自己的命名
+    spoof = _order("stop_loss", "sma-BTC/USDT-deadbeef")
+    assert is_protective_order(spoof) is False
+    # 有 guard 前缀但 tag 不在保护集
+    not_protective = _order("signal", "guard-BTC/USDT-xyz")
+    assert is_protective_order(not_protective) is False
+    # guard 自己产的出场单恒满足（与生产构造一致）
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+    orders = guard.evaluate(_bar(70.0))
+    assert len(orders) == 1
+    assert is_protective_order(orders[0]) is True

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -1,0 +1,212 @@
+"""``PositionGuard`` 单测（ADR-0052 框架级持仓保护止损）。
+
+只测 guard 自身逻辑：给定持仓 + mark 序列，断言触发的 tag / 全平 / 峰值 / 关闭路径。
+出场单提交走 ``EXECUTION_ENGINE_ENDPOINT``，这里注册一个 capture endpoint 验证提交。
+"""
+from __future__ import annotations
+
+from inalpha_paper.engine.portfolio import Portfolio
+from inalpha_paper.engine.position_guard import PROTECTIVE_EXIT_TAGS, PositionGuard
+from inalpha_paper.execution.exchange import EXECUTION_ENGINE_ENDPOINT
+from inalpha_paper.kernel.clock import TestClock
+from inalpha_paper.kernel.identifiers import ClientOrderId, InstrumentId, StrategyId
+from inalpha_paper.kernel.msgbus import MessageBus
+from inalpha_paper.model.commands import SubmitOrderCommand
+from inalpha_paper.model.data import Bar
+from inalpha_paper.model.events import OrderFilled
+from inalpha_paper.model.orders import OrderSide, OrderType
+
+_SID = StrategyId("test")
+
+
+def _btc() -> InstrumentId:
+    return InstrumentId(symbol="BTC/USDT", venue="binance")
+
+
+def _bar(close: float, ts_ns: int = 1) -> Bar:
+    return Bar(
+        instrument_id=_btc(),
+        timeframe="1h",
+        open=close,
+        high=close,
+        low=close,
+        close=close,
+        volume=1.0,
+        ts_event=ts_ns,
+        ts_init=ts_ns,
+    )
+
+
+def _long_portfolio(msgbus: MessageBus, qty: float, avg_price: float) -> Portfolio:
+    """建一个持有 long 仓的 Portfolio（通过发一笔 BUY fill 走正常路径建仓）。"""
+    pf = Portfolio(msgbus, initial_cash=1_000_000.0, fee_rate=0.0)
+    fill = OrderFilled(
+        client_order_id=ClientOrderId("setup"),
+        strategy_id=_SID,
+        ts_event=0,
+        ts_init=0,
+        instrument_id=_btc(),
+        side=OrderSide.BUY,
+        fill_quantity=qty,
+        fill_price=avg_price,
+        is_last_fill=True,
+    )
+    msgbus.publish(f"events.fills.{_btc()}", fill)
+    pos = pf.position(_btc())
+    assert pos is not None and pos.quantity == qty and pos.avg_open_price == avg_price
+    return pf
+
+
+def _guard_with_capture(
+    pf: Portfolio,
+    msgbus: MessageBus,
+    **thresholds: float | None,
+) -> tuple[PositionGuard, list[SubmitOrderCommand]]:
+    """建 guard + 注册 EXECUTION_ENGINE_ENDPOINT capture，返回 (guard, captured cmds)。"""
+    captured: list[SubmitOrderCommand] = []
+    msgbus.register_endpoint(
+        EXECUTION_ENGINE_ENDPOINT,
+        lambda cmd: captured.append(cmd),  # type: ignore[arg-type, return-value]
+    )
+    guard = PositionGuard(msgbus, TestClock(0), pf, **thresholds)
+    guard.bind_strategy(_SID)
+    return guard, captured
+
+
+# ─── 硬止损 ───
+
+
+def test_stop_loss_triggers_full_close() -> None:
+    """浮亏穿 -stop_loss_pct → 一笔 SELL 全平，tag=stop_loss，并已提交到 EE。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=2.0, avg_price=100.0)
+    guard, captured = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+
+    # mark=79 → -21% 穿过 -20%
+    orders = guard.evaluate(_bar(79.0))
+
+    assert len(orders) == 1
+    order = orders[0]
+    assert order.side == OrderSide.SELL
+    assert order.type == OrderType.MARKET
+    assert order.quantity == 2.0  # 全平
+    assert order.tag == "stop_loss"
+    assert order.tag in PROTECTIVE_EXIT_TAGS
+    # 已提交到 ExecutionEngine endpoint（绕过 RiskEngine）
+    assert len(captured) == 1
+    assert captured[0].order.client_order_id == order.client_order_id
+    assert captured[0].strategy_id == _SID
+
+
+def test_stop_loss_not_triggered_above_threshold() -> None:
+    """浮亏未穿阈值 → 不触发。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, captured = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+
+    # mark=85 → -15%，未穿 -20%
+    assert guard.evaluate(_bar(85.0)) == []
+    assert captured == []
+
+
+# ─── 止盈 ───
+
+
+def test_take_profit_triggers() -> None:
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(pf, msgbus, take_profit_pct=0.30)
+
+    # mark=131 → +31% 穿过 +30%
+    orders = guard.evaluate(_bar(131.0))
+    assert len(orders) == 1
+    assert orders[0].tag == "take_profit"
+
+
+def test_take_profit_disabled_by_default_none() -> None:
+    """take_profit_pct=None → 上行不平仓。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+
+    assert guard.evaluate(_bar(200.0)) == []  # +100% 也不平（止盈关）
+
+
+# ─── 移动止损 ───
+
+
+def test_trailing_triggers_after_peak() -> None:
+    """先涨到峰值，再自峰值回撤 >= trailing_stop_pct → 触发 trailing_stop_loss。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(pf, msgbus, trailing_stop_pct=0.10)
+
+    # 第一根：mark=130（+30%）建立峰值，自身回撤 0 → 不触发
+    assert guard.evaluate(_bar(130.0, ts_ns=1)) == []
+    # 第二根：mark=115（+15%），自峰值 +30% 回撤 15% >= 10% → 触发
+    orders = guard.evaluate(_bar(115.0, ts_ns=2))
+    assert len(orders) == 1
+    assert orders[0].tag == "trailing_stop_loss"
+
+
+# ─── 工厂 / 关闭 / 边界 ───
+
+
+def test_from_thresholds_all_none_returns_none() -> None:
+    msgbus = MessageBus()
+    pf = Portfolio(msgbus, initial_cash=10_000.0)
+    guard = PositionGuard.from_thresholds(
+        msgbus,
+        TestClock(0),
+        pf,
+        stop_loss_pct=None,
+        take_profit_pct=None,
+        trailing_stop_pct=None,
+    )
+    assert guard is None
+
+
+def test_flat_position_returns_empty_and_clears_peak() -> None:
+    """无持仓 → 返空；峰值被清除。"""
+    msgbus = MessageBus()
+    pf = Portfolio(msgbus, initial_cash=10_000.0)  # 空仓
+    guard, _ = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+    assert guard.evaluate(_bar(50.0)) == []
+
+
+def test_short_position_is_noop() -> None:
+    """spot 当前只管 long；short 持仓 no-op（留待合约阶段）。"""
+    msgbus = MessageBus()
+    pf = Portfolio(msgbus, initial_cash=1_000_000.0, fee_rate=0.0)
+    # 直接造一个 short 仓（SELL 开空）—— 仅为测 guard 对负 quantity 的 no-op
+    fill = OrderFilled(
+        client_order_id=ClientOrderId("s"),
+        strategy_id=_SID,
+        ts_event=0,
+        ts_init=0,
+        instrument_id=_btc(),
+        side=OrderSide.SELL,
+        fill_quantity=1.0,
+        fill_price=100.0,
+        is_last_fill=True,
+    )
+    msgbus.publish(f"events.fills.{_btc()}", fill)
+    guard, captured = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+    # 价格暴涨（对 short 是大亏）也不动 —— short 由后续合约阶段处理
+    assert guard.evaluate(_bar(200.0)) == []
+    assert captured == []
+
+
+def test_no_strategy_bound_returns_empty() -> None:
+    """未 bind_strategy → 不提交（防裸提交无主单）。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    captured: list[SubmitOrderCommand] = []
+    msgbus.register_endpoint(
+        EXECUTION_ENGINE_ENDPOINT,
+        lambda cmd: captured.append(cmd),  # type: ignore[arg-type, return-value]
+    )
+    guard = PositionGuard(msgbus, TestClock(0), pf, stop_loss_pct=0.20)
+    # 没 bind
+    assert guard.evaluate(_bar(50.0)) == []
+    assert captured == []

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -141,12 +141,41 @@ def test_trailing_triggers_after_peak() -> None:
     pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
     guard, _ = _guard_with_capture(pf, msgbus, trailing_stop_pct=0.10)
 
-    # 第一根：mark=130（+30%）建立峰值，自身回撤 0 → 不触发
+    # 第一根：mark=130 建立峰值价，自身回撤 0 → 不触发
     assert guard.evaluate(_bar(130.0, ts_ns=1)) == []
-    # 第二根：mark=115（+15%），自峰值 +30% 回撤 15% >= 10% → 触发
+    # 第二根：mark=115，自峰值价 130 回撤 (130-115)/130≈11.5% >= 10% → 触发
     orders = guard.evaluate(_bar(115.0, ts_ns=2))
     assert len(orders) == 1
     assert orders[0].tag == "trailing_stop_loss"
+
+
+def test_trailing_uses_price_drawdown_not_return_pct() -> None:
+    """大盈利下 trailing 用「自峰值价格回撤」而非「成本收益率降幅」(CR #88 medium)。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(pf, msgbus, trailing_stop_pct=0.10)
+
+    # 峰值 mark=200（+100%）
+    assert guard.evaluate(_bar(200.0, ts_ns=1)) == []
+    # mark=185：自峰值价回撤 (200-185)/200=7.5% < 10% → 不触发
+    #（旧的成本收益率口径会是 100%-85%=15% >=10% 误触发——本测试钉住新口径）
+    assert guard.evaluate(_bar(185.0, ts_ns=2)) == []
+    # mark=175：自峰值价回撤 (200-175)/200=12.5% >= 10% → 触发
+    orders = guard.evaluate(_bar(175.0, ts_ns=3))
+    assert len(orders) == 1
+    assert orders[0].tag == "trailing_stop_loss"
+
+
+def test_trailing_inactive_when_never_profitable() -> None:
+    """移动止损仅在仓位进入盈利区后生效；从未盈利(峰值价≤成本)不触发(CR #88 medium)。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(pf, msgbus, trailing_stop_pct=0.10)
+
+    # 开仓即走低：mark 95（峰值价=95<成本100），再跌到 80
+    assert guard.evaluate(_bar(95.0, ts_ns=1)) == []
+    # 自峰值价 95 回撤 (95-80)/95≈15.8% >= 10%，但峰值价 95 < 成本 100 → trailing 不生效
+    assert guard.evaluate(_bar(80.0, ts_ns=2)) == []
 
 
 # ─── 工厂 / 关闭 / 边界 ───

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -260,33 +260,34 @@ def test_bind_strategy_rejects_second_strategy() -> None:
         guard.bind_strategy(StrategyId("B"))
 
 
-def _order(tag: str | None, coid: str) -> Order:
+def _order(tag: str | None, coid: str, side: OrderSide = OrderSide.SELL) -> Order:
     return Order(
         client_order_id=ClientOrderId(coid),
         instrument_id=_btc(),
-        side=OrderSide.SELL,
+        side=side,
         type=OrderType.MARKET,
         quantity=1.0,
         tag=tag,
     )
 
 
-def test_is_protective_order_requires_tag_and_guard_prefix() -> None:
-    """CR #88 major 回归：风控豁免双因子判定，策略仅靠 tag 仿冒无法绕过。
+def test_is_protective_order_requires_sell_tag_and_guard_prefix() -> None:
+    """CR #88 major 回归：风控豁免三因子判定（side=SELL + tag + guard 前缀），缺一即仿冒。
 
-    - guard 真出场单（tag ∈ 保护集 + client_order_id 以 'guard-' 开头）→ True
-    - 策略仿冒（tag='stop_loss' 但普通 client_order_id）→ False（仍走风控闸）
+    - guard 真出场单（SELL + tag ∈ 保护集 + 'guard-' 前缀）→ True
+    - 仅改 tag（普通 client_order_id）→ False
     - guard 前缀但非保护性 tag → False
+    - **BUY 单即便 tag + 前缀都伪造 → False**（guard 永不做 BUY；挡借豁免下超大开仓单）
     """
     # guard 真单
-    real = _order("stop_loss", "guard-BTC/USDT-abc123")
-    assert is_protective_order(real) is True
-    # 策略仿冒：只改 tag，client_order_id 仍是策略自己的命名
-    spoof = _order("stop_loss", "sma-BTC/USDT-deadbeef")
-    assert is_protective_order(spoof) is False
-    # 有 guard 前缀但 tag 不在保护集
-    not_protective = _order("signal", "guard-BTC/USDT-xyz")
-    assert is_protective_order(not_protective) is False
+    assert is_protective_order(_order("stop_loss", "guard-BTC/USDT-abc123")) is True
+    # 仅改 tag
+    assert is_protective_order(_order("stop_loss", "sma-BTC/USDT-deadbeef")) is False
+    # guard 前缀但 tag 不在保护集
+    assert is_protective_order(_order("signal", "guard-BTC/USDT-xyz")) is False
+    # 双因子全伪造但 side=BUY → 仍 False（side 守门挡掉借豁免开超大单）
+    forged_buy = _order("stop_loss", "guard-BTC/USDT-evil", side=OrderSide.BUY)
+    assert is_protective_order(forged_buy) is False
     # guard 自己产的出场单恒满足（与生产构造一致）
     msgbus = MessageBus()
     pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)


### PR DESCRIPTION
## 背景

回测只是历史,无法保证未来跑模拟盘的情况。把止盈止损「写进策略再回测」解决不了这个问题——为让回测曲线好看而调出来的止损位本身就是过拟合参数,未来一样不灵。

代码实测确认一个真实缺口:回测引擎与 live session 都是**纯信号驱动**,既有风控规则(MaxDrawdown / StoplossGuard / Cooldown)只「挡开仓」、**从不强平已有持仓**——单仓失控时没有兜底刀。

本 PR 加一道**独立于策略 alpha、回测与 live 共用、行为一致**的持仓级保护止损(灾难性兜底),专门封尾部风险。详见 ADR-0052(本地 `docs/miro/`,按约定不入 git)。

## 改动

新组件 `engine/position_guard.py` + 接入两套引擎 + 配置贯通 + 报表/工具透出,共 5 个 commit:

1. **PositionGuard 组件 + 单测** — 硬止损/止盈/移动止损三闸 + 峰值跟踪;出场打 tag 经 `close_detector`→`exit_reason`,直发 `EXECUTION_ENGINE_ENDPOINT` 绕过开仓闸
2. **接入 backtest/live session** — 两套引擎在 `update_mark` 之后同一逻辑点调 `guard.evaluate`,保证回测与模拟盘行为一致
3. **配置贯通 runner/live_runner** — `protective_*` 三项默认(硬止损 0.20,止盈/移动止损默认关);live runner 对保护性 tag 跳过 `enforce`(回撤熔断锁期内仍能平仓)
4. **报表汇总 + 一致性回归** — `BacktestReport.protective_exits` 计数;回测 vs live `feed_bar` 同口径回归
5. **透出到 agent** — `BacktestResponse` 字段 + runner 映射 + orchestration TS client/tool,agent 能看到「框架兜底本次触发 N 次」

## 设计原则

- **宽兜底,不是紧止损**:默认 −20%,封尾部风险而非切正常波动;紧止损是策略层 alpha 的事
- **默认只做亏损侧**:硬止损默认开;止盈(封上行偏 alpha)、移动止损默认关,均可配
- **回测与 live 一致**:同组件、同阈值、同逻辑点——这是硬约束,否则又回到「回测不可信」
- **不偷未来**:bar close 判定、出场单下一根 bar 撮合,与 live 只能看收盘 bar 对齐
- **与既有 RiskRule 组合**:规则挡开仓 / guard 平持仓,正交互补;保护性出场 tag 自动喂 StoplossGuard/Cooldown 实现「止损后不立刻回场」

## 验证

- `uv run ruff check .` ✅ / `uv run pytest` ✅ **723 passed**(含新增 `test_position_guard.py` 9 例 + e2e 一致性回归 3 例)
- orchestration `tsc --noEmit` ✅
- 隔离验证(干净 main + 本 PR 5 commit):17 测试全过、schema/runner 自洽、无外部 WIP 依赖

## 注意

- 默认 0.20 兜底现在对**所有回测**生效(为回测/live 一致),全套测试已确认无回归
- `protective_exits` 已到 API 响应 + agent 工具描述;前端展示可作后续增强

🤖 Generated with [Claude Code](https://claude.com/claude-code)