### PR TITLE
feat(paper): Position Guard 加 Chandelier ATR 移动止损 (ADR-0052 增补 A)

### DIFF
--- a/services/paper/src/inalpha_paper/config.py
+++ b/services/paper/src/inalpha_paper/config.py
@@ -173,6 +173,21 @@ class PaperSettings(BaseSettings):
         description="框架级移动止损：仓位进入盈利区后，自【峰值价格】回撤 X → 全平（锁大利润，"
         "口径是价格自峰值的跌幅，非成本收益率降幅）。默认 None = 关（设 0 不合法，gt=0）。",
     )
+    protective_chandelier_atr_mult: float | None = Field(
+        default=None,
+        alias="INALPHA_PROTECTIVE_CHANDELIER_ATR_MULT",
+        gt=0.0,
+        description="框架级 Chandelier（吊灯）ATR 移动止损（ADR-0052 增补 A）：止损位 = 开仓"
+        "以来最高价 − X×ATR，随波动自适应（高波动品种止损位自动放宽）。默认 None = 关（设 0 "
+        "不合法，gt=0）。与 trailing_stop_pct 通常二选一；动量策略搭配 chandelier 是经典打法。",
+    )
+    protective_chandelier_atr_period: int = Field(
+        default=22,
+        alias="INALPHA_PROTECTIVE_CHANDELIER_ATR_PERIOD",
+        ge=2,
+        description="Chandelier ATR 周期（Wilder RMA），默认 22（经典 chandelier 取值）。"
+        "仅在 protective_chandelier_atr_mult 启用时生效。",
+    )
 
     # ─── D-12 · 因子衰减巡检（ADR-0047）────────────────────────────────
 

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -50,6 +50,8 @@ class BacktestEngine:
         protective_stop_loss_pct: float | None = None,
         protective_take_profit_pct: float | None = None,
         protective_trailing_stop_pct: float | None = None,
+        protective_chandelier_atr_mult: float | None = None,
+        protective_chandelier_atr_period: int = 22,
     ) -> None:
         """初始化。
 
@@ -63,6 +65,8 @@ class BacktestEngine:
             protective_stop_loss_pct: ADR-0052 框架级持仓保护止损阈值（None = 关）
             protective_take_profit_pct: 框架级止盈阈值（None = 关）
             protective_trailing_stop_pct: 框架级移动止损阈值（None = 关）
+            protective_chandelier_atr_mult: Chandelier ATR 移动止损倍数（增补 A，None = 关）
+            protective_chandelier_atr_period: Chandelier ATR 周期（默认 22）
         """
         # 内核
         self.clock = TestClock(0)
@@ -85,7 +89,7 @@ class BacktestEngine:
         self.exchange.bind_portfolio(self.portfolio)
 
         # ADR-0052：框架级持仓保护止损（与 live session 共用同一组件，行为一致）。
-        # 三阈值全 None → from_thresholds 返 None，退化为无 guard（向后兼容）。
+        # 所有闸阈值全 None → from_thresholds 返 None，退化为无 guard（向后兼容）。
         self._guard = PositionGuard.from_thresholds(
             self.msgbus,
             self.clock,
@@ -93,6 +97,8 @@ class BacktestEngine:
             stop_loss_pct=protective_stop_loss_pct,
             take_profit_pct=protective_take_profit_pct,
             trailing_stop_pct=protective_trailing_stop_pct,
+            chandelier_atr_mult=protective_chandelier_atr_mult,
+            chandelier_atr_period=protective_chandelier_atr_period,
         )
 
         self._strategies: list[Strategy] = []

--- a/services/paper/src/inalpha_paper/engine/live_session.py
+++ b/services/paper/src/inalpha_paper/engine/live_session.py
@@ -116,6 +116,8 @@ class LiveEngineSession:
         protective_stop_loss_pct: float | None = None,
         protective_take_profit_pct: float | None = None,
         protective_trailing_stop_pct: float | None = None,
