### PR TITLE
test+fix(paper): CR backlog 收口 — live_runner flaky 超时 + PositionGuard 去重 + 多租户红线 (#90 #91)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ approval_token 状态机（D-8/D-9）→ LLM 自创策略沙盒 + 风控引擎 +
 - ❌ 不在 `services/_shared/` 加项目特有逻辑（破坏复用）
 - ❌ 不写跳过测试 / 跳过 hook 的 commit（`--no-verify` 等）——遇阻先 ask user
 - ❌ 不在不公开源码的前提下把 Inalpha（或其修改版）当作网络服务对外提供（LICENSE: AGPL-3.0；需闭源 / 托管 SaaS 请提 issue 谈双重许可）
+- ❌ 多租户上线前不验证 promote 审批已按用户隔离：现 askCache 在缺稳定会话 id 时落 `__global__`（单租户兜底），需先让 Mastra 把 `threadId`/`resourceId` 注入 tool ctx，否则 A 的审批会被 B 复用（越权）。详 #91 / `hooks/with-hooks.ts` 注释
 
 ---
 

--- a/services/paper/src/inalpha_paper/engine/live_session.py
+++ b/services/paper/src/inalpha_paper/engine/live_session.py
@@ -30,7 +30,7 @@ from ..kernel.identifiers import ClientOrderId, InstrumentId, StrategyId, VenueO
 from ..kernel.msgbus import MessageBus
 from ..model.commands import SubmitOrderCommand
 from ..model.data import Bar
-from ..model.orders import Order, OrderSide, OrderType
+from ..model.orders import Order, OrderSide, OrderType, is_protective_order
 from ..strategy.base import RISK_ENGINE_ENDPOINT, Strategy
 from .portfolio import Portfolio
 from .position_guard import PositionGuard
@@ -244,6 +244,10 @@ class LiveEngineSession:
                 "ts": ts_event,
             },
         )
+        # 保护性出场被拒 → 解除 guard 去重标记，否则出场没成交、持仓不 flat，guard 会永久
+        # 跳过该 inst，灾难止损静默失效（#94 CR）。
+        if self._guard is not None and is_protective_order(order):
+            self._guard.cancel_pending_exit(order.instrument_id)
 
     def restore_position(
         self,

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -76,6 +76,10 @@ class PositionGuard:
         self._strategy_id: StrategyId | None = None
         # 每 instrument 的峰值 mark 价（trailing 用，自峰值价格回撤口径）；持仓转 flat 时清除
         self._peak_mark: dict[InstrumentId, float] = {}
+        # 已提交保护性出场、但持仓尚未平掉的 instrument（出场单下一根才撮合）。
+        # 防 live 撮合延迟 / batch 行情下 evaluate 在持仓仍在时重复提交出场单（#91）。
+        # 持仓转 flat（出场成交）时清除。
+        self._pending_exit_insts: set[InstrumentId] = set()
 
     @staticmethod
     def from_thresholds(
@@ -127,10 +131,15 @@ class PositionGuard:
         pos = self._portfolio.position(inst)
         if pos is None or pos.is_flat:
             self._peak_mark.pop(inst, None)
+            self._pending_exit_insts.discard(inst)  # 出场已成交（持仓平），解除去重标记
             return []
 
         # 仅 spot long；short 留待合约阶段（no-op，避免对 short 误平）
         if pos.quantity <= 0:
+            return []
+
+        # 已下保护性出场但持仓未平（撮合延迟）→ 跳过，不重复提交第二笔出场单（#91）
+        if inst in self._pending_exit_insts:
             return []
 
         avg = pos.avg_open_price
@@ -150,8 +159,10 @@ class PositionGuard:
 
         order = self._build_exit(inst, pos.quantity, tag)
         self._submit(order, bar.ts_event)
-        # 出场单已下，清峰值（持仓将于下一根平掉；防同 instrument 状态泄漏）
+        # 出场单已下，清峰值（持仓将于下一根平掉；防同 instrument 状态泄漏）。
+        # 标记 pending：撮合前若再被 evaluate（live 延迟）不重复下单，待持仓平掉再解除。
         self._peak_mark.pop(inst, None)
+        self._pending_exit_insts.add(inst)
         return [order]
 
     # ─── 内部 ───

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -165,6 +165,14 @@ class PositionGuard:
         self._pending_exit_insts.add(inst)
         return [order]
 
+    def cancel_pending_exit(self, inst: InstrumentId) -> None:
+        """保护性出场单被 reject / cancel（如 live 路由 DB 失败）时调用，解除去重标记。
+
+        否则出场没成交 → 持仓不 flat → evaluate 永久命中 ``_pending_exit_insts`` 跳过该
+        instrument → 灾难止损静默失效（#94 CR）。解除后下一根 bar 重新评估，仍穿阈则重发。
+        """
+        self._pending_exit_insts.discard(inst)
+
     # ─── 内部 ───
 
     def _triggered_tag(

--- a/services/paper/src/inalpha_paper/strategy_authoring/archetypes.py
+++ b/services/paper/src/inalpha_paper/strategy_authoring/archetypes.py
@@ -127,6 +127,8 @@ class MomentumTrendStrategy(Strategy):
             self._position_pct is not None and self._position_pct > 0
             and self._initial_cash > 0 and bar.close > 0
         ):
+            # /1.05 ≈ 5% 缓冲:信号 bar.close 算 qty、下一根 open 才撮合,留余量抗 bar 间
+            # 价格 jitter + 手续费 + 滑点,避免 can_afford 守门拒单(故 position_pct=1.0 约 95% 仓)
             return (self._initial_cash * self._position_pct) / bar.close / 1.05
         return self._trade_size
 
@@ -229,6 +231,8 @@ class MeanReversionStrategy(Strategy):
             self._position_pct is not None and self._position_pct > 0
             and self._initial_cash > 0 and bar.close > 0
         ):
+            # /1.05 ≈ 5% 缓冲:信号 bar.close 算 qty、下一根 open 才撮合,留余量抗 bar 间
+            # 价格 jitter + 手续费 + 滑点,避免 can_afford 守门拒单(故 position_pct=1.0 约 95% 仓)
             return (self._initial_cash * self._position_pct) / bar.close / 1.05
         return self._trade_size
 
@@ -342,6 +346,8 @@ class VolatilityContractionStrategy(Strategy):
             self._position_pct is not None and self._position_pct > 0
             and self._initial_cash > 0 and bar.close > 0
         ):
