### PR TITLE
fix(paper): PositionGuard 加固集成(承接 #88 全部 CR 修复)

### DIFF
--- a/packages/orchestration/src/clients/paper.ts
+++ b/packages/orchestration/src/clients/paper.ts
@@ -90,8 +90,9 @@ export type BacktestReport = {
    * ADR-0052：本次回测框架级持仓保护止损触发的平仓笔数（tag ∈
    * stop_loss/take_profit/trailing_stop_loss）。>0 说明灾难兜底生效过几次——
    * 回测如实反映未来 live 也会有的兜底，agent 可据此向用户说明风险被框架封住了几次。
+   * 非 optional：Python BacktestResponse 有 default=0，响应恒带该字段。
    */
-  protective_exits?: number;
+  protective_exits: number;
   /**
    * D-9 起：账户是否穿仓（任意时点 equity ≤ -1%×initial_cash）。true 表示本次
    * 回测物理上不可信，agent 必须显式告警而非直接展示 Sharpe / 收益率。

--- a/services/paper/src/inalpha_paper/config.py
+++ b/services/paper/src/inalpha_paper/config.py
@@ -157,7 +157,7 @@ class PaperSettings(BaseSettings):
         le=1.0,
         description="框架级持仓灾难性兜底止损：单仓浮亏穿 -X → 全平（回测 + live 共用同一"
         "阈值，行为一致）。默认 0.20 = 宽兜底（封尾部风险而非切正常波动；贴行情的紧止损"
-        "是策略层 alpha 的事）。None / 0 视为关闭硬止损闸。",
+        "是策略层 alpha 的事）。关闭硬止损闸 = 不设该环境变量（None）；0 不合法（gt=0）。",
     )
     protective_take_profit_pct: float | None = Field(
         default=None,
@@ -170,7 +170,8 @@ class PaperSettings(BaseSettings):
         default=None,
         alias="INALPHA_PROTECTIVE_TRAILING_STOP_PCT",
         gt=0.0,
-        description="框架级移动止损：自峰值浮盈回撤 X → 全平（锁大利润）。默认 None = 关。",
+        description="框架级移动止损：仓位进入盈利区后，自【峰值价格】回撤 X → 全平（锁大利润，"
+        "口径是价格自峰值的跌幅，非成本收益率降幅）。默认 None = 关（设 0 不合法，gt=0）。",
     )
 
     # ─── D-12 · 因子衰减巡检（ADR-0047）────────────────────────────────

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -99,7 +99,17 @@ class BacktestEngine:
         self._num_bars: int = 0
 
     def add_strategy(self, strategy: Strategy) -> None:
-        """挂载策略。strategy 构造时必须传 ``engine.clock`` / ``engine.msgbus``。"""
+        """挂载策略。strategy 构造时必须传 ``engine.clock`` / ``engine.msgbus``。
+
+        启用了 PositionGuard（protective_* 阈值非空）时**只允许单策略**：guard 只持一个
+        strategy_id，多策略会让保护性出场归属错误（前策略 on_position_closed 不触发、状态
+        不归零）。挂第二个策略即抛 RuntimeError（CR #88）。需多策略回测请关闭 protective_*。
+        """
+        if self._guard is not None and self._strategies:
+            raise RuntimeError(
+                "PositionGuard 启用时只支持单策略 per engine（多策略需先完成引擎多策略化，"
+                "CR #88 / ADR-0052 已知限制）；多策略回测请置 protective_* 阈值为 None。"
+            )
         self._strategies.append(strategy)
         # guard 出场单用策略自身 id 提交（确保 on_position_closed 回到策略让其状态归零）
         if self._guard is not None:
@@ -129,6 +139,11 @@ class BacktestEngine:
             self.portfolio.update_mark(bar.instrument_id, bar.close)
             # 3.5 ADR-0052：框架级持仓保护止损在 mark 更新后判定（与 live session 同点），
             #     触发的保护性出场单进 pending，下一根 process_bar 撮合（不偷未来）。
+            #     已知限制（CR #88，仅显式传 rules 的回测受影响、生产 runner rules=None 不触达、
+            #     live 顺序路由不受影响）：guard 的 SELL 在 bar N 仅入 pending、bar N+1 才成交，
+            #     故同一 bar 内策略经 RiskEngine 提交的 BUY 看不到这次平仓 → CooldownRule 等
+            #     基于 closed_trades 的锁在该时间窗查不到记录，可能放过同 bar 重入单（"止损后
+            #     不回场"在此窗失效）。要严格联动 rules，用 live 路径（顺序路由先确认 guard 成交）。
             if self._guard is not None:
                 self._guard.evaluate(bar)
             # 4. 发布 bar，触发 strategy.on_bar
@@ -141,6 +156,19 @@ class BacktestEngine:
             self.portfolio.snapshot(bar.ts_event)
 
             self._num_bars += 1
+
+        # ADR-0052：末根 bar 触发的保护性出场单没有下一根可撮合（process_bar 用 next-bar
+        # open 防 look-ahead）。收尾按末根 close 兜底成交——close 是决策时已知价、非
+        # look-ahead，且与 live runner 同根 close 撮合对齐，避免「末根触发 → 漏计 /
+        # 持仓显示未平」的回测/live 不一致（CR #88）。只动保护性单，策略单不收盘强平。
+        # 限制：按 bars_list[-1] 的 instrument 收尾（沿用引擎「单 instrument per session」
+        # 契约）；多标的回测末端非末根 instrument 的保护单不在此 flush——多标的支持是引擎
+        # 层整体未做项（CR #88 medium，与引擎多标的化一并推进，非本闸单独修）。
+        if self._guard is not None and bars_list:
+            if self.exchange.flush_protective_at_close(bars_list[-1]) > 0:
+                # 兜底平仓改变了持仓/现金（差一笔手续费），重记末点权益。snapshot 对同 ts
+                # 是**覆盖**末点（见 Portfolio.snapshot），不会产生重复 ts / 多算一个 bar。
+                self.portfolio.snapshot(bars_list[-1].ts_event)
 
         for s in self._strategies:
             s.on_stop()

--- a/services/paper/src/inalpha_paper/engine/live_session.py
+++ b/services/paper/src/inalpha_paper/engine/live_session.py
@@ -263,6 +263,11 @@ class LiveEngineSession:
         局限：策略若用非标准内部 flag（不订阅 position/fill 事件）跟踪持仓，无法还原其
         私有状态——但 Inalpha 契约 / 模板引导走 position/fill hook，主流策略可正确续跑。
         ``quantity_signed == 0`` 时 no-op。
+
+        **PositionGuard 移动止损 resume 限制（CR #88 medium）**：resume 不还原 guard 的
+        ``_peak_mark``（历史峰值价 DB 没存），续跑后峰值从首根 bar 的 close 重新起算。若
+        崩溃前价格曾远高于续跑价，``trailing_stop`` 触发会延迟（按续跑后新峰值算回撤）。
+        硬止损 / 止盈不受影响（按 avg 算，avg 已还原）；且 ``trailing`` 默认关，影响面小。
         """
         if quantity_signed == 0:
             return

--- a/services/paper/src/inalpha_paper/engine/portfolio.py
+++ b/services/paper/src/inalpha_paper/engine/portfolio.py
@@ -20,7 +20,7 @@ from uuid import UUID
 from ..kernel.identifiers import InstrumentId
 from ..kernel.msgbus import MessageBus
 from ..model.events import OrderFilled, PositionChanged, PositionClosed, PositionOpened
-from ..model.orders import OrderSide
+from ..model.orders import OrderSide, is_protective_signature
 from ..model.positions import Position
 from .close_detector import ClosedTradeStaging, detect_close
 from .report import FillRecord
@@ -262,6 +262,10 @@ class Portfolio:
                 realized_pnl=pos.realized_pnl - prev_realized,
                 intent=intent,
                 tag=msg.tag,
+                # 三因子判定是否框架 guard 兜底出场（区分策略自带 stop_loss tag，CR #88）
+                is_guard=is_protective_signature(
+                    msg.side, msg.tag, msg.client_order_id
+                ),
             )
         )
 

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -166,8 +166,7 @@ class PositionGuard:
         # 用自峰值价格的回撤幅度判定（peak_mark - mark) / peak_mark），不掺成本基准。
         if (
             self._trailing_stop_pct is not None
-            and peak_mark > avg
-            and peak_mark > 0
+            and peak_mark > avg  # 曾进盈利区(avg>0 已在 evaluate 守门,故 peak_mark>0 恒真)
             and (peak_mark - mark) / peak_mark >= self._trailing_stop_pct
         ):
             return "trailing_stop_loss"

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -30,17 +30,11 @@ from ..kernel.identifiers import ClientOrderId, InstrumentId, StrategyId
 from ..kernel.msgbus import MessageBus
 from ..model.commands import SubmitOrderCommand
 from ..model.data import Bar
-from ..model.orders import Order, OrderSide, OrderType
+from ..model.orders import GUARD_ORDER_PREFIX, Order, OrderSide, OrderType
 
 if TYPE_CHECKING:
     from ..kernel.clock import Clock
     from .portfolio import Portfolio
-
-#: 保护性出场 tag 集合（与 closed_trades.exit_reason CHECK 集合、StoplossGuardRule 对齐）。
-#: live_runner 据此判定一笔单是否为框架兜底出场（跳过开仓闸 enforce）。
-PROTECTIVE_EXIT_TAGS: frozenset[str] = frozenset(
-    {"stop_loss", "take_profit", "trailing_stop_loss"}
-)
 
 
 class PositionGuard:
@@ -80,8 +74,8 @@ class PositionGuard:
         self._take_profit_pct = take_profit_pct
         self._trailing_stop_pct = trailing_stop_pct
         self._strategy_id: StrategyId | None = None
-        # 每 instrument 的峰值浮盈率（trailing 用）；持仓转 flat 时清除
-        self._peak_pct: dict[InstrumentId, float] = {}
+        # 每 instrument 的峰值 mark 价（trailing 用，自峰值价格回撤口径）；持仓转 flat 时清除
+        self._peak_mark: dict[InstrumentId, float] = {}
 
     @staticmethod
     def from_thresholds(
@@ -108,15 +102,14 @@ class PositionGuard:
     def bind_strategy(self, strategy_id: StrategyId) -> None:
         """绑定所属策略 id。出场单用它提交，确保 on_position_closed 回到策略让其状态归零。
 
-        **单策略约束**（CR Medium）：PositionGuard 只记一个 ``_strategy_id``，多策略挂同一
-        engine 时后绑定会覆盖前者 → 保护性出场的 on_position_closed 回错策略，前策略状态不归零。
-        当前所有用法均单策略（每 engine/session 只 bind 一次，或重复 bind 同一策略）；用断言把
-        "只支持单策略" 显式化，防未来多策略静默踩坑。
+        **单策略约束**：guard 只持一个 ``_strategy_id``。绑第二个不同策略会让保护性出场
+        归属错误（前策略状态不归零），故直接断言拒绝——多策略支持是引擎层整体未做项
+        （CR #88，需与引擎多策略化一并推进）。调用方 ``BacktestEngine.add_strategy`` 也已
+        在挂第二个策略时抛 RuntimeError，双层防呆。
         """
-        # 用 raise 而非 assert：assert 在 python -O 下被剥除，多策略误用会静默通过（CR）。
         if self._strategy_id is not None and self._strategy_id != strategy_id:
-            raise ValueError(
-                "PositionGuard 只支持单策略：bind_strategy 不能绑定第二个不同的 strategy_id "
+            raise RuntimeError(
+                "PositionGuard 只支持单策略：不能绑定第二个不同的 strategy_id"
                 f"（已绑 {self._strategy_id}，又试图绑 {strategy_id}）"
             )
         self._strategy_id = strategy_id
@@ -133,7 +126,7 @@ class PositionGuard:
         inst = bar.instrument_id
         pos = self._portfolio.position(inst)
         if pos is None or pos.is_flat:
-            self._peak_pct.pop(inst, None)
+            self._peak_mark.pop(inst, None)
             return []
 
         # 仅 spot long；short 留待合约阶段（no-op，避免对 short 误平）
@@ -146,32 +139,36 @@ class PositionGuard:
 
         mark = bar.close
         pct = (mark - avg) / avg
-        peak = max(self._peak_pct.get(inst, pct), pct)
-        self._peak_pct[inst] = peak
+        # trailing 用「自峰值价格的回撤」口径（不是自成本基准的收益率降幅）：避免大盈利下
+        # 触发远比 trailing_stop_pct 直觉更激进（CR #88 medium）。峰值价跟 mark 走。
+        peak_mark = max(self._peak_mark.get(inst, mark), mark)
+        self._peak_mark[inst] = peak_mark
 
-        tag = self._triggered_tag(pct, peak)
+        tag = self._triggered_tag(pct, mark, peak_mark, avg)
         if tag is None:
             return []
 
         order = self._build_exit(inst, pos.quantity, tag)
         self._submit(order, bar.ts_event)
         # 出场单已下，清峰值（持仓将于下一根平掉；防同 instrument 状态泄漏）
-        self._peak_pct.pop(inst, None)
+        self._peak_mark.pop(inst, None)
         return [order]
 
     # ─── 内部 ───
 
-    def _triggered_tag(self, pct: float, peak: float) -> str | None:
+    def _triggered_tag(
+        self, pct: float, mark: float, peak_mark: float, avg: float
+    ) -> str | None:
         """按优先级判定触发的保护性 tag：硬止损 > 移动止损 > 止盈（None = 不触发）。"""
         if self._stop_loss_pct is not None and pct <= -self._stop_loss_pct:
             return "stop_loss"
-        # trailing 仅在持仓**曾经盈利**（peak > 0）时激活——语义是"自峰值浮盈回撤锁利"。
-        # 否则建仓即亏损会误触发（peak=-4% 跌到 -11% 时 peak-pct=7% 也过阈），抢在 -20%
-        # 硬止损前强平，与文档/用户预期不符（CR Major）。亏损阶段交给 stop_loss 兜底。
+        # 移动止损：仅在仓位「曾进入盈利区」（峰值价 > 成本）后才生效——锁的是已有利润；
+        # 用自峰值价格的回撤幅度判定（peak_mark - mark) / peak_mark），不掺成本基准。
         if (
             self._trailing_stop_pct is not None
-            and peak > 0
-            and (peak - pct) >= self._trailing_stop_pct
+            and peak_mark > avg
+            and peak_mark > 0
+            and (peak_mark - mark) / peak_mark >= self._trailing_stop_pct
         ):
             return "trailing_stop_loss"
         if self._take_profit_pct is not None and pct >= self._take_profit_pct:
@@ -180,7 +177,8 @@ class PositionGuard:
 
     def _build_exit(self, inst: InstrumentId, quantity: float, tag: str) -> Order:
         return Order(
-            client_order_id=ClientOrderId(f"guard-{inst.symbol}-{uuid4().hex[:8]}"),
+            # GUARD_ORDER_PREFIX 是风控豁免的「不可仿冒」第二因子（见 is_protective_order）
+            client_order_id=ClientOrderId(f"{GUARD_ORDER_PREFIX}{inst.symbol}-{uuid4().hex[:8]}"),
             instrument_id=inst,
             side=OrderSide.SELL,  # spot long-only：平多 = 卖出
             type=OrderType.MARKET,

--- a/services/paper/src/inalpha_paper/engine/report.py
+++ b/services/paper/src/inalpha_paper/engine/report.py
@@ -28,7 +28,6 @@ from ..kernel.identifiers import InstrumentId
 from ..model.orders import OrderSide
 from ..model.positions import Position
 from . import metrics
-from .position_guard import PROTECTIVE_EXIT_TAGS
 from .robustness import bootstrap_sharpe_ci
 
 if TYPE_CHECKING:
@@ -57,6 +56,9 @@ class FillRecord:
     realized_pnl: float
     intent: str | None = None
     tag: str | None = None
+    #: ADR-0052/CR #88：本笔是否为框架 PositionGuard 兜底出场（三因子 is_protective_signature
+    #: 判定）。与 ``tag`` 区分——策略也能自打 tag="stop_loss"，只有这个 bool 才真代表框架触发。
+    is_guard: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -170,7 +172,8 @@ class BacktestReport:
         max_dd = metrics.max_drawdown_pct(equity_values)
         trade_pnls = portfolio.closed_trade_pnls
         fills = list(portfolio.fills)
-        protective_exits = sum(1 for f in fills if f.tag in PROTECTIVE_EXIT_TAGS)
+        # 只数框架 guard 兜底出场（f.is_guard），不混入策略自带 stop_loss tag（CR #88 major）
+        protective_exits = sum(1 for f in fills if f.is_guard)
 
         sharpe_value = metrics.sharpe_ratio(returns, ppy)
         # ADR-0027 防过拟合：单次回测给 Bootstrap Sharpe 95% CI。仅在 Sharpe 有定义

--- a/services/paper/src/inalpha_paper/execution/exchange.py
+++ b/services/paper/src/inalpha_paper/execution/exchange.py
@@ -27,7 +27,7 @@ from ..kernel.clock import Clock
 from ..kernel.identifiers import ClientOrderId, StrategyId, VenueOrderId
 from ..kernel.msgbus import MessageBus
 from ..model.data import Bar
-from ..model.orders import Order, OrderSide, OrderType
+from ..model.orders import Order, OrderSide, OrderType, is_protective_order
 from .gateway import Gateway
 
 if TYPE_CHECKING:
@@ -130,26 +130,67 @@ class SimulatedExchange(Gateway):
                 continue
 
             fill_qty, fill_price = fill
-            trade_id = f"trade-{self._next_id}"
-            self._next_id += 1
-
-            self._msgbus.publish(
-                "internal.venue.filled",
-                {
-                    "client_order_id": order.client_order_id,
-                    "strategy_id": strategy_id,
-                    "instrument_id": order.instrument_id,
-                    "side": order.side,
-                    "fill_qty": fill_qty,
-                    "fill_price": fill_price,
-                    "trade_id": trade_id,
-                    "ts": bar.ts_event,
-                },
-            )
+            self._publish_fill(order, strategy_id, fill_qty, fill_price, bar.ts_event)
             filled_count += 1
 
         self._pending = remaining
         return filled_count
+
+    def flush_protective_at_close(self, bar: Bar) -> int:
+        """收尾兜底：对仍 pending 的【保护性出场单】按 ``bar.close`` 成交（ADR-0052）。
+
+        保护性出场（stop_loss / take_profit / trailing_stop_loss）是框架兜底——末根
+        触发时没有下一根可撮合（``_try_fill`` 用 next-bar open 避免 look-ahead）。在此
+        按**决策那根的 close** 成交：close 是决策时已知价，非 look-ahead，且与 live
+        runner「同根按 bar.close 撮合」同口径，修掉「末根触发 → backtest 漏计 / 持仓
+        显示未平」的回测/live 不一致（CR #88 medium）。
+
+        **只动保护性单**：策略单维持「不收盘强平」语义不变。返回成交笔数。
+        """
+        filled_count = 0
+        remaining: list[tuple[Order, StrategyId]] = []
+        for order, strategy_id in self._pending:
+            if order.instrument_id != bar.instrument_id or not is_protective_order(order):
+                remaining.append((order, strategy_id))
+                continue
+            # spot 守门：SELL 平仓量不应超过持仓（保护性单按全仓发，正常恒满足）
+            if (
+                self._portfolio is not None
+                and order.side == OrderSide.SELL
+                and not self._portfolio.can_afford_sell(order.instrument_id, order.quantity)
+            ):
+                remaining.append((order, strategy_id))
+                continue
+            self._publish_fill(order, strategy_id, order.quantity, bar.close, bar.ts_event)
+            filled_count += 1
+
+        self._pending = remaining
+        return filled_count
+
+    def _publish_fill(
+        self,
+        order: Order,
+        strategy_id: StrategyId,
+        fill_qty: float,
+        fill_price: float,
+        ts_event: int,
+    ) -> None:
+        """发 ``internal.venue.filled`` → ExecutionEngine → Portfolio / 策略。"""
+        trade_id = f"trade-{self._next_id}"
+        self._next_id += 1
+        self._msgbus.publish(
+            "internal.venue.filled",
+            {
+                "client_order_id": order.client_order_id,
+                "strategy_id": strategy_id,
+                "instrument_id": order.instrument_id,
+                "side": order.side,
+                "fill_qty": fill_qty,
+                "fill_price": fill_price,
+                "trade_id": trade_id,
+                "ts": ts_event,
+            },
+        )
 
     def pending_count(self) -> int:
         return len(self._pending)

--- a/services/paper/src/inalpha_paper/execution/exchange.py
+++ b/services/paper/src/inalpha_paper/execution/exchange.py
@@ -21,6 +21,7 @@ internal topic 约定（仅在本服务内使用）：
 """
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from ..kernel.clock import Clock
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
     from ..engine.portfolio import Portfolio
 
 EXECUTION_ENGINE_ENDPOINT = "ExecutionEngine.execute"
+
+_logger = logging.getLogger(__name__)
 
 
 class SimulatedExchange(Gateway):
@@ -159,6 +162,11 @@ class SimulatedExchange(Gateway):
                 and order.side == OrderSide.SELL
                 and not self._portfolio.can_afford_sell(order.instrument_id, order.quantity)
             ):
+                # 正常不可达(guard 出场量=持仓);留日志便于未来排查边界异常
+                _logger.warning(
+                    "flush_protective_at_close: 保护单 %s 量 %s 超持仓被守门拒,跳过",
+                    order.client_order_id, order.quantity,
+                )
                 remaining.append((order, strategy_id))
                 continue
             self._publish_fill(order, strategy_id, order.quantity, bar.close, bar.ts_event)

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -29,7 +29,6 @@ from inalpha_shared.errors import ConflictError, InalphaError
 from .config import PaperSettings
 from .data_client import DataClient
 from .engine.live_session import LiveEngineSession
-from .engine.position_guard import PROTECTIVE_EXIT_TAGS
 from .execution import risk_guard as risk_guard_mod
 from .execution.currency_resolver import resolve_currency
 from .execution.order_executor import OrderExecutor
@@ -39,7 +38,7 @@ from .fills import apply_fill_to_positions_and_cash
 from .fx import BaseCurrencyConverter, needs_network
 from .kernel.identifiers import InstrumentId, StrategyId
 from .model.data import Bar
-from .model.orders import Order
+from .model.orders import Order, is_protective_order
 from .runner import _bar_from_dict
 from .storage import accounts as accounts_store
 from .storage import closed_trades as closed_trades_store
@@ -598,12 +597,21 @@ class LiveRunnerManager:
         # 措辞「触发 N 个信号（待撮合）」：此处 orders 是策略意图、尚未过风控/撮合，
         # 后续可能被 risk_rejected 全拦——不写「产生 N 个下单意图」以免与最终无成交割裂（CR）。
         if orders:
+            # 区分策略信号 vs 框架 guard 兜底出场（CR #88 medium）：混算会让运维误以为
+            # 策略产生了信号，实则可能是 guard 触发止损/止盈。
+            guard_n = sum(1 for o, _ in orders if is_protective_order(o))
+            strat_n = len(orders) - guard_n
+            parts = []
+            if strat_n:
+                parts.append(f"策略触发 {strat_n} 个信号")
+            if guard_n:
+                parts.append(f"框架 guard 触发 {guard_n} 个保护性出场")
             try:
                 async with get_conn() as conn:
                     await runs_store.append_log(
                         conn, run["id"], "info",
                         f"bar {_ns_to_dt(bar.ts_event):%Y-%m-%d %H:%M} · "
-                        f"策略触发 {len(orders)} 个信号（待撮合）",
+                        f"{' + '.join(parts)}（待撮合）",
                     )
             except Exception:
                 _logger.exception("live run %s: 写出单日志失败", run["id"])
@@ -756,16 +764,20 @@ class LiveRunnerManager:
         # 1. 风控；命中 → 拒单 + 记 error_log，不杀 run。两道闸门同 except 处理：
         #    (a) 单笔 notional 硬上限（无状态，挡策略算错 quantity 的超大单，issue #42）；
         #    (b) DB-backed RiskGuard 行为型锁规则（drawdown / cooldown / ...）。
-        # ADR-0052：框架级保护性出场（stop_loss / take_profit / trailing_stop_loss）跳过
-        # "挡开仓"的行为型锁——回撤熔断锁期内恰恰最需要它平仓；guard 本身就是风控，不该
-        # 被开仓闸拦住。notional 硬上限仍保留（防 quantity 算错的超大单）。
-        is_protective_exit = order.tag in PROTECTIVE_EXIT_TAGS
+        # ADR-0052：框架级保护性出场（stop_loss / take_profit / trailing_stop_loss）**两道闸
+        # 全豁免**——guard 是风控兜底，必须能平仓：① 行为型锁（回撤熔断锁期内恰恰最需要它平
+        # 仓）；② notional 硬上限（CR #88 major：保护性 SELL 量=实际持仓，价涨/累积建仓后仓位
+        # notional 必然超单笔买入上限；若也卡 notional → 止损被静默拒 → 持仓不动 → 每根 bar
+        # 重试又被拒 → 止损形同虚设。notional 上限是防"胖手指"超大开仓单，平实际持仓不属此列）。
+        # 三因子判定(side=SELL + tag + guard 专属 client_order_id 前缀)：策略代码可控 tag/前缀，
+        # 单看 tag 会被仿冒绕过风控（CR #88 major），必须三者同时校验。
+        is_protective_exit = is_protective_order(order)
         try:
-            risk_guard_mod.check_order_notional(
-                self._factory, quantity=order.quantity, ref_price=float(bar.close),
-                venue=venue, symbol=symbol,
-            )
             if not is_protective_exit:
+                risk_guard_mod.check_order_notional(
+                    self._factory, quantity=order.quantity, ref_price=float(bar.close),
+                    venue=venue, symbol=symbol,
+                )
                 await risk_guard_mod.enforce(
                     self._factory, account_id=account_id, venue=venue, symbol=symbol,
                     side=side,

--- a/services/paper/src/inalpha_paper/model/orders.py
+++ b/services/paper/src/inalpha_paper/model/orders.py
@@ -43,6 +43,18 @@ class OrderStatus(Enum):
     REJECTED = "REJECTED"
 
 
+#: 框架级保护性出场的 ``Order.tag`` 集合（ADR-0052）。放在 model 中立层：engine
+#: （PositionGuard）与 execution（SimulatedExchange）都引它，避免 engine↔execution
+#: 循环依赖（与下方 ``Order.tag`` 约定值同源）。
+PROTECTIVE_EXIT_TAGS: frozenset[str] = frozenset(
+    {"stop_loss", "take_profit", "trailing_stop_loss"}
+)
+
+#: ``PositionGuard`` 出场单 ``client_order_id`` 的专属前缀。与 ``PROTECTIVE_EXIT_TAGS``
+#: 一起构成「不可仅靠 tag 仿冒」的双因子判定（见 ``is_protective_order``）。
+GUARD_ORDER_PREFIX = "guard-"
+
+
 # 合法转移表，违反抛 ``ValueError``
 _VALID_TRANSITIONS: dict[OrderStatus, set[OrderStatus]] = {
     OrderStatus.NEW: {OrderStatus.SUBMITTED, OrderStatus.REJECTED},
@@ -181,3 +193,30 @@ class Order:
         if reason:
             self.reason = reason
         self._transition(OrderStatus.CANCELED, ts)
+
+
+def is_protective_signature(
+    side: OrderSide, tag: str | None, client_order_id: object
+) -> bool:
+    """三因子判定原语：``side==SELL`` + ``tag`` ∈ ``PROTECTIVE_EXIT_TAGS`` + ``client_order_id``
+    以 ``GUARD_ORDER_PREFIX`` 开头。供 :func:`is_protective_order`（拿 Order）与成交侧
+    （Portfolio 拿 OrderFilled 字段，无 Order 对象）共用，避免重复逻辑。
+
+    **安全前提（CR #88 medium）**：三个字段策略代码均可自设，故这层判定**不是**对抗性防伪，
+    用途是把「框架 guard 出场」与「策略普通单 / 策略自带 stop_loss」区分开（给 guard 出场
+    风控豁免 + 单独计数）。真正防伪依赖**策略源码 AST 审计 + 运行隔离**（audit_strategy_code；
+    当前策略不在 runtime 沙箱内，是已知攻击面，待后续补沙箱时收口——见 ADR-0052）。
+    """
+    return (
+        side == OrderSide.SELL
+        and tag in PROTECTIVE_EXIT_TAGS
+        and str(client_order_id).startswith(GUARD_ORDER_PREFIX)
+    )
+
+
+def is_protective_order(order: Order) -> bool:
+    """是否为 ``PositionGuard`` 框架兜底出场单（享风控豁免：跳过开仓闸 + notional 上限）。
+
+    见 :func:`is_protective_signature`（三因子判定 + 安全前提说明）。
+    """
+    return is_protective_signature(order.side, order.tag, order.client_order_id)

--- a/services/paper/tests/test_backtest_e2e.py
+++ b/services/paper/tests/test_backtest_e2e.py
@@ -6,15 +6,25 @@
 from __future__ import annotations
 
 import math
+from uuid import uuid4
 
 from inalpha_paper.engine.backtest import BacktestEngine
 from inalpha_paper.engine.live_session import LiveEngineSession
-from inalpha_paper.engine.position_guard import PROTECTIVE_EXIT_TAGS
 from inalpha_paper.engine.report import BacktestReport
-from inalpha_paper.kernel.identifiers import InstrumentId
+from inalpha_paper.kernel.clock import Clock
+from inalpha_paper.kernel.identifiers import ClientOrderId, InstrumentId
+from inalpha_paper.kernel.msgbus import MessageBus
 from inalpha_paper.model.data import Bar
+from inalpha_paper.model.events import PositionClosed, PositionOpened
+from inalpha_paper.model.orders import (
+    PROTECTIVE_EXIT_TAGS,
+    Order,
+    OrderSide,
+    OrderType,
+)
 from inalpha_paper.strategies.buy_and_hold import BuyAndHoldStrategy
 from inalpha_paper.strategies.sma_cross import SMACrossStrategy
+from inalpha_paper.strategy.base import Strategy
 
 
 def _btc() -> InstrumentId:
@@ -414,3 +424,148 @@ def test_live_session_protective_stop_matches_backtest() -> None:
     tags_off, final_qty_off = _drive_live_with_guard(bars, stop_loss_pct=None)
     assert tags_off == []
     assert final_qty_off > 0.0  # 仍持有
+
+
+def test_backtest_protective_stop_on_last_bar_settles_at_close() -> None:
+    """末根 bar 触发兜底也如实成交+计数(按末根 close 兜底平仓),与 live 对齐(CR #88)。
+
+    价格在最后一根才砸穿 -20%：常规 next-bar 撮合没有下一根,会漏计/显示未平；
+    收尾 flush_protective_at_close 按末根 close 兜底平仓修正。
+    """
+    # 买入持有到末根(第5根 idx=4)才跌到 -30%
+    bars = _gen_bars([100.0, 100.0, 100.0, 100.0, 70.0])
+    engine = BacktestEngine(
+        initial_cash=10_000.0, fee_rate=0.0, protective_stop_loss_pct=0.20
+    )
+    strat = BuyAndHoldStrategy(
+        name="bh",
+        clock=engine.clock,
+        msgbus=engine.msgbus,
+        instrument_id=_btc(),
+        timeframe="1h",
+        trade_size=1.0,
+    )
+    engine.add_strategy(strat)
+    report = engine.run(bars)
+
+    # 末根触发也计入、也平仓（修复前是 0 / 持有）
+    assert report.protective_exits == 1
+    stop_fills = [f for f in report.fills if f.tag == "stop_loss"]
+    assert len(stop_fills) == 1
+    assert stop_fills[0].fill_price == 70.0  # 按末根 close 兜底成交
+    pos = report.positions.get(_btc())
+    assert pos is None or pos.is_flat
+
+
+def test_guard_enabled_rejects_second_strategy() -> None:
+    """启用 guard 时挂第二个策略 → RuntimeError(单策略约束,CR #88)。"""
+    import pytest
+
+    engine = BacktestEngine(
+        initial_cash=10_000.0, fee_rate=0.0, protective_stop_loss_pct=0.20
+    )
+    engine.add_strategy(
+        BuyAndHoldStrategy(
+            name="a", clock=engine.clock, msgbus=engine.msgbus,
+            instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+        )
+    )
+    with pytest.raises(RuntimeError, match="只支持单策略"):
+        engine.add_strategy(
+            BuyAndHoldStrategy(
+                name="b", clock=engine.clock, msgbus=engine.msgbus,
+                instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+            )
+        )
+
+
+def test_no_guard_allows_multiple_strategies() -> None:
+    """未启用 guard(阈值全 None)时多策略仍可挂(不破坏既有能力)。"""
+    engine = BacktestEngine(initial_cash=10_000.0, fee_rate=0.0)
+    engine.add_strategy(
+        BuyAndHoldStrategy(
+            name="a", clock=engine.clock, msgbus=engine.msgbus,
+            instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+        )
+    )
+    # 第二个策略不报错
+    engine.add_strategy(
+        BuyAndHoldStrategy(
+            name="b", clock=engine.clock, msgbus=engine.msgbus,
+            instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+        )
+    )
+
+
+class _StrategyStopLossStrat(Strategy):
+    """测试用：bar1 买入，bar3 用 tag='stop_loss' 卖出（普通 client_order_id，非 guard）。"""
+
+    def __init__(
+        self,
+        name: str,
+        clock: Clock,
+        msgbus: MessageBus,
+        instrument_id: InstrumentId,
+        timeframe: str = "1h",
+        trade_size: float = 1.0,
+        **_: object,
+    ) -> None:
+        super().__init__(name, clock, msgbus)
+        self._iid = instrument_id
+        self._tf = timeframe
+        self._size = trade_size
+        self._n = 0
+        self._is_long = False
+        self._open_qty = 0.0
+
+    def on_start(self) -> None:
+        self.subscribe_bars(self._iid, self._tf)
+
+    def on_bar(self, bar: Bar) -> None:
+        self._n += 1
+        if self._n == 1:
+            self.submit_order(Order(
+                client_order_id=ClientOrderId(f"mystrat-{uuid4().hex[:8]}"),
+                instrument_id=self._iid, side=OrderSide.BUY,
+                type=OrderType.MARKET, quantity=self._size,
+            ))
+        elif self._n == 3 and self._is_long:
+            self.submit_order(Order(
+                client_order_id=ClientOrderId(f"mystrat-{uuid4().hex[:8]}"),
+                instrument_id=self._iid, side=OrderSide.SELL,
+                type=OrderType.MARKET, quantity=self._open_qty, tag="stop_loss",
+            ))
+
+    def on_position_opened(self, event: PositionOpened) -> None:
+        self._is_long = True
+        self._open_qty = abs(event.quantity)
+
+    def on_position_closed(self, event: PositionClosed) -> None:
+        self._is_long = False
+
+
+def test_strategy_own_stop_loss_tag_not_counted_as_guard() -> None:
+    """CR #88 major 回归：策略自打 tag='stop_loss' 的平仓不计入 protective_exits。
+
+    protective_exits 只数框架 guard 兜底（is_guard），策略自带止损 tag（client_order_id 非
+    'guard-' 前缀）不算——否则 agent 会把策略止损误报成"框架止损"。
+    """
+    # 价格平稳，guard 不会触发；关掉 guard 也行，这里关掉以纯测策略 tag 计数
+    bars = _gen_bars([100.0, 100.0, 100.0, 100.0, 100.0])
+    engine = BacktestEngine(
+        initial_cash=10_000.0, fee_rate=0.0, protective_stop_loss_pct=None
+    )
+    engine.add_strategy(
+        _StrategyStopLossStrat(
+            name="s", clock=engine.clock, msgbus=engine.msgbus,
+            instrument_id=_btc(), timeframe="1h", trade_size=1.0,
+        )
+    )
+    report = engine.run(bars)
+
+    # 策略确实平了一笔且打了 stop_loss tag
+    stop_fills = [f for f in report.fills if f.tag == "stop_loss"]
+    assert len(stop_fills) == 1
+    assert stop_fills[0].is_guard is False  # 关键：不是框架 guard
+    # 框架 guard 计数为 0（不被策略自带 tag 污染）
+    assert report.protective_exits == 0

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from inalpha_paper.engine.portfolio import Portfolio
-from inalpha_paper.engine.position_guard import PROTECTIVE_EXIT_TAGS, PositionGuard
+from inalpha_paper.engine.position_guard import PositionGuard
 from inalpha_paper.execution.exchange import EXECUTION_ENGINE_ENDPOINT
 from inalpha_paper.kernel.clock import TestClock
 from inalpha_paper.kernel.identifiers import ClientOrderId, InstrumentId, StrategyId
@@ -14,7 +14,13 @@ from inalpha_paper.kernel.msgbus import MessageBus
 from inalpha_paper.model.commands import SubmitOrderCommand
 from inalpha_paper.model.data import Bar
 from inalpha_paper.model.events import OrderFilled
-from inalpha_paper.model.orders import OrderSide, OrderType
+from inalpha_paper.model.orders import (
+    PROTECTIVE_EXIT_TAGS,
+    Order,
+    OrderSide,
+    OrderType,
+    is_protective_order,
+)
 
 _SID = StrategyId("test")
 
@@ -141,29 +147,41 @@ def test_trailing_triggers_after_peak() -> None:
     pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
     guard, _ = _guard_with_capture(pf, msgbus, trailing_stop_pct=0.10)
 
-    # 第一根：mark=130（+30%）建立峰值，自身回撤 0 → 不触发
+    # 第一根：mark=130 建立峰值价，自身回撤 0 → 不触发
     assert guard.evaluate(_bar(130.0, ts_ns=1)) == []
-    # 第二根：mark=115（+15%），自峰值 +30% 回撤 15% >= 10% → 触发
+    # 第二根：mark=115，自峰值价 130 回撤 (130-115)/130≈11.5% >= 10% → 触发
     orders = guard.evaluate(_bar(115.0, ts_ns=2))
     assert len(orders) == 1
     assert orders[0].tag == "trailing_stop_loss"
 
 
-def test_trailing_does_not_trigger_when_never_profitable() -> None:
-    """CR Major 回归：持仓从未盈利（peak ≤ 0）→ trailing 不激活，亏损交给硬止损。
-
-    旧逻辑 peak 初始化为首根 pct（可负），peak-pct 在纯亏损段也会过阈 → 在 -20% 硬止损
-    前误强平。修复后 trailing 仅 peak>0 才激活。
-    """
+def test_trailing_uses_price_drawdown_not_return_pct() -> None:
+    """大盈利下 trailing 用「自峰值价格回撤」而非「成本收益率降幅」(CR #88 medium)。"""
     msgbus = MessageBus()
     pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
-    # 纯 trailing（无 stop_loss），隔离验证亏损段不被 trailing 误触发
-    guard, _ = _guard_with_capture(pf, msgbus, trailing_stop_pct=0.05)
+    guard, _ = _guard_with_capture(pf, msgbus, trailing_stop_pct=0.10)
 
-    # 建仓即亏：-4% 建"峰值"-4%（仍为负），再跌到 -15%
-    assert guard.evaluate(_bar(96.0, ts_ns=1)) == []
-    # peak-pct = -4% - (-15%) = 11% >= 5%，但 peak 从未 > 0 → 不触发 trailing
-    assert guard.evaluate(_bar(85.0, ts_ns=2)) == []
+    # 峰值 mark=200（+100%）
+    assert guard.evaluate(_bar(200.0, ts_ns=1)) == []
+    # mark=185：自峰值价回撤 (200-185)/200=7.5% < 10% → 不触发
+    #（旧的成本收益率口径会是 100%-85%=15% >=10% 误触发——本测试钉住新口径）
+    assert guard.evaluate(_bar(185.0, ts_ns=2)) == []
+    # mark=175：自峰值价回撤 (200-175)/200=12.5% >= 10% → 触发
+    orders = guard.evaluate(_bar(175.0, ts_ns=3))
+    assert len(orders) == 1
+    assert orders[0].tag == "trailing_stop_loss"
+
+
+def test_trailing_inactive_when_never_profitable() -> None:
+    """移动止损仅在仓位进入盈利区后生效；从未盈利(峰值价≤成本)不触发(CR #88 medium)。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(pf, msgbus, trailing_stop_pct=0.10)
+
+    # 开仓即走低：mark 95（峰值价=95<成本100），再跌到 80
+    assert guard.evaluate(_bar(95.0, ts_ns=1)) == []
+    # 自峰值价 95 回撤 (95-80)/95≈15.8% >= 10%，但峰值价 95 < 成本 100 → trailing 不生效
+    assert guard.evaluate(_bar(80.0, ts_ns=2)) == []
 
 
 # ─── 工厂 / 关闭 / 边界 ───
@@ -227,3 +245,53 @@ def test_no_strategy_bound_returns_empty() -> None:
     # 没 bind
     assert guard.evaluate(_bar(50.0)) == []
     assert captured == []
+
+
+def test_bind_strategy_rejects_second_strategy() -> None:
+    """单策略约束：绑第二个不同 strategy_id → RuntimeError(CR #88)。"""
+    import pytest
+
+    msgbus = MessageBus()
+    pf = Portfolio(msgbus, initial_cash=10_000.0)
+    guard = PositionGuard(msgbus, TestClock(0), pf, stop_loss_pct=0.20)
+    guard.bind_strategy(StrategyId("A"))
+    guard.bind_strategy(StrategyId("A"))  # 同 id 重复绑定 ok（幂等）
+    with pytest.raises(RuntimeError, match="只支持单策略"):
+        guard.bind_strategy(StrategyId("B"))
+
+
+def _order(tag: str | None, coid: str, side: OrderSide = OrderSide.SELL) -> Order:
+    return Order(
+        client_order_id=ClientOrderId(coid),
+        instrument_id=_btc(),
+        side=side,
+        type=OrderType.MARKET,
+        quantity=1.0,
+        tag=tag,
+    )
+
+
+def test_is_protective_order_requires_sell_tag_and_guard_prefix() -> None:
+    """CR #88 major 回归：风控豁免三因子判定（side=SELL + tag + guard 前缀），缺一即仿冒。
+
+    - guard 真出场单（SELL + tag ∈ 保护集 + 'guard-' 前缀）→ True
+    - 仅改 tag（普通 client_order_id）→ False
+    - guard 前缀但非保护性 tag → False
+    - **BUY 单即便 tag + 前缀都伪造 → False**（guard 永不做 BUY；挡借豁免下超大开仓单）
+    """
+    # guard 真单
+    assert is_protective_order(_order("stop_loss", "guard-BTC/USDT-abc123")) is True
+    # 仅改 tag
+    assert is_protective_order(_order("stop_loss", "sma-BTC/USDT-deadbeef")) is False
+    # guard 前缀但 tag 不在保护集
+    assert is_protective_order(_order("signal", "guard-BTC/USDT-xyz")) is False
+    # 双因子全伪造但 side=BUY → 仍 False（side 守门挡掉借豁免开超大单）
+    forged_buy = _order("stop_loss", "guard-BTC/USDT-evil", side=OrderSide.BUY)
+    assert is_protective_order(forged_buy) is False
+    # guard 自己产的出场单恒满足（与生产构造一致）
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+    orders = guard.evaluate(_bar(70.0))
+    assert len(orders) == 1
+    assert is_protective_order(orders[0]) is True


### PR DESCRIPTION
## 背景

main 经 d12 合并已含**早期版** PositionGuard（ADR-0052），但缺了 #88 七轮 CR 的加固——其中两条是**真风控缺口**。本 PR 是针对当前 main 的**纯加固 delta**（不重复已在 main 的基础实现），把 #88 的修复整合进来。#88 因 base 被 main 取代、平行实现冲突已关闭。

## 修的什么（main 现状 → 本 PR）

**风控（major）**
- `is_protective_order` 从单因子(只看 `order.tag`)→ **三因子**(`side==SELL` + tag ∈ 保护集 + `client_order_id` 以 `guard-` 前缀)。否则策略写 `Order(tag="stop_loss")` 即可仿冒、绕过 `enforce`（熔断锁期内继续开仓）
- 保护性出场**同时豁免 `check_order_notional`**：价涨/累积建仓后止损 SELL 的 notional 必然超单笔上限，原先会被拒 → 持仓不动 → 每根 bar 重试又被拒 → **止损静默失效**

**观测（major）**
- `report.protective_exits` 从按 tag 计数 → 按 `FillRecord.is_guard`（成交侧三因子算出）。否则策略自带 `tag="stop_loss"` 会被混入 → agent 误报"框架止损 N 次"

**架构 / 一致性 / 其它**
- `PROTECTIVE_EXIT_TAGS` / `GUARD_ORDER_PREFIX` / `is_protective_*` 移到 `model.orders` 中立层 → 消除 engine↔execution 循环依赖
- 末根 bar 触发的保护单收尾按 close 兜底成交（`flush_protective_at_close`），对齐 live
- trailing 改自峰值**价格**回撤口径（非成本收益率降幅）
- `add_strategy` 启用 guard 时多策略显式 `RuntimeError`；live 出单日志区分 guard/策略
- TS `BacktestReport.protective_exits` 改非 optional

## 保留 main 的内容

合并保留了 main 的 SharpeCI 响应映射、report 的 bootstrap CI、以及 main 自己的同 bar 双 SELL 回归测试——本 PR 只叠加加固，不回退 main 的工作。

## 验证

- `uv run ruff check .` ✅ · 全套 **762 passed**（确定序）· 无循环依赖（导入冒烟）
- 测试为两边并集：#88 的三因子/BUY 仿冒/is_guard 计数/末根/多策略回归 + main 的双 SELL 回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)