+        protective_chandelier_atr_mult: float | None = None,
+        protective_chandelier_atr_period: int = 22,
     ) -> None:
         self.clock = TestClock(0)
         self.msgbus = MessageBus()
@@ -133,7 +135,7 @@ class LiveEngineSession:
         self._strategy = self._build_strategy(strategy_cls, params, initial_cash)
         self._strategy.on_start()  # 策略在此订阅 bars（subscribe_bars）
 
-        # ADR-0052：框架级持仓保护止损（与回测引擎共用同一组件，行为一致）。三阈值全
+        # ADR-0052：框架级持仓保护止损（与回测引擎共用同一组件，行为一致）。所有闸阈值全
         # None → None（退化为无 guard）。出场单直发 ExecutionEngine → 被 _CaptureGateway
         # 收走，与策略单一起由 runner 走护栏 plan/exec 路由（runner 对保护性 tag 跳过开仓闸）。
         self._guard = PositionGuard.from_thresholds(
@@ -143,6 +145,8 @@ class LiveEngineSession:
             stop_loss_pct=protective_stop_loss_pct,
             take_profit_pct=protective_take_profit_pct,
             trailing_stop_pct=protective_trailing_stop_pct,
+            chandelier_atr_mult=protective_chandelier_atr_mult,
+            chandelier_atr_period=protective_chandelier_atr_period,
         )
         if self._guard is not None:
             self._guard.bind_strategy(self._strategy.strategy_id)

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -52,14 +52,16 @@ class _ChandelierState:
 
     period: int
     atr: float | None = None
-    highest_high: float = 0.0
+    highest_high: float = 0.0  # 止损距离基准（chandelier 标准用最高价）
+    highest_close: float = 0.0  # 激活门基准（close-based，与百分比 trailing 同口径）
     _prev_close: float | None = None
     _tr_count: int = 0
     _tr_seed_sum: float = 0.0
 
     def update(self, bar: Bar) -> None:
-        """用当根 bar 推进最高价与 ATR（Wilder RMA）。"""
+        """用当根 bar 推进最高价 / 最高收盘 / ATR（Wilder RMA）。"""
         self.highest_high = max(self.highest_high, bar.high)
