### PR TITLE
fix(orchestration): mastra identity middleware → askCache 按已认证主体隔离 (#91)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ approval_token 状态机（D-8/D-9）→ LLM 自创策略沙盒 + 风控引擎 +
 - ❌ 不在 `services/_shared/` 加项目特有逻辑（破坏复用）
 - ❌ 不写跳过测试 / 跳过 hook 的 commit（`--no-verify` 等）——遇阻先 ask user
 - ❌ 不在不公开源码的前提下把 Inalpha（或其修改版）当作网络服务对外提供（LICENSE: AGPL-3.0；需闭源 / 托管 SaaS 请提 issue 谈双重许可）
-- ❌ 多租户上线前不验证 promote 审批已按用户隔离：现 askCache 在缺稳定会话 id 时落 `__global__`（单租户兜底），需先让 Mastra 把 `threadId`/`resourceId` 注入 tool ctx，否则 A 的审批会被 B 复用（越权）。详 #91 / `hooks/with-hooks.ts` 注释
+- ❌ 多租户上线前不给每用户发各自 JWT：promote 审批的 askCache 已按**已认证 sub** 隔离（mastra identity middleware 从 Bearer 注入 → `with-hooks` 读），但 dashboard 现给所有人发同一个 `CONSOLE_SUBJECT` 常量 token；要真隔离须让 dashboard 按登录用户发各自 JWT，否则所有人共享一个 sub scope（A 的审批被 B 复用）。详 #91 / `mastra/index.ts` identityMiddleware
 
 ---
 

--- a/packages/orchestration/src/hooks/index.ts
+++ b/packages/orchestration/src/hooks/index.ts
@@ -12,7 +12,7 @@ export type {
 
 export { HookRunner } from "./runner.js";
 export { toolMatches } from "./matcher.js";
-export { withHooks, defaultGetSessionId } from "./with-hooks.js";
+export { withHooks, defaultGetSessionId, AUTH_SUB_KEY } from "./with-hooks.js";
 export type { PermissionResolver, WithHooksOptions } from "./with-hooks.js";
 
 export { createAuditLogHandler, defaultAuditRegistration } from "./handlers/audit-log.js";

--- a/packages/orchestration/src/hooks/with-hooks.ts
+++ b/packages/orchestration/src/hooks/with-hooks.ts
@@ -62,22 +62,43 @@ type GenericTool = {
  * - ``ctx.runId`` —— **每个 user-turn 一个新值**（不稳定，跨 turn 会变）
  * - 顶层 ``ctx.threadId`` 在 1.10 已**不再存在**（被移进 ``ctx.agent``）
  *
- * 因此优先级：``ctx.agent.threadId`` > ``ctx.agent.resourceId`` >
- * ``requestContext.sessionId`` > 顶层 ``sessionId`` > **undefined**（→ askCache
- * 用稳定的 ``"__global__"`` scope）。
+ * 因此优先级：``requestContext[AUTH_SUB_KEY]``（mastra server.middleware 从 Bearer 注入的
+ * **已认证主体**，#91 多租户隔离的权威 scope）> ``ctx.agent.threadId`` >
+ * ``ctx.agent.resourceId`` > ``requestContext.sessionId`` > 顶层 ``sessionId`` >
+ * **undefined**（→ askCache 用稳定的 ``"__global__"`` scope）。
  *
  * **故意不回退到 ``ctx.runId``**：runId 每 user-turn 一个新值，当 askCache key 会让
  * 跨 turn 审批永远 miss → 死循环（ADR-0018）。stable ``__global__`` 比 unstable runId
  * 更对：跨 turn 能命中，approvalKey 里的 candidateId 仍区分不同候选。
  *
- * 这样 askCache 跨 turn 也能命中（单租户 dev）；多租户隔离需让 threadId 真正进 ctx。
+ * 多租户隔离：dashboard 给每用户发各自 JWT（现发 CONSOLE_SUBJECT 常量）后，askSub 即按
+ * 用户隔离，promote 审批不再跨用户越权——askCache 侧无需再改（#91）。
  */
+/**
+ * mastra ``server.middleware`` 从 Bearer JWT 解出的已认证主体（sub）写进 RequestContext
+ * 的 key（#91）。getSessionId 最高优先读它 → askCache 按已认证主体 scope（替代 __global__）。
+ * 单租户 = console subject（稳定唯一）；多租户 = 每用户隔离，自动生效。
+ */
+export const AUTH_SUB_KEY = "inalpha__authSub";
+
 /** Module-level flag：进程内仅 warn 一次 runId fallback / 完全失败，避免每次 tool 调用刷屏。 */
 let _warnedRunIdFallback = false;
 
 export function defaultGetSessionId(ctx: unknown): string | undefined {
   if (!ctx || typeof ctx !== "object") return undefined;
   const c = ctx as Record<string, unknown>;
+
+  // 最高优先级：mastra server.middleware 注入的已认证主体（#91 多租户 askCache scope）。
+  // requestContext 是 Mastra RequestContext（Map → .get）；也兼容自构造的普通对象。
+  const rcForAuth = c.requestContext;
+  if (rcForAuth && typeof rcForAuth === "object") {
+    const getter = (rcForAuth as { get?: (k: string) => unknown }).get;
+    const authSub =
+      typeof getter === "function"
+        ? pickString(getter.call(rcForAuth, AUTH_SUB_KEY))
+        : pickString((rcForAuth as Record<string, unknown>)[AUTH_SUB_KEY]);
+    if (authSub) return authSub;
+  }
 
   // Mastra 1.10：threadId / resourceId 在 ctx.agent 下（thread-level 稳定）
   const agent = c.agent;

--- a/packages/orchestration/src/hooks/with-hooks.ts
+++ b/packages/orchestration/src/hooks/with-hooks.ts
@@ -52,6 +52,16 @@ type GenericTool = {
 };
 
 /**
+ * mastra ``server.middleware`` 从 Bearer JWT 解出的已认证主体（sub）写进 RequestContext
+ * 的 key（#91）。getSessionId 最高优先读它 → askCache 按已认证主体 scope（替代 __global__）。
+ * 单租户 = console subject（稳定唯一）；多租户 = 每用户隔离，自动生效。
+ */
+export const AUTH_SUB_KEY = "inalpha__authSub";
+
+/** Module-level flag：进程内仅 warn 一次 runId fallback / 完全失败，避免每次 tool 调用刷屏。 */
+let _warnedRunIdFallback = false;
+
+/**
  * 默认 sessionId 抽取器：按优先级从 Mastra runtime context 取**conversation 级**
  * 稳定的 ID。
  *
@@ -74,16 +84,6 @@ type GenericTool = {
  * 多租户隔离：dashboard 给每用户发各自 JWT（现发 CONSOLE_SUBJECT 常量）后，askSub 即按
  * 用户隔离，promote 审批不再跨用户越权——askCache 侧无需再改（#91）。
  */
-/**
- * mastra ``server.middleware`` 从 Bearer JWT 解出的已认证主体（sub）写进 RequestContext
- * 的 key（#91）。getSessionId 最高优先读它 → askCache 按已认证主体 scope（替代 __global__）。
- * 单租户 = console subject（稳定唯一）；多租户 = 每用户隔离，自动生效。
- */
-export const AUTH_SUB_KEY = "inalpha__authSub";
-
-/** Module-level flag：进程内仅 warn 一次 runId fallback / 完全失败，避免每次 tool 调用刷屏。 */
-let _warnedRunIdFallback = false;
-
 export function defaultGetSessionId(ctx: unknown): string | undefined {
   if (!ctx || typeof ctx !== "object") return undefined;
   const c = ctx as Record<string, unknown>;

--- a/packages/orchestration/src/mastra/index.ts
+++ b/packages/orchestration/src/mastra/index.ts
@@ -89,8 +89,9 @@ const observability = new Observability({
  * - 多租户：dashboard 给每用户发各自 JWT → 自动按用户隔离，无需再改 askCache。
  * - 无 / 非法 / 过期 token：不注入，沿用既有 fallback，绝不阻断请求（审批门有后端硬校验兜底）。
  */
-/** 进程内仅 warn 一次 requestContext 缺失（避免每请求刷屏），见 identityMiddleware。 */
+/** 进程内仅 warn 一次 requestContext 缺失 / Bearer 校验失败（避免每请求刷屏），见 identityMiddleware。 */
 let _warnedNoRequestContext = false;
+let _warnedAuthFailure = false;
 
 const identityMiddleware: MiddlewareHandler = async (c, next) => {
   try {
@@ -114,8 +115,18 @@ const identityMiddleware: MiddlewareHandler = async (c, next) => {
         }
       }
     }
-  } catch {
-    // 非法 / 过期 token → 不注入身份，沿用 fallback（不阻断；审批门后端硬校验兜底）
+  } catch (err) {
+    // 单次校验失败正常会发生（用户带过期 / 无效 token）→ 静默沿用 fallback，不阻断。
+    // 但若**每个**请求都失败（JWT_SECRET 配错 / getSettings 异常等），#91 隔离会零日志
+    // 静默失效；进程内 warn 一次提示排查（与 requestContext 缺失告警对称，CR #96）。
+    if (!_warnedAuthFailure) {
+      _warnedAuthFailure = true;
+      console.warn(
+        "[identity-mw] Bearer 校验失败，本次不注入 authSub（沿用 __global__）；" +
+          "若每个请求都报此条，多半 JWT_SECRET 配错 → 多租户 #91 隔离静默失效，请排查：",
+        err instanceof Error ? err.message : err,
+      );
+    }
   }
   await next();
 };

--- a/packages/orchestration/src/mastra/index.ts
+++ b/packages/orchestration/src/mastra/index.ts
@@ -26,6 +26,7 @@ if (existsSync(envPath)) {
 
 import { Mastra } from "@mastra/core/mastra";
 import { LibSQLStore } from "@mastra/libsql";
+import type { MiddlewareHandler } from "hono";
 import { PinoLogger } from "@mastra/loggers";
 import {
   ConsoleExporter,
@@ -34,7 +35,9 @@ import {
   SamplingStrategyType,
 } from "@mastra/observability";
 
+import { verifyToken } from "../auth.js";
 import { getSettings } from "../config.js";
+import { AUTH_SUB_KEY } from "../hooks/with-hooks.js";
 import { divinationApiRoutes } from "../divination/api.js";
 import { closePool as closeDivinationPool } from "../divination/repo.js";
 import { permissionsApiRoutes } from "../permissions/api.js";
@@ -70,6 +73,39 @@ const observability = new Observability({
   },
 });
 
+/**
+ * 身份注入 middleware（#91 多租户审批隔离根治）。
+ *
+ * 从 ``Authorization: Bearer <jwt>`` 解出 ``sub`` → 写进 Mastra ``requestContext`` 的
+ * ``MASTRA_RESOURCE_ID_KEY`` → Mastra 把它注入工具的 ``ctx.agent.resourceId`` →
+ * ``withHooks.defaultGetSessionId`` 本就优先读 resourceId → askCache 按**已认证主体**
+ * scope，替代不稳定的 ``__global__`` fallback（promote 审批不再跨用户越权）。
+ *
+ * - 单租户 dev：sub 恒为 console subject → scope 稳定且唯一（行为等价 __global__，但显式）。
+ * - 多租户：dashboard 给每用户发各自 JWT → 自动按用户隔离，无需再改 askCache。
+ * - 无 / 非法 / 过期 token：不注入，沿用既有 fallback，绝不阻断请求（审批门有后端硬校验兜底）。
+ */
+const identityMiddleware: MiddlewareHandler = async (c, next) => {
+  try {
+    const authz = c.req.header("Authorization");
+    const token = authz?.startsWith("Bearer ") ? authz.slice(7).trim() : undefined;
+    if (token) {
+      const payload = await verifyToken(token);
+      const sub = typeof payload.sub === "string" && payload.sub ? payload.sub : undefined;
+      if (sub) {
+        // 用自定义 key 而非 MASTRA_RESOURCE_ID_KEY：后者会牵动 Mastra Memory（要求
+        // resourceId+threadId 成对，单设 resourceId 会让无 threadId 的 generate 直接 500）。
+        // 自定义 key 只供 askCache scope 用，与 Memory 解耦。
+        const rc = c.get("requestContext") as { set?: (k: string, v: unknown) => void } | undefined;
+        rc?.set?.(AUTH_SUB_KEY, sub);
+      }
+    }
+  } catch {
+    // 非法 / 过期 token → 不注入身份，沿用 fallback（不阻断；审批门后端硬校验兜底）
+  }
+  await next();
+};
+
 export const mastra = new Mastra({
   storage: observabilityStore,
   // D-8a'：只剩 orchestrator 一个 agent；trader/risk subagent 已废弃
@@ -94,6 +130,7 @@ export const mastra = new Mastra({
   // （ADR-0037 调试记录）。
   server: {
     timeout: 600_000,
+    middleware: identityMiddleware,
     apiRoutes: [...schedulerApiRoutes, ...permissionsApiRoutes, ...divinationApiRoutes],
   },
 });

--- a/packages/orchestration/src/mastra/index.ts
+++ b/packages/orchestration/src/mastra/index.ts
@@ -77,14 +77,21 @@ const observability = new Observability({
  * 身份注入 middleware（#91 多租户审批隔离根治）。
  *
  * 从 ``Authorization: Bearer <jwt>`` 解出 ``sub`` → 写进 Mastra ``requestContext`` 的
- * ``MASTRA_RESOURCE_ID_KEY`` → Mastra 把它注入工具的 ``ctx.agent.resourceId`` →
- * ``withHooks.defaultGetSessionId`` 本就优先读 resourceId → askCache 按**已认证主体**
- * scope，替代不稳定的 ``__global__`` fallback（promote 审批不再跨用户越权）。
+ * **自定义 key ``AUTH_SUB_KEY``** → ``withHooks.defaultGetSessionId`` 最高优先读
+ * ``requestContext[AUTH_SUB_KEY]`` → askCache 按**已认证主体** scope，替代不稳定的
+ * ``__global__`` fallback（promote 审批不再跨用户越权）。
+ *
+ * **为何用自定义 key 而非 ``MASTRA_RESOURCE_ID_KEY``**：后者会牵动 Mastra Memory
+ * （要求 resourceId+threadId 成对，单设 resourceId 会让无 threadId 的 generate 直接 500，
+ * spike 实测踩到）。自定义 key 只供 askCache scope，与 Memory 的 resourceId 机制**完全解耦**。
  *
  * - 单租户 dev：sub 恒为 console subject → scope 稳定且唯一（行为等价 __global__，但显式）。
  * - 多租户：dashboard 给每用户发各自 JWT → 自动按用户隔离，无需再改 askCache。
  * - 无 / 非法 / 过期 token：不注入，沿用既有 fallback，绝不阻断请求（审批门有后端硬校验兜底）。
  */
+/** 进程内仅 warn 一次 requestContext 缺失（避免每请求刷屏），见 identityMiddleware。 */
+let _warnedNoRequestContext = false;
+
 const identityMiddleware: MiddlewareHandler = async (c, next) => {
   try {
     const authz = c.req.header("Authorization");
@@ -93,11 +100,18 @@ const identityMiddleware: MiddlewareHandler = async (c, next) => {
       const payload = await verifyToken(token);
       const sub = typeof payload.sub === "string" && payload.sub ? payload.sub : undefined;
       if (sub) {
-        // 用自定义 key 而非 MASTRA_RESOURCE_ID_KEY：后者会牵动 Mastra Memory（要求
-        // resourceId+threadId 成对，单设 resourceId 会让无 threadId 的 generate 直接 500）。
-        // 自定义 key 只供 askCache scope 用，与 Memory 解耦。
         const rc = c.get("requestContext") as { set?: (k: string, v: unknown) => void } | undefined;
-        rc?.set?.(AUTH_SUB_KEY, sub);
+        if (typeof rc?.set === "function") {
+          rc.set(AUTH_SUB_KEY, sub);
+        } else if (!_warnedNoRequestContext) {
+          // 防御性可观测：rc 缺失则已验证的 sub 被丢、askCache 静默落回 __global__、#91 隔离
+          // 悄然复现。Mastra 升级若改了中间件初始化顺序最可能触发——进程内 warn 一次即够定位。
+          _warnedNoRequestContext = true;
+          console.warn(
+            "[identity-mw] requestContext 不可用（无 .set）——authSub 未注入，askCache 落回 " +
+              "__global__；Mastra 升级后请复查中间件与 requestContext 初始化顺序（#91 隔离失效）。",
+          );
+        }
       }
     }
   } catch {

--- a/packages/orchestration/src/mastra/index.ts
+++ b/packages/orchestration/src/mastra/index.ts
@@ -89,9 +89,9 @@ const observability = new Observability({
  * - 多租户：dashboard 给每用户发各自 JWT → 自动按用户隔离，无需再改 askCache。
  * - 无 / 非法 / 过期 token：不注入，沿用既有 fallback，绝不阻断请求（审批门有后端硬校验兜底）。
  */
-/** 进程内仅 warn 一次 requestContext 缺失 / Bearer 校验失败（避免每请求刷屏），见 identityMiddleware。 */
+/** 进程内仅 warn 一次 requestContext 缺失 / Bearer 签名失败（避免每请求刷屏），见 identityMiddleware。 */
 let _warnedNoRequestContext = false;
-let _warnedAuthFailure = false;
+let _warnedAuthSignature = false;
 
 const identityMiddleware: MiddlewareHandler = async (c, next) => {
   try {
@@ -116,15 +116,17 @@ const identityMiddleware: MiddlewareHandler = async (c, next) => {
       }
     }
   } catch (err) {
-    // 单次校验失败正常会发生（用户带过期 / 无效 token）→ 静默沿用 fallback，不阻断。
-    // 但若**每个**请求都失败（JWT_SECRET 配错 / getSettings 异常等），#91 隔离会零日志
-    // 静默失效；进程内 warn 一次提示排查（与 requestContext 缺失告警对称，CR #96）。
-    if (!_warnedAuthFailure) {
-      _warnedAuthFailure = true;
+    // 过期 / 格式错 token 是正常用户行为（高频）→ 静默沿用 fallback，不阻断、不刷屏。
+    // **只对签名验证失败**（ERR_JWS_SIGNATURE_VERIFICATION_FAILED）进程内 warn 一次：受信
+    // dashboard→mastra 链路下签名失败基本=JWT_SECRET 配错，若系统性配错则每请求都触发、
+    // 第一笔即告警，#91 隔离静默失效可见。把告警配额留给"配错"信号、不被高频过期 token
+    // 提前耗掉（CR #96 round3：旧 _warnedAuthFailure 会被过期 token 先消耗）。
+    const code = (err as { code?: unknown } | null)?.code;
+    if (code === "ERR_JWS_SIGNATURE_VERIFICATION_FAILED" && !_warnedAuthSignature) {
+      _warnedAuthSignature = true;
       console.warn(
-        "[identity-mw] Bearer 校验失败，本次不注入 authSub（沿用 __global__）；" +
-          "若每个请求都报此条，多半 JWT_SECRET 配错 → 多租户 #91 隔离静默失效，请排查：",
-        err instanceof Error ? err.message : err,
+        "[identity-mw] Bearer 签名验证失败（多半 JWT_SECRET 配错）——authSub 未注入、" +
+          "askCache 落回 __global__、多租户 #91 隔离静默失效，请排查 JWT_SECRET。",
       );
     }
   }

--- a/packages/orchestration/tests/hooks.test.ts
+++ b/packages/orchestration/tests/hooks.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_GRID_MAX,
   HookRunner,
   createAuditLogHandler,
+  AUTH_SUB_KEY,
   createGridSizeCapHandler,
   createToolIdempotencyHandlers,
   defaultAuditRegistration,
@@ -683,6 +684,19 @@ describe("audit-log handler", () => {
 // ────────────────────────────────────────────────────────────────────
 
 describe("defaultGetSessionId", () => {
+  it("prefers requestContext authSub — mastra middleware 注入的已认证主体 (#91 多租户 scope)", () => {
+    // RequestContext 是 Map（.get）；authSub 高于 agent.threadId
+    const rc = new Map<string, unknown>([[AUTH_SUB_KEY, "user-42"]]);
+    expect(defaultGetSessionId({ requestContext: rc, agent: { threadId: "t-1" } })).toBe(
+      "user-42",
+    );
+  });
+
+  it("authSub 缺失 → 落回既有优先级（不影响无中间件的路径）", () => {
+    const rc = new Map<string, unknown>();
+    expect(defaultGetSessionId({ requestContext: rc, agent: { threadId: "t-1" } })).toBe("t-1");
+  });
+
   it("prefers threadId (Mastra native)", () => {
     expect(defaultGetSessionId({ threadId: "t-1", runId: "r-1" })).toBe("t-1");
   });


### PR DESCRIPTION
## #91 多租户审批越权根治（askCache 按已认证主体 scope）

承接 #91：promote 审批的 askCache 此前在 dock 路径无稳定会话 id 时落 `__global__`（进程全局 → 用户 A 的批准会被 B 在 60s TTL 内复用，越权）。根因是 AG-UI/mastra 远程路径不把 thread/resource 注入 tool `ctx`（promote 死循环排查时已查实）。

## 修复（spike 确认可行后实现）
1. **mastra `server.middleware`（`mastra/index.ts` identityMiddleware）**：从 `Authorization: Bearer` 解出 `sub` → `requestContext.set(AUTH_SUB_KEY, sub)`。
2. **`with-hooks.defaultGetSessionId`** 最高优先读 `ctx.requestContext` 里的 `AUTH_SUB_KEY` → askCache 按**已认证主体** scope。
3. 用**自定义 key** 而非 `MASTRA_RESOURCE_ID_KEY`：后者牵动 Mastra Memory（要 resourceId+threadId 成对，单设 resourceId 会让无 threadId 的 generate 直接 500——spike 实测踩到）。自定义 key 与 Memory 解耦，dock/直连/playground 都安全。
4. 无 / 非法 / 过期 token → 不注入，沿用既有 `__global__` fallback，绝不阻断（审批门有后端硬校验兜底）。

## spike 实测确认（链路通）
带 Bearer 打 `/api/agents/orchestrator/generate`：
```
[identity-mw] set authSub=console:dev
[with-hooks] getSessionId via authSub=console:dev   ← 工具侧真读到
generate HTTP 200                                   ← 自定义 key 不碰 Memory，不 500
```
无 token 路径不受影响。

## 影响
- **单租户 dev**：sub 恒为 console subject → scope 稳定唯一（行为等价 __global__，但显式、按主体）。
- **多租户**：只差 dashboard 给每用户发各自 JWT（现发 `CONSOLE_SUBJECT` 常量）；发了之后**askCache 自动按用户隔离，无需再改**。AGENTS.md §8 红线已更新为此。

## 验证
`pnpm typecheck` ✓ / `pnpm vitest run` 411 真实过（1 个已知 flaky `foreach`，见 #90）/ `check-consistency` 0 失败。回归测试 `hooks.test.ts`：authSub 优先 / 缺失落回既有优先级。

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