+            # /1.05 ≈ 5% 缓冲:信号 bar.close 算 qty、下一根 open 才撮合,留余量抗 bar 间
+            # 价格 jitter + 手续费 + 滑点,避免 can_afford 守门拒单(故 position_pct=1.0 约 95% 仓)
             return (self._initial_cash * self._position_pct) / bar.close / 1.05
         return self._trade_size
 
@@ -470,6 +476,8 @@ class MultiFactorStrategy(Strategy):
             self._position_pct is not None and self._position_pct > 0
             and self._initial_cash > 0 and bar.close > 0
         ):
+            # /1.05 ≈ 5% 缓冲:信号 bar.close 算 qty、下一根 open 才撮合,留余量抗 bar 间
+            # 价格 jitter + 手续费 + 滑点,避免 can_afford 守门拒单(故 position_pct=1.0 约 95% 仓)
             return (self._initial_cash * self._position_pct) / bar.close / 1.05
         return self._trade_size
 

--- a/services/paper/tests/test_backtest_e2e.py
+++ b/services/paper/tests/test_backtest_e2e.py
@@ -569,3 +569,47 @@ def test_strategy_own_stop_loss_tag_not_counted_as_guard() -> None:
     assert stop_fills[0].is_guard is False  # 关键：不是框架 guard
     # 框架 guard 计数为 0（不被策略自带 tag 污染）
     assert report.protective_exits == 0
+
+
+def test_live_session_reject_protective_exit_rearms_guard() -> None:
+    """集成（#94）：保护性出场单被 `session.reject_order` 拒 → 经
+    `cancel_pending_exit` 解除去重 → 下一根 bar guard 重新发出场单。
+
+    锁住安全 wiring（reject_order → guard.cancel_pending_exit）防 reject_order 重构回归：
+    guard 层单测只验 guard 自身，这条走完整 LiveEngineSession 路径。无 wiring 则第一笔被拒后
+    持仓永不平、guard 永久跳过 → 只见 1 笔（死锁）。
+    """
+    session = LiveEngineSession(
+        strategy_cls=BuyAndHoldStrategy,
+        instrument_id=_btc(),
+        timeframe="1h",
+        params={},
+        initial_cash=10_000.0,
+        fee_rate=0.0,
+        protective_stop_loss_pct=0.20,
+    )
+    protective_seen = 0
+    for bar in _gen_bars(_CRASH_PRICES):
+        orders = session.feed_bar(bar)
+        session.take_unsupported_orders()
+        for order, sid in orders:
+            is_protective = order.tag in PROTECTIVE_EXIT_TAGS
+            if is_protective:
+                protective_seen += 1
+            # 第一笔保护性出场模拟路由失败 → reject（不 confirm，持仓维持开仓）；
+            # 其余（建仓 BUY、第二笔保护性出场）正常回灌成交。
+            if is_protective and protective_seen == 1:
+                session.reject_order(
+                    order=order, strategy_id=sid,
+                    reason="simulated route failure", ts_event=bar.ts_event,
+                )
+            else:
+                session.confirm_fill(
+                    order=order, strategy_id=sid,
+                    fill_qty=order.quantity, fill_price=bar.close, ts_event=bar.ts_event,
+                )
+    # 第一笔被拒后 guard 重新武装、后续 bar 再发 → 至少 2 笔（无 wiring 则死锁只见 1）
+    assert protective_seen >= 2
+    # 第二笔成交后持仓已平
+    pos = session.portfolio.position(_btc())
+    assert pos is None or pos.is_flat