+        self.highest_close = max(self.highest_close, bar.close)
         if self._prev_close is not None:
             tr = max(
                 bar.high - bar.low,
@@ -261,13 +263,15 @@ class PositionGuard:
         if self._stop_loss_pct is not None and pct <= -self._stop_loss_pct:
             return "stop_loss"
         # chandelier（吊灯）ATR 移动止损（增补 A）：止损位 = 开仓以来最高价 − mult×ATR，随波动
-        # 自适应。仅在「曾进盈利区」（最高价 > 成本）+ ATR 种子就绪后生效；复用 trailing_stop_loss
-        # tag（语义同为移动止损，避免新增 exit_reason 迁移）。
+        # 自适应。激活门用「曾收盘进盈利区」（highest_close > 成本）——与百分比 trailing 的
+        # close-based peak_mark>avg 同口径，避免单根上影线（high>avg 但 close<avg）误激活
+        # （#97 CR）；止损距离仍用 highest_high（chandelier 标准）。ATR 种子就绪后才判；复用
+        # trailing_stop_loss tag（语义同为移动止损，避免新增 exit_reason 迁移）。
         if (
             self._chandelier_atr_mult is not None
             and chan is not None
             and chan.atr is not None
-            and chan.highest_high > avg
+            and chan.highest_close > avg
             and mark <= chan.highest_high - self._chandelier_atr_mult * chan.atr
         ):
             return "trailing_stop_loss"

--- a/services/paper/src/inalpha_paper/engine/position_guard.py
+++ b/services/paper/src/inalpha_paper/engine/position_guard.py
@@ -9,6 +9,9 @@
 - **宽兜底,不是紧止损**：默认硬止损放宽（0.20），封尾部风险而非切正常波动；贴行情的
   紧止损是策略层 alpha 的事，框架层只做灾难兜底。
 - **默认只做亏损侧**：硬止损默认开；移动止损 / 止盈默认关（封上行偏 alpha，会伤趋势）。
+- **Chandelier（吊灯）ATR 移动止损（ADR-0052 增补 A）**：除固定百分比 trailing，另有一档
+  基于 ATR 的吊灯移动止损（``mark ≤ 最高价 − atr_mult × ATR``），止损位随波动自适应；
+  **复用 ``trailing_stop_loss`` tag**（语义同为移动止损，避免新增 exit_reason 迁移），默认关。
 - **不偷未来**：在 bar close 的 mark 判定，出场单**下一根 bar 撮合**（与策略下单同语义），
   与 live 只能在收盘 bar 行动完全对齐。
 - **绕过开仓闸**：保护性出场直接走 ``EXECUTION_ENGINE_ENDPOINT``，**不经 RiskEngine**——
@@ -22,6 +25,7 @@
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -37,6 +41,41 @@ if TYPE_CHECKING:
     from .portfolio import Portfolio
 
 
+@dataclass
+class _ChandelierState:
+    """单 instrument 的 chandelier 状态：Wilder RMA ATR + 开仓以来最高价。
+
+    ATR 递推与 ``strategies/atr_channel.py`` 同口径：前 ``period`` 根 TR 均值做种子，之后
+    指数式平滑。``update`` 在 bar close 调用——已知当根完整 OHLC，无 lookahead（与 guard
+    "收盘判定、下一根撮合"语义一致）。持仓转 flat 时整个 state 被丢弃，下次开仓重新累积。
+    """
+
+    period: int
+    atr: float | None = None
+    highest_high: float = 0.0
+    _prev_close: float | None = None
+    _tr_count: int = 0
+    _tr_seed_sum: float = 0.0
+
+    def update(self, bar: Bar) -> None:
+        """用当根 bar 推进最高价与 ATR（Wilder RMA）。"""
+        self.highest_high = max(self.highest_high, bar.high)
+        if self._prev_close is not None:
+            tr = max(
+                bar.high - bar.low,
+                abs(bar.high - self._prev_close),
+                abs(bar.low - self._prev_close),
+            )
+            if self.atr is None:
+                self._tr_count += 1
+                self._tr_seed_sum += tr
+                if self._tr_count >= self.period:
+                    self.atr = self._tr_seed_sum / self.period
+            else:
+                self.atr = (self.atr * (self.period - 1) + tr) / self.period
+        self._prev_close = bar.close
+
+
 class PositionGuard:
     """框架级持仓保护止损。被回测引擎与 live session 实例化。
 
@@ -47,6 +86,8 @@ class PositionGuard:
         stop_loss_pct: 单仓浮亏穿 ``-stop_loss_pct`` → 全平（None = 关）
         take_profit_pct: 单仓浮盈穿 ``+take_profit_pct`` → 全平（None = 关）
         trailing_stop_pct: 自峰值浮盈回撤 ``trailing_stop_pct`` → 全平（None = 关）
+        chandelier_atr_mult: 吊灯移动止损倍数，``mark ≤ 最高价 − mult×ATR`` → 全平（None = 关）
+        chandelier_atr_period: 吊灯 ATR 周期（默认 22，经典 chandelier 取值）
     """
 
     def __init__(
@@ -58,14 +99,21 @@ class PositionGuard:
         stop_loss_pct: float | None = None,
         take_profit_pct: float | None = None,
         trailing_stop_pct: float | None = None,
+        chandelier_atr_mult: float | None = None,
+        chandelier_atr_period: int = 22,
     ) -> None:
         for name, val in (
             ("stop_loss_pct", stop_loss_pct),
             ("take_profit_pct", take_profit_pct),
             ("trailing_stop_pct", trailing_stop_pct),
+            ("chandelier_atr_mult", chandelier_atr_mult),
         ):
             if val is not None and val <= 0:
                 raise ValueError(f"{name} must be positive or None, got {val}")
+        if chandelier_atr_mult is not None and chandelier_atr_period < 2:
+            raise ValueError(
+                f"chandelier_atr_period must be >= 2, got {chandelier_atr_period}"
+            )
 
         self._msgbus = msgbus
         self._clock = clock
@@ -73,9 +121,13 @@ class PositionGuard:
         self._stop_loss_pct = stop_loss_pct
         self._take_profit_pct = take_profit_pct
         self._trailing_stop_pct = trailing_stop_pct
+        self._chandelier_atr_mult = chandelier_atr_mult
+        self._chandelier_atr_period = chandelier_atr_period
         self._strategy_id: StrategyId | None = None
         # 每 instrument 的峰值 mark 价（trailing 用，自峰值价格回撤口径）；持仓转 flat 时清除
         self._peak_mark: dict[InstrumentId, float] = {}
+        # 每 instrument 的 chandelier 状态（ATR + 最高价，增补 A）；持仓转 flat 时清除
+        self._chandelier_state: dict[InstrumentId, _ChandelierState] = {}
         # 已提交保护性出场、但持仓尚未平掉的 instrument（出场单下一根才撮合）。
         # 防 live 撮合延迟 / batch 行情下 evaluate 在持仓仍在时重复提交出场单（#91）。
         # 持仓转 flat（出场成交）时清除。
@@ -90,9 +142,16 @@ class PositionGuard:
         stop_loss_pct: float | None,
         take_profit_pct: float | None,
         trailing_stop_pct: float | None,
+        chandelier_atr_mult: float | None = None,
+        chandelier_atr_period: int = 22,
     ) -> PositionGuard | None:
-        """工厂：三个阈值全为 None → 返 None（引擎据此退化为无 guard，向后兼容）。"""
-        if stop_loss_pct is None and take_profit_pct is None and trailing_stop_pct is None:
+        """工厂：所有闸阈值全为 None → 返 None（引擎据此退化为无 guard，向后兼容）。"""
+        if (
+            stop_loss_pct is None
+            and take_profit_pct is None
+            and trailing_stop_pct is None
+            and chandelier_atr_mult is None
+        ):
             return None
         return PositionGuard(
             msgbus,
@@ -101,6 +160,8 @@ class PositionGuard:
             stop_loss_pct=stop_loss_pct,
             take_profit_pct=take_profit_pct,
             trailing_stop_pct=trailing_stop_pct,
+            chandelier_atr_mult=chandelier_atr_mult,
+            chandelier_atr_period=chandelier_atr_period,
         )
 
     def bind_strategy(self, strategy_id: StrategyId) -> None:
@@ -131,6 +192,7 @@ class PositionGuard:
         pos = self._portfolio.position(inst)
         if pos is None or pos.is_flat:
             self._peak_mark.pop(inst, None)
+            self._chandelier_state.pop(inst, None)
             self._pending_exit_insts.discard(inst)  # 出场已成交（持仓平），解除去重标记
             return []
 
@@ -153,15 +215,25 @@ class PositionGuard:
         peak_mark = max(self._peak_mark.get(inst, mark), mark)
         self._peak_mark[inst] = peak_mark
 
-        tag = self._triggered_tag(pct, mark, peak_mark, avg)
+        # chandelier：用当根 bar 推进 ATR + 最高价（增补 A，None 时不建状态、零开销）
+        chan: _ChandelierState | None = None
+        if self._chandelier_atr_mult is not None:
+            chan = self._chandelier_state.get(inst)
+            if chan is None:
+                chan = _ChandelierState(period=self._chandelier_atr_period)
+                self._chandelier_state[inst] = chan
+            chan.update(bar)
+
+        tag = self._triggered_tag(pct, mark, peak_mark, avg, chan)
         if tag is None:
             return []
 
         order = self._build_exit(inst, pos.quantity, tag)
         self._submit(order, bar.ts_event)
-        # 出场单已下，清峰值（持仓将于下一根平掉；防同 instrument 状态泄漏）。
+        # 出场单已下，清峰值 + chandelier 状态（持仓将于下一根平掉；防同 instrument 状态泄漏）。
         # 标记 pending：撮合前若再被 evaluate（live 延迟）不重复下单，待持仓平掉再解除。
         self._peak_mark.pop(inst, None)