--- a/services/paper/tests/test_live_runner.py
+++ b/services/paper/tests/test_live_runner.py
@@ -230,7 +230,7 @@ async def test_run_loop_circuit_break_auto_stops(
     monkeypatch.setattr("inalpha_paper.live_runner.risk_guard_mod.enforce", fake_enforce)
     monkeypatch.setattr("inalpha_paper.live_runner.asyncio.sleep", lambda _s: asyncio.sleep(0))
 
-    await asyncio.wait_for(manager._run_loop(run), timeout=2.0)
+    await asyncio.wait_for(manager._run_loop(run), timeout=30.0)  # 抗负载 flaky：墙钟超时只为抓真 hang，重负载下 2s 太短(#90)
 
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
@@ -460,7 +460,7 @@ async def test_run_loop_non_retryable_error_immediate_errored(
     monkeypatch.setattr(manager, "_build_session", fake_build)
     monkeypatch.setattr(manager, "_fetch_latest_bar", fake_fetch)
 
-    await asyncio.wait_for(manager._run_loop(run), timeout=2.0)
+    await asyncio.wait_for(manager._run_loop(run), timeout=30.0)  # 抗负载 flaky：墙钟超时只为抓真 hang，重负载下 2s 太短(#90)
 
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
@@ -491,7 +491,7 @@ async def test_run_loop_retryable_error_accumulates_to_errored(
     monkeypatch.setattr(manager, "_fetch_latest_bar", fake_fetch)
     monkeypatch.setattr("inalpha_paper.live_runner.asyncio.sleep", no_sleep)
 
-    await asyncio.wait_for(manager._run_loop(run), timeout=2.0)
+    await asyncio.wait_for(manager._run_loop(run), timeout=30.0)  # 抗负载 flaky：墙钟超时只为抓真 hang，重负载下 2s 太短(#90)
 
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
@@ -565,7 +565,7 @@ async def test_done_callback_marks_loop_crashed(
     manager.start(run)
     task = manager._tasks[run["id"]]
     with pytest.raises(RuntimeError):  # 证明异常确实逃出了 _run_loop
-        await asyncio.wait_for(task, timeout=2.0)
+        await asyncio.wait_for(task, timeout=30.0)  # 抗负载 flaky：墙钟超时只为抓真 hang，重负载下 2s 太短(#90)
 
     # 兜底写库在 done_callback 另起的 task 里：轮询等它落库
     fresh = None
@@ -605,7 +605,7 @@ async def test_build_errored_path_survives_log_write_failure(
         "inalpha_paper.live_runner.runs_store.append_error_log", always_fail_append
     )
 
-    await asyncio.wait_for(manager._run_loop(run), timeout=2.0)  # 不抛 = 异常没逃出
+    await asyncio.wait_for(manager._run_loop(run), timeout=30.0)  # 抗负载 flaky：墙钟超时只为抓真 hang，重负载下 2s 太短(#90)  # 不抛 = 异常没逃出
 
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])
@@ -702,7 +702,7 @@ async def test_run_loop_build_session_failure_errored(app_with_lifespan: Any) ->
     # → _build_session 加载/审计/契约校验抛错
     run = await _insert_run(uuid4())
 
-    await asyncio.wait_for(manager._run_loop(run), timeout=2.0)
+    await asyncio.wait_for(manager._run_loop(run), timeout=30.0)  # 抗负载 flaky：墙钟超时只为抓真 hang，重负载下 2s 太短(#90)
 
     async with get_conn() as conn:
         fresh = await runs_store.get(conn, run["id"])

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -206,6 +206,24 @@ def test_no_duplicate_exit_while_pending_fill() -> None:
     assert len(captured) == 1  # 没多发第二笔
 
 
+def test_cancel_pending_exit_rearms_guard_after_reject() -> None:
+    """出场单被拒（live 路由失败）→ cancel_pending_exit 解除去重 → 下一根重新触发可再发。
+
+    防 #94 死锁：否则出场没成交、持仓不 flat，guard 永久跳过该 inst → 灾难止损静默失效。
+    """
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, captured = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+
+    guard.evaluate(_bar(79.0, ts_ns=1))  # 出 1 单 + 标 pending
+    assert len(captured) == 1
+    guard.evaluate(_bar(78.0, ts_ns=2))  # pending → 跳过
+    assert len(captured) == 1
+    guard.cancel_pending_exit(_btc())  # 出场被拒 → 解除去重
+    guard.evaluate(_bar(77.0, ts_ns=3))  # 重新评估、仍穿阈 → 再发（不再死锁）
+    assert len(captured) == 2
+
+
 # ─── 工厂 / 关闭 / 边界 ───
 
 

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -184,6 +184,28 @@ def test_trailing_inactive_when_never_profitable() -> None:
     assert guard.evaluate(_bar(80.0, ts_ns=2)) == []
 
 
+# ─── pending-exit 去重（防 live 撮合延迟重复触发，#91）───
+
+
+def test_no_duplicate_exit_while_pending_fill() -> None:
+    """已提交保护性出场、持仓尚未平（撮合下一根才发生）→ 再次 evaluate 不重复下单 (#91)。
+
+    捕获 endpoint 不真撮合，故 pf 持仓在 evaluate 之间保持开仓——模拟 live 撮合延迟。
+    无去重时第二次会再发一笔；有去重则 captured 始终 1。
+    """
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, captured = _guard_with_capture(pf, msgbus, stop_loss_pct=0.20)
+
+    orders1 = guard.evaluate(_bar(79.0, ts_ns=1))  # -21% 穿阈 → 出 1 单 + 标 pending
+    assert len(orders1) == 1
+    assert len(captured) == 1
+
+    orders2 = guard.evaluate(_bar(78.0, ts_ns=2))  # 持仓未平、仍穿阈 → 不重复
+    assert orders2 == []
+    assert len(captured) == 1  # 没多发第二笔
+
+
 # ─── 工厂 / 关闭 / 边界 ───
 
 


### PR DESCRIPTION
收口 PR #89 衍生的两个 follow-up issue（#90 测试 flaky / #91 CR medium backlog）。3 个逻辑 commit，均经 ruff + 相关 pytest（79 passed）+ check-consistency。

## #90 — live_runner 测试负载 flaky（`8e8931a`）
6 处 `asyncio.wait_for(_run_loop/task, timeout=2.0)` 给做真实 DB I/O 的异步 loop 钉死 2s 墙钟。重负载下（全套件 305s vs 空载 66s，4.6×）DB 延迟超 2s → `TimeoutError` → run errored → 假杀。墙钟超时只为抓真 hang，放宽到 30s 既留兜底又不被负载假杀。`Closes #90`

## #91 — CR medium backlog（`c218586` + `b3426f9`）
- **guard live 重触发** → `c218586`：PositionGuard 加 `_pending_exit_insts` 去重。出场单下一根才撮合，live batch/确认延迟下持仓未平时 evaluate 会重复提交；现触发后标记、持仓 flat 时解除、未平期间跳过。回归测试 `test_no_duplicate_exit_while_pending_fill`。
- **骨架 `_qty` 缓冲** → `b3426f9`：`/1.05` 注明是 jitter+fee+滑点缓冲（信号 close 算 qty、下一根 open 撮合），故 position_pct=1.0 约 95% 仓——纠 CR 误读（非单纯 fee 折算 50×）。
- **`__global__` 多租户审批** → `b3426f9`：AGENTS.md §8 加红线（多租户上线前需让 Mastra 注入 threadId/resourceId，否则 promote 审批跨用户越权）。代码级修复（threadId 注入）是更大改动，留 issue 跟踪；本 PR 先把约束写进红线防遗忘。

> #91 三条均 CR 标 medium / 不阻 merge；本 PR 把 guard 去重（真代码修复）+ 两条文档/注释做掉。`__global__` 的代码级 threadId 注入仍可在 #91 留底跟踪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