+        self._chandelier_state.pop(inst, None)
         self._pending_exit_insts.add(inst)
         return [order]
 
@@ -176,12 +248,30 @@ class PositionGuard:
     # ─── 内部 ───
 
     def _triggered_tag(
-        self, pct: float, mark: float, peak_mark: float, avg: float
+        self,
+        pct: float,
+        mark: float,
+        peak_mark: float,
+        avg: float,
+        chan: _ChandelierState | None,
     ) -> str | None:
-        """按优先级判定触发的保护性 tag：硬止损 > 移动止损 > 止盈（None = 不触发）。"""
+        """按优先级判定触发的保护性 tag：硬止损 > chandelier > 百分比移动止损 > 止盈
+        （None = 不触发）。chandelier 与百分比 trailing 通常二选一配置，同配时按此序谁先穿阈谁先触发。
+        """
         if self._stop_loss_pct is not None and pct <= -self._stop_loss_pct:
             return "stop_loss"
-        # 移动止损：仅在仓位「曾进入盈利区」（峰值价 > 成本）后才生效——锁的是已有利润；
+        # chandelier（吊灯）ATR 移动止损（增补 A）：止损位 = 开仓以来最高价 − mult×ATR，随波动
+        # 自适应。仅在「曾进盈利区」（最高价 > 成本）+ ATR 种子就绪后生效；复用 trailing_stop_loss
+        # tag（语义同为移动止损，避免新增 exit_reason 迁移）。
+        if (
+            self._chandelier_atr_mult is not None
+            and chan is not None
+            and chan.atr is not None
+            and chan.highest_high > avg
+            and mark <= chan.highest_high - self._chandelier_atr_mult * chan.atr
+        ):
+            return "trailing_stop_loss"
+        # 百分比移动止损：仅在仓位「曾进入盈利区」（峰值价 > 成本）后才生效——锁的是已有利润；
         # 用自峰值价格的回撤幅度判定（peak_mark - mark) / peak_mark），不掺成本基准。
         if (
             self._trailing_stop_pct is not None

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -465,6 +465,8 @@ class LiveRunnerManager:
             protective_stop_loss_pct=self._settings.protective_stop_loss_pct,
             protective_take_profit_pct=self._settings.protective_take_profit_pct,
             protective_trailing_stop_pct=self._settings.protective_trailing_stop_pct,
+            protective_chandelier_atr_mult=self._settings.protective_chandelier_atr_mult,
+            protective_chandelier_atr_period=self._settings.protective_chandelier_atr_period,
         )
         warmup_ts = await self._warmup_session(session, run)
         # resume（last_bar_ts 非空 = 本 run 之前跑过）：把 DB 当前持仓灌回 session，让续跑

--- a/services/paper/src/inalpha_paper/runner.py
+++ b/services/paper/src/inalpha_paper/runner.py
@@ -583,7 +583,7 @@ async def _run_engine(
 
     # ADR-0052：从 Settings 解析框架级持仓保护止损阈值（main 进程读，传给子进程；
     # 回测与 live 共用同一阈值，保证行为一致）。
-    sl, tp, ts = _protective_thresholds()
+    sl, tp, ts, ch_mult, ch_period = _protective_thresholds()
 
     if pool is None:
         # 兜底：同进程跑（不真正 CPU 并行，但函数语义一致）
@@ -599,6 +599,8 @@ async def _run_engine(
             protective_stop_loss_pct=sl,
             protective_take_profit_pct=tp,
             protective_trailing_stop_pct=ts,
+            protective_chandelier_atr_mult=ch_mult,
+            protective_chandelier_atr_period=ch_period,
         )
 
     loop = asyncio.get_running_loop()
@@ -616,17 +618,24 @@ async def _run_engine(
         protective_stop_loss_pct=sl,
         protective_take_profit_pct=tp,
         protective_trailing_stop_pct=ts,
+        protective_chandelier_atr_mult=ch_mult,
+        protective_chandelier_atr_period=ch_period,
     )
     return await loop.run_in_executor(pool, fn)
 
 
-def _protective_thresholds() -> tuple[float | None, float | None, float | None]:
-    """从 Settings 读 ADR-0052 框架级持仓保护止损三阈值 ``(stop_loss, take_profit, trailing)``。"""
+def _protective_thresholds() -> tuple[
+    float | None, float | None, float | None, float | None, int
+]:
+    """从 Settings 读 ADR-0052 框架级持仓保护止损阈值
+    ``(stop_loss, take_profit, trailing, chandelier_atr_mult, chandelier_atr_period)``。"""
     s = get_paper_settings()
     return (
         s.protective_stop_loss_pct,
         s.protective_take_profit_pct,
         s.protective_trailing_stop_pct,
+        s.protective_chandelier_atr_mult,
+        s.protective_chandelier_atr_period,
     )
 
 
@@ -643,6 +652,8 @@ def _make_pool_call(
     protective_stop_loss_pct: float | None = None,
     protective_take_profit_pct: float | None = None,
     protective_trailing_stop_pct: float | None = None,
+    protective_chandelier_atr_mult: float | None = None,
+    protective_chandelier_atr_period: int = 22,
 ) -> Any:
     """生成一个无参 callable，丢给 ``run_in_executor``。
 
@@ -664,6 +675,8 @@ def _make_pool_call(
         protective_stop_loss_pct=protective_stop_loss_pct,
         protective_take_profit_pct=protective_take_profit_pct,
         protective_trailing_stop_pct=protective_trailing_stop_pct,
+        protective_chandelier_atr_mult=protective_chandelier_atr_mult,
+        protective_chandelier_atr_period=protective_chandelier_atr_period,
     )
 
 
@@ -680,6 +693,8 @@ def run_engine_in_subprocess(
     protective_stop_loss_pct: float | None = None,
     protective_take_profit_pct: float | None = None,
     protective_trailing_stop_pct: float | None = None,
+    protective_chandelier_atr_mult: float | None = None,
+    protective_chandelier_atr_period: int = 22,
 ) -> BacktestReport:
     """**Top-level 函数 = 可 pickle**：实例化 engine + strategy + 跑 bars，返 ``BacktestReport``。
 
@@ -706,6 +721,8 @@ def run_engine_in_subprocess(
         protective_stop_loss_pct=protective_stop_loss_pct,
         protective_take_profit_pct=protective_take_profit_pct,
         protective_trailing_stop_pct=protective_trailing_stop_pct,
+        protective_chandelier_atr_mult=protective_chandelier_atr_mult,
+        protective_chandelier_atr_period=protective_chandelier_atr_period,
     )
 
     if candidate_code is not None:

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -43,6 +43,21 @@ def _bar(close: float, ts_ns: int = 1) -> Bar:
     )
 
 
+def _ohlc(o: float, h: float, low: float, c: float, ts_ns: int) -> Bar:
+    """显式 OHLC bar（chandelier 测试用：ATR 需要 high/low/prev_close 算 TR）。"""
+    return Bar(
+        instrument_id=_btc(),
+        timeframe="1h",
+        open=o,
+        high=h,
+        low=low,
+        close=c,
+        volume=1.0,
+        ts_event=ts_ns,
+        ts_init=ts_ns,
+    )
+
+
 def _long_portfolio(msgbus: MessageBus, qty: float, avg_price: float) -> Portfolio:
     """建一个持有 long 仓的 Portfolio（通过发一笔 BUY fill 走正常路径建仓）。"""
     pf = Portfolio(msgbus, initial_cash=1_000_000.0, fee_rate=0.0)
@@ -182,6 +197,88 @@ def test_trailing_inactive_when_never_profitable() -> None:
     assert guard.evaluate(_bar(95.0, ts_ns=1)) == []
     # 自峰值价 95 回撤 (95-80)/95≈15.8% >= 10%，但峰值价 95 < 成本 100 → trailing 不生效
     assert guard.evaluate(_bar(80.0, ts_ns=2)) == []
+
+
+# ─── chandelier（吊灯）ATR 移动止损（ADR-0052 增补 A）───
+
+
+def test_chandelier_triggers_on_atr_drop() -> None:
+    """涨出最高价、ATR 种子就绪后，收盘跌穿 最高价 − mult×ATR → 触发 trailing_stop_loss。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(
+        msgbus=msgbus, pf=pf, chandelier_atr_mult=1.0, chandelier_atr_period=2
+    )
+
+    # bar1：建最高价 110，prev_close 未就绪无 TR、atr None → 不触发
+    assert guard.evaluate(_ohlc(100.0, 110.0, 99.0, 108.0, 1)) == []
+    # bar2：最高价升到 120，TR2 入种子（tr_count=1<2）、atr 仍 None → 不触发
+    assert guard.evaluate(_ohlc(108.0, 120.0, 107.0, 118.0, 2)) == []
+    # bar3：最高价 124，TR3 让 atr 种子就绪（atr=10.5）；止损位=124−10.5=113.5，mark=120>113.5 不触发
+    assert guard.evaluate(_ohlc(118.0, 124.0, 116.0, 120.0, 3)) == []
+    # bar4：atr≈10.75，止损位=124−10.75≈113.25，mark=112≤113.25 → 触发，复用 trailing_stop_loss tag
+    orders = guard.evaluate(_ohlc(120.0, 121.0, 110.0, 112.0, 4))
+    assert len(orders) == 1
+    assert orders[0].tag == "trailing_stop_loss"
+    assert orders[0].tag in PROTECTIVE_EXIT_TAGS
+    assert orders[0].quantity == 1.0  # 全平
+
+
+def test_chandelier_no_trigger_before_atr_seeded() -> None:
+    """ATR 种子未就绪（开仓后不足 period 根）期间 chandelier 静默，即便大跌也不触发。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(
+        msgbus=msgbus, pf=pf, chandelier_atr_mult=1.0, chandelier_atr_period=10
+    )
+
+    assert guard.evaluate(_ohlc(100.0, 130.0, 99.0, 128.0, 1)) == []  # 建高点，无 TR
+    # 暴跌到 80（自高点 −38%），但 period=10 atr 远未就绪 → chandelier 不触发
+    assert guard.evaluate(_ohlc(128.0, 129.0, 80.0, 80.0, 2)) == []
+
+
+def test_chandelier_inactive_when_never_profitable() -> None:
+    """chandelier 仅在「曾进盈利区」（最高价 > 成本）后生效；从未盈利不触发。"""
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(
+        msgbus=msgbus, pf=pf, chandelier_atr_mult=1.0, chandelier_atr_period=2
+    )
+
+    # 价格全程在成本 100 之下（最高价 ≤ 99）：atr 会就绪但 highest_high < avg → 不生效
+    assert guard.evaluate(_ohlc(100.0, 99.0, 95.0, 98.0, 1)) == []
+    assert guard.evaluate(_ohlc(98.0, 97.0, 90.0, 92.0, 2)) == []
+    assert guard.evaluate(_ohlc(92.0, 93.0, 80.0, 82.0, 3)) == []
+
+
+def test_from_thresholds_chandelier_only_builds_guard() -> None:
+    """仅配 chandelier（其余 None）→ from_thresholds 仍建出 guard（不退化为 None）。"""
+    msgbus = MessageBus()
+    pf = Portfolio(msgbus, initial_cash=10_000.0)
+    guard = PositionGuard.from_thresholds(
+        msgbus,
+        TestClock(0),
+        pf,
+        stop_loss_pct=None,
+        take_profit_pct=None,
+        trailing_stop_pct=None,
+        chandelier_atr_mult=2.0,
+    )
+    assert guard is not None
+
+
+def test_chandelier_param_validation() -> None:
+    """chandelier_atr_mult ≤ 0 / period < 2 → ValueError。"""
+    import pytest
+
+    msgbus = MessageBus()
+    pf = Portfolio(msgbus, initial_cash=10_000.0)
+    with pytest.raises(ValueError, match="chandelier_atr_mult"):
+        PositionGuard(msgbus, TestClock(0), pf, chandelier_atr_mult=0.0)
+    with pytest.raises(ValueError, match="chandelier_atr_period"):
+        PositionGuard(
+            msgbus, TestClock(0), pf, chandelier_atr_mult=2.0, chandelier_atr_period=1
+        )
 
 
 # ─── pending-exit 去重（防 live 撮合延迟重复触发，#91）───

--- a/services/paper/tests/test_position_guard.py
+++ b/services/paper/tests/test_position_guard.py
@@ -237,6 +237,25 @@ def test_chandelier_no_trigger_before_atr_seeded() -> None:
     assert guard.evaluate(_ohlc(128.0, 129.0, 80.0, 80.0, 2)) == []
 
 
+def test_chandelier_activation_is_close_based_not_wick() -> None:
+    """#97：上影线穿成本（high>avg）但收盘从未站上成本（close<avg）→ chandelier 不激活。
+
+    钉住激活门用 highest_close（close-based，与百分比 trailing 同口径），而非 highest_high；
+    否则单根上影线即误激活、与 trailing 口径不一致。
+    """
+    msgbus = MessageBus()
+    pf = _long_portfolio(msgbus, qty=1.0, avg_price=100.0)
+    guard, _ = _guard_with_capture(
+        msgbus=msgbus, pf=pf, chandelier_atr_mult=1.0, chandelier_atr_period=2
+    )
+
+    # 每根 high 都上影穿 100，但 close 始终 < 100（从未收盘进盈利区）
+    assert guard.evaluate(_ohlc(98.0, 101.0, 97.0, 99.0, 1)) == []
+    assert guard.evaluate(_ohlc(99.0, 102.0, 96.0, 98.0, 2)) == []  # ATR 种子凑齐
+    # mark 大跌：highest_high=102 止损位会被穿，但 highest_close=99 < 成本 100 → 未激活
+    assert guard.evaluate(_ohlc(98.0, 100.0, 85.0, 86.0, 3)) == []
+
+
 def test_chandelier_inactive_when_never_profitable() -> None:
     """chandelier 仅在「曾进盈利区」（最高价 > 成本）后生效；从未盈利不触发。"""
     msgbus = MessageBus()


### PR DESCRIPTION
## 背景

读个人量化博主经验帖后:动量因子 + chandelier(吊灯)止损是其主观趋势交易的工程化对应。框架级 Position Guard 此前只有固定百分比 trailing,固定比例在不同波动品种上一刀切。本 PR 补一档**基于 ATR 的吊灯移动止损**(`mark ≤ 开仓以来最高价 − mult×ATR`),止损位随波动自适应。

## 改动

- `config`: `protective_chandelier_atr_mult`(默认 None=关) + `protective_chandelier_atr_period`(默认 22)
- `position_guard`: `_ChandelierState`(Wilder RMA ATR + 最高价),`_triggered_tag` 加 chandelier 分支(优先级:硬止损 > chandelier > 百分比 trailing > 止盈)
- **复用 `trailing_stop_loss` tag,零迁移**:`is_guard` / `protective_exits` / Cooldown 自动覆盖(语义同为移动止损,避免动 closed_trades.exit_reason CHECK)
- 默认关、回测与 live 共用同组件同阈值、不偷未来(收盘判定、下一根撮合)
- 两引擎构造 + runner 子进程链路 + live_runner 全程透传

## 验证

`ruff` 干净;paper `pytest` 770 passed(+5 chandelier 单测:触发/种子未就绪静默/未盈利不生效/工厂/参数校验);`check-consistency.sh` 0 失败。

设计依据:ADR-0052 增补 A(`docs/miro/decisions/`,gitignored)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)