### PR TITLE
feat(paper,orchestration): WalkForward/CPCV 时序交叉验证回测 (ADR-0028)

### DIFF
--- a/packages/orchestration/config/permissions.default.yaml
+++ b/packages/orchestration/config/permissions.default.yaml
@@ -27,6 +27,8 @@ allow:
   - "paper.run_backtest"
   # D-12 · 参数邻域敏感性（promote 前必跑）：只读回测扇出，无下单路径
   - "paper.check_sensitivity"
+  # ADR-0028 · 多路径时序 CV（深度稳健评估）：只读回测扇出，无下单路径
+  - "paper.cv_backtest"
   - "paper.compose_strategy"
   - "paper.author_strategy"
   - "paper.health"

--- a/packages/orchestration/src/clients/paper.ts
+++ b/packages/orchestration/src/clients/paper.ts
@@ -169,6 +169,45 @@ export type SensitivityResult = {
   verdict: "robust" | "cliff" | "insufficient";
 };
 
+export type CVBacktestParams = {
+  strategyId?: string;
+  candidateId?: string;
+  params?: Record<string, unknown>;
+  venue?: string;
+  symbol: string;
+  timeframe?: string;
+  fromTs: string;
+  toTs: string;
+  initialCash?: number;
+  feeRate?: number;
+  /** 时序 CV 切分器；cpcv（多路径最强）/ walk_forward / purged_kfold */
+  splitter?: "cpcv" | "walk_forward" | "purged_kfold";
+  nFolds?: number;
+  nTestFolds?: number;
+  embargoPct?: number;
+  wfTestSize?: number;
+  wfTrainSize?: number;
+};
+
+export type CVBacktestResult = {
+  symbol: string;
+  timeframe: string;
+  n_bars: number;
+  /** 实际用的 splitter（cpcv 不足回落时 != 请求值） */
+  splitter_used: string;
+  n_paths: number;
+  n_splits: number;
+  sharpe_per_path: number[];
+  max_dd_per_path: number[];
+  sharpe_p5: number;
+  sharpe_p50: number;
+  sharpe_p95: number;
+  sharpe_mean: number;
+  dsr: number | null;
+  dsr_p_value: number | null;
+  note: string | null;
+};
+
 export type BacktestParams = {
   /** 内置策略 ID（与 candidateId 二选一） */
   strategyId?: string;
@@ -541,6 +580,31 @@ export class PaperClient {
       initial_cash: params.initialCash ?? 10_000,
       fee_rate: params.feeRate ?? 0.001,
       pct: params.pct ?? 0.2,
+    });
+  }
+
+  /**
+   * ADR-0028 · 多路径时序交叉验证回测：输出样本外 Sharpe 分布 + DSR。
+   * cpcv 在 bar 不足时自动回落 walk_forward（splitter_used 标明）。
+   */
+  async cvBacktest(params: CVBacktestParams): Promise<CVBacktestResult> {
+    return await this.http.post<CVBacktestResult>("/backtest/cv", {
+      strategy_id: params.strategyId,
+      candidate_id: params.candidateId,
+      params: params.params ?? {},
+      venue: params.venue ?? "binance",
+      symbol: params.symbol,
+      timeframe: params.timeframe ?? "1h",
+      from_ts: params.fromTs,
+      to_ts: params.toTs,
+      initial_cash: params.initialCash ?? 10_000,
+      fee_rate: params.feeRate ?? 0.001,
+      splitter: params.splitter ?? "cpcv",
+      n_folds: params.nFolds ?? 6,
+      n_test_folds: params.nTestFolds ?? 2,
+      embargo_pct: params.embargoPct ?? 0.05,
+      wf_test_size: params.wfTestSize ?? 21,
+      wf_train_size: params.wfTrainSize ?? 252,
     });
   }
 

--- a/packages/orchestration/src/mastra/agents/orchestrator.ts
+++ b/packages/orchestration/src/mastra/agents/orchestrator.ts
@@ -124,6 +124,10 @@ rewrite it; always pass language=<user's language> + userQuestion=<verbatim> whe
   holdout.sharpe < 0 = 过拟合信号
 - paper.check_sensitivity —— 参数邻域 ±20% 扰动回测（D-12）。**promote 前必跑**；
   verdict=cliff = 参数尖峰 = 过拟合，不应 promote
+- paper.cv_backtest —— 多路径时序交叉验证（CPCV，ADR-0028）。**深度/稳健评估**用：
+  用户问"稳不稳/会不会过拟合"或 promote 前把关时跑。看**中位 sharpe_p50**（非最优 path）
+  + DSR；单段好看的 forward-looking 策略 CPCV 中位会塌。成本 N×，别用于探索性首轮回测；
+  bar < 200 自动回落 walk_forward（看 splitter_used / note）
 - paper.list_backtest_trades —— 一次回测的逐笔成交明细，诊断"亏在哪几笔"
 - 迭代改进策略按《迭代纪律》一节执行（有停止规则，不是无限重写）
 - swarm.run_backtest_grid —— **批量**回测（多策略 × 多标的笛卡尔积），返 Pareto + topK

--- a/packages/orchestration/src/permissions/defaults.ts
+++ b/packages/orchestration/src/permissions/defaults.ts
@@ -30,6 +30,8 @@ export const DEFAULT_PERMISSIONS: PermissionConfig = {
     "paper.run_backtest",
     // D-12 · 参数邻域敏感性（promote 前必跑）：只读回测扇出，无下单路径
     "paper.check_sensitivity",
+    // ADR-0028 · 多路径时序 CV（深度稳健评估）：只读回测扇出，无下单路径
+    "paper.cv_backtest",
     "paper.compose_strategy",
     "paper.author_strategy",
     "paper.health",

--- a/packages/orchestration/src/tools/index.ts
+++ b/packages/orchestration/src/tools/index.ts
@@ -19,6 +19,7 @@ import {
 import {
   paperCheckSensitivityTool,
   paperComposeStrategyTool,
+  paperCvBacktestTool,
   paperGetAccountTool,
   paperHealthTool,
   paperListArchetypesTool,
@@ -118,6 +119,7 @@ export {
   paperAuthorStrategyTool,
   paperCheckSensitivityTool,
   paperComposeStrategyTool,
+  paperCvBacktestTool,
   paperGetAccountTool,
   paperGetCandidateTool,
   paperHealthTool,
@@ -238,6 +240,8 @@ export const orchestratorToolList = [
   paperRunBacktestTool,
   // D-12 · 参数邻域敏感性（promote 前必跑，cliff = 过拟合信号）
   paperCheckSensitivityTool,
+  // ADR-0028 · 多路径时序 CV（深度/稳健评估，看 CPCV 中位 Sharpe + DSR）
+  paperCvBacktestTool,
   paperHealthTool,
   // 研究
   researchDeepDiveTool,

--- a/packages/orchestration/src/tools/paper.ts
+++ b/packages/orchestration/src/tools/paper.ts
@@ -348,6 +348,95 @@ export const paperCheckSensitivityTool = createTool({
   },
 });
 
+export const paperCvBacktestTool = createTool({
+  id: "paper.cv_backtest",
+  description: `
+    多路径时序交叉验证回测（ADR-0028）：把策略在多条样本外路径上跑一遍，返回 OOS Sharpe
+    分布（p5/p50/p95）+ Deflated Sharpe（DSR）。单段回测好看的 forward-looking / 过拟合
+    策略，CPCV 多路径下中位 Sharpe 会塌——这是用来抓过拟合的。
+
+    何时用：
+    - **深度 / 稳健性评估**：用户说"稳不稳 / 会不会过拟合 / 深度评估"，或 promote 前把关
+    - Swarm grid TopK 候选晋级的二阶段验证
+
+    何时不用：
+    - 探索性首轮回测（成本 N×，先用 paper.run_backtest 看方向）
+    - 只想看单条收益曲线 → run_backtest
+
+    坑：
+    - cpcv 需 bar >= 200；不足**自动回落 walk_forward**（看返回的 splitter_used / note）
+    - 看**中位 sharpe_p50** 而非最优 path：挑最好那条 = cherry-pick
+    - splitter=cpcv 时 nTestFolds 必须 < nFolds
+  `.trim(),
+  inputSchema: z
+    .object({
+      strategyId: z.string().optional().describe("内置策略 ID；与 candidateId 互斥"),
+      candidateId: z.string().uuid().optional().describe("候选 UUID；与 strategyId 互斥"),
+      params: z.record(z.string(), z.unknown()).default({}).describe("策略参数 dict"),
+      venue: z.string().default("binance"),
+      symbol: SymbolSchema,
+      timeframe: TimeframeSchema.default("1h"),
+      fromTs: z.string().datetime().describe("ISO 8601 起始时间"),
+      toTs: z.string().datetime().describe("ISO 8601 结束时间"),
+      initialCash: z.number().positive().default(10_000),
+      feeRate: z.number().min(0).lt(1).default(0.001),
+      splitter: z
+        .enum(["cpcv", "walk_forward", "purged_kfold"])
+        .default("cpcv")
+        .describe("时序 CV 切分器；cpcv 最强（多路径）"),
+      nFolds: z.number().int().min(2).max(20).default(6).describe("cpcv/kfold 分组数"),
+      nTestFolds: z
+        .number()
+        .int()
+        .min(1)
+        .default(2)
+        .describe("cpcv 每组合取作 test 的组数（须 < nFolds）"),
+      embargoPct: z.number().min(0).lt(1).default(0.05),
+      wfTestSize: z.number().int().min(1).default(21),
+      wfTrainSize: z.number().int().min(1).default(252),
+    })
+    .superRefine((data, ctx) => {
+      const hasId = typeof data.strategyId === "string" && data.strategyId.length > 0;
+      const hasCand = typeof data.candidateId === "string" && data.candidateId.length > 0;
+      if (hasId === hasCand) {
+        ctx.addIssue({
+          code: "custom",
+          message: "必须给 strategyId 或 candidateId，二选一",
+          path: ["strategyId"],
+        });
+      }
+      if (data.splitter === "cpcv" && !(data.nTestFolds < data.nFolds)) {
+        ctx.addIssue({
+          code: "custom",
+          message: "cpcv 要求 nTestFolds < nFolds",
+          path: ["nTestFolds"],
+        });
+      }
+    }),
+  execute: async (inputData, ctx) => {
+    const tc = ctx?.requestContext as ToolRequestContext | undefined;
+    const client = await getClient(tc);
+    return await client.cvBacktest({
+      strategyId: inputData.strategyId,
+      candidateId: inputData.candidateId,
+      params: inputData.params ?? {},
+      venue: inputData.venue ?? "binance",
+      symbol: inputData.symbol,
+      timeframe: inputData.timeframe ?? "1h",
+      fromTs: inputData.fromTs,
+      toTs: inputData.toTs,
+      initialCash: inputData.initialCash ?? 10_000,
+      feeRate: inputData.feeRate ?? 0.001,
+      splitter: inputData.splitter ?? "cpcv",
+      nFolds: inputData.nFolds ?? 6,
+      nTestFolds: inputData.nTestFolds ?? 2,
+      embargoPct: inputData.embargoPct ?? 0.05,
+      wfTestSize: inputData.wfTestSize ?? 21,
+      wfTrainSize: inputData.wfTrainSize ?? 252,
+    });
+  },
+});
+
 // ────────────────────────────────────────────────────────────────────
 // D-8c · paper.compose_strategy + paper.list_backtest_runs
 // ────────────────────────────────────────────────────────────────────
@@ -741,6 +830,7 @@ export const paperTools = [
   paperListStrategiesTool,
   paperRunBacktestTool,
   paperCheckSensitivityTool,
+  paperCvBacktestTool,
   paperHealthTool,
   paperListOrdersTool,
   paperListPositionsTool,

--- a/packages/orchestration/tests/cv-backtest.test.ts
+++ b/packages/orchestration/tests/cv-backtest.test.ts
@@ -1,0 +1,125 @@
+/**
+ * ADR-0028 · paper.cv_backtest tool 单测。
+ *
+ * 覆盖：POST /backtest/cv 透传（splitter 参数 + token）、strategyId/candidateId 互斥、
+ * cpcv nTestFolds < nFolds 校验、默认 permission allow。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearSettings, setSettings } from "../src/config.js";
+import { DEFAULT_PERMISSIONS, PermissionEngine } from "../src/permissions/index.js";
+import { paperCvBacktestTool } from "../src/tools/index.js";
+
+const TEST_TOKEN = "test-token-doesnt-need-to-be-real";
+
+beforeEach(() => {
+  setSettings({
+    dataServiceUrl: "http://data-mock.test",
+    paperServiceUrl: "http://paper-mock.test",
+    researchServiceUrl: "http://research-mock.test",
+    jwtSecret: "test-secret-32-chars-or-more-xxxxxxx",
+    jwtAlgorithm: "HS256",
+  });
+});
+
+afterEach(() => {
+  clearSettings();
+  vi.restoreAllMocks();
+});
+
+function mockFetch(impl: (url: string, init?: RequestInit) => Promise<Response>) {
+  vi.stubGlobal("fetch", vi.fn(impl));
+}
+
+const ctx = (authToken: string | undefined = TEST_TOKEN): never =>
+  ({ requestContext: { authToken } }) as never;
+
+const CV_RESPONSE = {
+  symbol: "BTC/USDT",
+  timeframe: "1d",
+  n_bars: 300,
+  splitter_used: "cpcv",
+  n_paths: 5,
+  n_splits: 30,
+  sharpe_per_path: [0.2, 0.4, 0.5, 0.6, 0.9],
+  max_dd_per_path: [10, 12, 8, 15, 7],
+  sharpe_p5: 0.24,
+  sharpe_p50: 0.5,
+  sharpe_p95: 0.84,
+  sharpe_mean: 0.52,
+  dsr: 0.31,
+  dsr_p_value: 0.12,
+  note: null,
+};
+
+describe("paper.cv_backtest", () => {
+  it("POSTs /backtest/cv 透传 splitter 参数与 token", async () => {
+    let capturedUrl = "";
+    let capturedAuth = "";
+    let capturedBody: Record<string, unknown> = {};
+    mockFetch(async (url, init) => {
+      capturedUrl = url;
+      capturedAuth = (init?.headers as Record<string, string>)?.Authorization ?? "";
+      capturedBody = JSON.parse((init?.body as string) ?? "{}");
+      return new Response(JSON.stringify(CV_RESPONSE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const result = await paperCvBacktestTool.execute!(
+      {
+        strategyId: "sma_cross",
+        params: { fast_period: 5, slow_period: 15 },
+        symbol: "BTC/USDT",
+        timeframe: "1d",
+        fromTs: "2026-01-01T00:00:00Z",
+        toTs: "2026-02-01T00:00:00Z",
+        splitter: "cpcv",
+        nFolds: 6,
+        nTestFolds: 2,
+      } as never,
+      ctx(),
+    );
+
+    expect(capturedUrl).toContain("/backtest/cv");
+    expect(capturedAuth).toBe(`Bearer ${TEST_TOKEN}`);
+    expect(capturedBody.strategy_id).toBe("sma_cross");
+    expect(capturedBody.splitter).toBe("cpcv");
+    expect(capturedBody.n_folds).toBe(6);
+    expect(capturedBody.n_test_folds).toBe(2);
+    expect((result as { n_paths: number }).n_paths).toBe(5);
+    expect((result as { sharpe_p50: number }).sharpe_p50).toBe(0.5);
+  });
+
+  it("strategyId 与 candidateId 互斥（schema superRefine）", () => {
+    const schema = paperCvBacktestTool.inputSchema!;
+    const both = schema.safeParse({
+      strategyId: "sma_cross",
+      candidateId: "550e8400-e29b-41d4-a716-446655440000",
+      symbol: "BTC/USDT",
+      fromTs: "2026-01-01T00:00:00Z",
+      toTs: "2026-02-01T00:00:00Z",
+    });
+    expect(both.success).toBe(false);
+  });
+
+  it("cpcv 要求 nTestFolds < nFolds（schema superRefine）", () => {
+    const schema = paperCvBacktestTool.inputSchema!;
+    const bad = schema.safeParse({
+      strategyId: "sma_cross",
+      symbol: "BTC/USDT",
+      fromTs: "2026-01-01T00:00:00Z",
+      toTs: "2026-02-01T00:00:00Z",
+      splitter: "cpcv",
+      nFolds: 4,
+      nTestFolds: 4,
+    });
+    expect(bad.success).toBe(false);
+  });
+
+  it("默认 permission = allow（只读回测扇出，无下单路径）", () => {
+    const engine = new PermissionEngine(DEFAULT_PERMISSIONS);
+    expect(engine.authorize("paper.cv_backtest", {}).decision).toBe("allow");
+  });
+});

--- a/services/paper/src/inalpha_paper/api/backtest.py
+++ b/services/paper/src/inalpha_paper/api/backtest.py
@@ -17,11 +17,14 @@ from inalpha_shared.errors import UnauthorizedError, ValidationError
 from ..config import PaperSettings, get_paper_settings
 from ..data_client import DataClient
 from ..runner import run_backtest as _run_backtest
+from ..runner import run_cv as _run_cv
 from ..schemas import (
     BacktestRequest,
     BacktestResponse,
     BacktestRunSummary,
     BacktestTradeRecord,
+    CVBacktestRequest,
+    CVBacktestResponse,
     SensitivityRequest,
     SensitivityResponse,
 )
@@ -71,6 +74,40 @@ async def post_backtest(
 
     async with DataClient(settings.data_service_url, user_token) as data_client:
         return await _run_backtest(req, data_client, conn=db)
+
+
+@router.post("/backtest/cv", response_model=CVBacktestResponse)
+async def post_backtest_cv(
+    req: CVBacktestRequest,
+    db: DBConn,
+    settings: Annotated[PaperSettings, Depends(get_paper_settings)],
+    _user: Annotated[User, Depends(get_current_user)],
+    authorization: Annotated[str | None, Header()] = None,
+) -> CVBacktestResponse:
+    """多路径时序交叉验证回测（ADR-0028）：输出样本外 Sharpe 分布 + DSR。
+
+    用途：深度 / 稳健性评估（单段回测好看的 forward-looking 策略，CPCV 多路径中位会塌）。
+    成本 N×，**不该用于探索性首轮回测**；bar < 200 时 cpcv 自动回落 walk_forward。
+    """
+    if req.from_ts >= req.to_ts:
+        raise ValidationError(
+            "from_ts must be < to_ts",
+            details={"from_ts": req.from_ts.isoformat(), "to_ts": req.to_ts.isoformat()},
+        )
+    if req.strategy_id is not None:
+        available = list_strategies()
+        if req.strategy_id not in available:
+            raise ValidationError(
+                f"unknown strategy_id {req.strategy_id!r}",
+                details={"available": available},
+            )
+
+    if not authorization or not authorization.startswith("Bearer "):
+        raise UnauthorizedError("missing Authorization header")
+    user_token = authorization.removeprefix("Bearer ").strip()
+
+    async with DataClient(settings.data_service_url, user_token) as data_client:
+        return await _run_cv(req, data_client, conn=db)
 
 
 @router.post("/backtest/sensitivity", response_model=SensitivityResponse)

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -21,7 +21,8 @@ D-5 阶段简化：
 """
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from datetime import datetime
 
 from ..execution.exchange import SimulatedExchange
@@ -32,9 +33,12 @@ from ..kernel.clock import TestClock
 from ..kernel.msgbus import MessageBus
 from ..model.data import Bar
 from ..strategy.base import Strategy
+from .cv import CombinatorialPurgedCV, PurgedKFold, WalkForward
+from .metrics import max_drawdown_pct, periods_per_year, sharpe_ratio
 from .portfolio import Portfolio
 from .position_guard import PositionGuard
 from .report import BacktestReport
+from .robustness import deflated_sharpe_ratio
 
 
 class BacktestEngine:
@@ -190,3 +194,150 @@ def _ts_to_dt(ts_ns: int) -> datetime:
     from datetime import UTC
 
     return datetime.fromtimestamp(ts_ns / 1_000_000_000, tz=UTC)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CV 多路径回测（ADR-0028 D2）
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class CVReport:
+    """多路径时序交叉验证回测结果（ADR-0028）。
+
+    把一个策略在多条样本外路径上的表现汇成分布——单段回测好看的 forward-looking 策略，
+    在 CPCV 多路径下中位 Sharpe 会塌下来，这正是它要抓的过拟合信号。
+
+    Attributes:
+        n_paths: 重构出的 OOS 路径数（CPCV = C(n_folds-1, n_test_folds-1)；WF/KFold = 1）。
+        n_splits: splitter 产出的 train/test 组合数。
+        sharpe_per_path: 每条路径的**年化** Sharpe。
+        max_dd_per_path: 每条路径的最大回撤（%）。
+        sharpe_p5 / p50 / p95: 路径 Sharpe 分布的 5 / 50 / 95 分位。
+        sharpe_mean: 路径 Sharpe 均值。
+        dsr: 最优路径 Sharpe 在 ``n_paths`` 次试验下的 Deflated Sharpe（None = 不可算）。
+        dsr_p_value: DSR 单边 p 值（< 0.05 提示多重检验下仍显著）。
+    """
+
+    n_paths: int
+    n_splits: int
+    sharpe_per_path: list[float]
+    max_dd_per_path: list[float]
+    sharpe_p5: float
+    sharpe_p50: float
+    sharpe_p95: float
+    sharpe_mean: float
+    dsr: float | None
+    dsr_p_value: float | None
+
+
+def run_cv_backtest(
+    *,
+    build_strategy: Callable[[BacktestEngine], Strategy],
+    bars: list[Bar],
+    splitter: WalkForward | PurgedKFold | CombinatorialPurgedCV,
+    initial_cash: float = 10_000.0,
+    fee_rate: float = 0.001,
+) -> CVReport:
+    """在 ``splitter`` 切出的多条 train/test 上跑回测，聚合成样本外 Sharpe 分布 + DSR。
+
+    每个 Split：起一个**全新** ``BacktestEngine`` + 由 ``build_strategy`` 造的**全新策略**，
+    在 ``train ∪ test`` 的 bar 上按时间跑（train 提供 warmup / 上下文），只取 **test 段**的
+    bar 收益。同 ``path_id`` 的 test 段按时间拼接成一条完整 OOS 路径再算 Sharpe（保留复利）。
+
+    Args:
+        build_strategy: 工厂——接 engine、返一个挂好 clock/msgbus 的新策略实例
+            （每个 Split 都重新造，避免跨 split 状态泄漏）。
+        bars: 完整 bar 序列（按时间升序）。
+        splitter: ``cv.py`` 的三种 splitter 之一。
+        initial_cash / fee_rate: 每个 split 引擎的起始现金 / 手续费率。
+
+    Returns:
+        ``CVReport``。CV 引擎跑**裸策略**（不挂 RiskRule / PositionGuard，专注 alpha 稳健性
+        评估，与执行层风控解耦）。路径并行化（ADR-0028 复用 ProcessPool）留后续优化，v1 顺序跑。
+    """
+    n = len(bars)
+    if n < 2:
+        raise ValueError("run_cv_backtest needs at least 2 bars")
+    timeframe = bars[0].timeframe
+    ppy = periods_per_year(timeframe)
+
+    # path_id → [(原始索引, test 段 bar 收益)]
+    returns_by_path: dict[int, list[tuple[int, float]]] = {}
+    for sp in splitter.split(n):
+        run_idx = sorted(set(sp.train_idx) | set(sp.test_idx))
+        if len(run_idx) < 2:
+            continue
+        test_set = set(sp.test_idx)
+        engine = BacktestEngine(initial_cash=initial_cash, fee_rate=fee_rate)
+        engine.add_strategy(build_strategy(engine))
+        report = engine.run([bars[i] for i in run_idx])
+        eq = [e for _ts, e in report.equity_curve]
+        # 每根 bar 一个 equity 快照；k 位收益归属 run_idx[k] 这根 bar
+        for k in range(1, len(eq)):
+            orig = run_idx[k]
+            if orig in test_set and eq[k - 1] > 0:
+                returns_by_path.setdefault(sp.path_id, []).append(
+                    (orig, eq[k] / eq[k - 1] - 1.0)
+                )
+
+    sharpe_per_path: list[float] = []
+    max_dd_per_path: list[float] = []
+    raw_sharpes: list[float] = []  # 非年化，喂 DSR（与 n_returns 频率对齐）
+    path_lens: list[int] = []
+    for pid in sorted(returns_by_path):
+        seq = [r for _i, r in sorted(returns_by_path[pid])]
+        if len(seq) < 2:
+            continue
+        ann = sharpe_ratio(seq, ppy)
+        raw = sharpe_ratio(seq, 1)
+        sharpe_per_path.append(ann if ann is not None else 0.0)
+        raw_sharpes.append(raw if raw is not None else 0.0)
+        path_lens.append(len(seq))
+        eqc = [1.0]
+        for r in seq:
+            eqc.append(eqc[-1] * (1.0 + r))
+        max_dd_per_path.append(max_drawdown_pct(eqc))
+
+    n_paths = len(sharpe_per_path)
+    dsr: float | None = None
+    dsr_p_value: float | None = None
+    if n_paths >= 1:
+        try:
+            res = deflated_sharpe_ratio(
+                observed_sharpe=max(raw_sharpes),
+                n_returns=max(path_lens),
+                n_strategies=n_paths,
+            )
+            dsr = res.dsr
+            dsr_p_value = res.p_value
+        except (ValueError, ZeroDivisionError):
+            dsr = None
+            dsr_p_value = None
+
+    return CVReport(
+        n_paths=n_paths,
+        n_splits=splitter.get_n_splits(n),
+        sharpe_per_path=sharpe_per_path,
+        max_dd_per_path=max_dd_per_path,
+        sharpe_p5=_percentile(sharpe_per_path, 0.05),
+        sharpe_p50=_percentile(sharpe_per_path, 0.50),
+        sharpe_p95=_percentile(sharpe_per_path, 0.95),
+        sharpe_mean=sum(sharpe_per_path) / n_paths if n_paths else 0.0,
+        dsr=dsr,
+        dsr_p_value=dsr_p_value,
+    )
+
+
+def _percentile(values: list[float], q: float) -> float:
+    """线性插值分位数（``q ∈ [0, 1]``）；空 → 0.0，单元素 → 该值。"""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = q * (len(ordered) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = pos - lo
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * frac

--- a/services/paper/src/inalpha_paper/engine/backtest.py
+++ b/services/paper/src/inalpha_paper/engine/backtest.py
@@ -283,8 +283,9 @@ def run_cv_backtest(
 
     sharpe_per_path: list[float] = []
     max_dd_per_path: list[float] = []
-    raw_sharpes: list[float] = []  # 非年化，喂 DSR（与 n_returns 频率对齐）
-    path_lens: list[int] = []
+    # (非年化 Sharpe, 路径长度) 成对——DSR 必须用**同一条路径**的 sharpe 与 n_returns，
+    # 否则多重检验修正错配（#99 CR：fold 不能整除时各 path 长度不一即触发）。
+    raw_pairs: list[tuple[float, int]] = []
     for pid in sorted(returns_by_path):
         seq = [r for _i, r in sorted(returns_by_path[pid])]
         if len(seq) < 2:
@@ -292,8 +293,7 @@ def run_cv_backtest(
         ann = sharpe_ratio(seq, ppy)
         raw = sharpe_ratio(seq, 1)
         sharpe_per_path.append(ann if ann is not None else 0.0)
-        raw_sharpes.append(raw if raw is not None else 0.0)
-        path_lens.append(len(seq))
+        raw_pairs.append((raw if raw is not None else 0.0, len(seq)))
         eqc = [1.0]
         for r in seq:
             eqc.append(eqc[-1] * (1.0 + r))
@@ -302,11 +302,13 @@ def run_cv_backtest(
     n_paths = len(sharpe_per_path)
     dsr: float | None = None
     dsr_p_value: float | None = None
-    if n_paths >= 1:
+    if raw_pairs:
+        # 取最高 Sharpe 的那条路径 + 它自己的 n_returns（成对，不跨路径取 max）
+        best_sharpe, best_len = max(raw_pairs, key=lambda p: p[0])
         try:
             res = deflated_sharpe_ratio(
-                observed_sharpe=max(raw_sharpes),
-                n_returns=max(path_lens),
+                observed_sharpe=best_sharpe,
+                n_returns=best_len,
                 n_strategies=n_paths,
             )
             dsr = res.dsr

--- a/services/paper/src/inalpha_paper/engine/cv.py
+++ b/services/paper/src/inalpha_paper/engine/cv.py
@@ -1,0 +1,256 @@
+"""时序交叉验证 splitter（ADR-0028）—— WalkForward / PurgedKFold / CombinatorialPurgedCV。
+
+**纯索引数学，与执行引擎正交**：splitter 只负责把 ``n_samples`` 根 bar 切成 train/test
+索引对，不碰回测执行（执行在 :func:`backtest.run_cv_backtest`）。API 对齐 skfolio，便于
+熟悉 sklearn 生态的用户上手；**不引入 skfolio 包**（控外部依赖），借鉴算法自实现。
+
+设计依据：
+- CPCV（López de Prado 2018）：切 N 份、每次取 K>1 份做 test、purging + embargo 消除
+  信息泄漏、输出 C(N,K) 条 train/test 组合并重构成 φ=C(N-1,K-1) 条 OOS 路径。
+- Arian et al. 2024：CPCV 在 PBO/DSR 双指标上优于 walk-forward / K-fold。
+
+**硬约束（CLAUDE.md §3.1 金融时效性）**：所有 splitter 必须保证**末段 test 含最新 bar**
+（``test_idx`` 覆盖到 ``n_samples - 1``）——回测末段不能丢最新行情。
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from itertools import combinations
+from math import comb
+
+#: CPCV 最少 bar 数（< 此值切分无统计意义，调用方回落 WalkForward）。
+_CPCV_MIN_BARS = 200
+
+
+class InsufficientDataError(ValueError):
+    """bar 数不足以构建请求的 CV 切分（调用方据此回落更简单的 splitter）。"""
+
+
+@dataclass(frozen=True, slots=True)
+class Split:
+    """一个 train/test 索引对。
+
+    Attributes:
+        train_idx: 训练（含 warmup / 上下文）bar 的原始索引，升序。
+        test_idx: 样本外评估 bar 的原始索引，升序。
+        path_id: CPCV 用于标记同一条 OOS 路径的多个片段（同 path_id 的 test 段按时间
+            拼接成一条完整路径）；WalkForward / PurgedKFold 恒为 0。
+    """
+
+    train_idx: list[int]
+    test_idx: list[int]
+    path_id: int
+
+
+class WalkForward:
+    """滚动 / 扩展窗口前向验证（对齐 ``skfolio.model_selection.WalkForward``）。
+
+    每折：train 在前、test 紧随其后，按 ``test_size`` 向前滑动。**末折 test 锚定到序列
+    末尾**（保证含最新 bar），起始多余的最旧 bar 被舍弃。
+
+    Args:
+        test_size: 每折 test 窗口的 bar 数。
+        train_size: train 窗口的 bar 数（``expanding=True`` 时为首折最小训练量）。
+        expanding: True = 扩展窗口（train 从 0 累积）；False = 滚动窗口（定长 train）。
+    """
+
+    def __init__(self, test_size: int, train_size: int, *, expanding: bool = False) -> None:
+        if test_size < 1:
+            raise ValueError(f"test_size must be >= 1, got {test_size}")
+        if train_size < 1:
+            raise ValueError(f"train_size must be >= 1, got {train_size}")
+        self.test_size = test_size
+        self.train_size = train_size
+        self.expanding = expanding
+
+    def get_n_splits(self, n_samples: int) -> int:
+        return max(0, (n_samples - self.train_size) // self.test_size)
+
+    def split(self, n_samples: int) -> Iterator[Split]:
+        n_folds = self.get_n_splits(n_samples)
+        if n_folds < 1:
+            raise InsufficientDataError(
+                f"WalkForward 需要 n_samples >= train_size + test_size "
+                f"({self.train_size} + {self.test_size}), 实际 {n_samples}"
+            )
+        for k in range(n_folds):
+            # 末折(k=n_folds-1) test_end 锚到 n_samples → 含最新 bar；前折依次前移
+            test_end = n_samples - (n_folds - 1 - k) * self.test_size
+            test_start = test_end - self.test_size
+            train_start = 0 if self.expanding else max(0, test_start - self.train_size)
+            yield Split(
+                train_idx=list(range(train_start, test_start)),
+                test_idx=list(range(test_start, test_end)),
+                path_id=0,
+            )
+
+
+class PurgedKFold:
+    """带 purging + embargo 的 K 折时序 CV（López de Prado 2018）。
+
+    每折取一段连续区间做 test，其余做 train，并**剔除 train 中与 test 相邻 embargo 根内的
+    bar**（消除时序信息泄漏）。
+
+    Args:
+        n_splits: 折数（>= 2）。
+        embargo_pct: embargo 占总 bar 数的比例（默认 0.05，按 bar 数不按日历，跨市场一致）。
+    """
+
+    def __init__(self, n_splits: int, *, embargo_pct: float = 0.05) -> None:
+        if n_splits < 2:
+            raise ValueError(f"n_splits must be >= 2, got {n_splits}")
+        if not 0.0 <= embargo_pct < 1.0:
+            raise ValueError(f"embargo_pct must be in [0, 1), got {embargo_pct}")
+        self.n_splits = n_splits
+        self.embargo_pct = embargo_pct
+
+    def get_n_splits(self, n_samples: int) -> int:
+        return self.n_splits
+
+    def split(self, n_samples: int) -> Iterator[Split]:
+        if n_samples < self.n_splits * 2:
+            raise InsufficientDataError(
+                f"PurgedKFold 需要 n_samples >= 2*n_splits ({2 * self.n_splits}), "
+                f"实际 {n_samples}"
+            )
+        bounds = _fold_bounds(n_samples, self.n_splits)
+        embargo = int(n_samples * self.embargo_pct)
+        for start, end in bounds:
+            test_idx = list(range(start, end))
+            train_idx = [
+                i
+                for i in range(n_samples)
+                if i < start - embargo or i >= end + embargo
+            ]
+            yield Split(train_idx=train_idx, test_idx=test_idx, path_id=0)
+
+
+class CombinatorialPurgedCV:
+    """组合式 purged CV（CPCV，对齐 ``skfolio.model_selection.CombinatorialPurgedCV``）。
+
+    切 ``n_folds`` 组，每次取 ``n_test_folds`` 组做 test，其余做 train（purge+embargo）。
+    每个 (组合, test 组) 产出一个 Split，并按"该组第几次作为 test"分配 ``path_id``——
+    同 path_id 的 test 段按时间拼接 = 一条完整 OOS 路径，共 ``n_paths`` 条。
+
+    Args:
+        n_folds: 总分组数（>= 2）。
+        n_test_folds: 每个组合取作 test 的组数（1 <= 此值 < n_folds，> 1 才是组合式）。
+        embargo_pct: embargo 比例（默认 0.05）。
+    """
+
+    def __init__(
+        self, n_folds: int, n_test_folds: int, *, embargo_pct: float = 0.05
+    ) -> None:
+        if n_folds < 2:
+            raise ValueError(f"n_folds must be >= 2, got {n_folds}")
+        if not 1 <= n_test_folds < n_folds:
+            raise ValueError(
+                f"n_test_folds must be in [1, n_folds), got {n_test_folds} (n_folds={n_folds})"
+            )
+        if not 0.0 <= embargo_pct < 1.0:
+            raise ValueError(f"embargo_pct must be in [0, 1), got {embargo_pct}")
+        self.n_folds = n_folds
+        self.n_test_folds = n_test_folds
+        self.embargo_pct = embargo_pct
+
+    def n_paths(self) -> int:
+        """重构出的完整 OOS 路径数 = C(n_folds-1, n_test_folds-1)。"""
+        return comb(self.n_folds - 1, self.n_test_folds - 1)
+
+    def get_n_splits(self, n_samples: int) -> int:
+        """总 Split 数 = C(n_folds, n_test_folds) * n_test_folds（每组合每 test 组各一）。"""
+        return comb(self.n_folds, self.n_test_folds) * self.n_test_folds
+
+    def split(self, n_samples: int) -> Iterator[Split]:
+        if n_samples < _CPCV_MIN_BARS:
+            raise InsufficientDataError(
+                f"CPCV 需要 n_samples >= {_CPCV_MIN_BARS}, 实际 {n_samples}"
+                "（调用方应回落 WalkForward）"
+            )
+        if n_samples < self.n_folds * 2:
+            raise InsufficientDataError(
+                f"CPCV 需要 n_samples >= 2*n_folds ({2 * self.n_folds}), 实际 {n_samples}"
+            )
+        bounds = _fold_bounds(n_samples, self.n_folds)
+        embargo = int(n_samples * self.embargo_pct)
+        # 每个组只作为 test 出现 φ=C(n_folds-1, n_test_folds-1) 次；按出现序分配 path_id 0..φ-1
+        occurrence = [0] * self.n_folds
+        for combo in combinations(range(self.n_folds), self.n_test_folds):
+            test_groups = set(combo)
+            test_ranges = [bounds[g] for g in combo]
+            train_idx = [
+                i
+                for i in range(n_samples)
+                if _group_of(i, bounds) not in test_groups
+                and not _within_embargo(i, test_ranges, embargo)
+            ]
+            for g in combo:
+                start, end = bounds[g]
+                yield Split(
+                    train_idx=train_idx,
+                    test_idx=list(range(start, end)),
+                    path_id=occurrence[g],
+                )
+                occurrence[g] += 1
+
+
+def optimal_folds_number(
+    n_observations: int,
+    *,
+    target_n_test_paths: int = 100,
+    target_train_size: int = 252,
+) -> tuple[int, int]:
+    """求接近目标路径数 + 目标训练量的 ``(n_folds, n_test_folds)``（对齐 skfolio 同名函数）。
+
+    在 ``n_folds ∈ [2, 20]``、``n_test_folds ∈ [1, n_folds)`` 中搜，优先满足
+    "单组合 train 量 >= target_train_size"，再最小化 |路径数 - 目标|。
+
+    Returns:
+        ``(n_folds, n_test_folds)``；找不到满足训练量约束的则返回路径数最接近的。
+    """
+    best: tuple[int, int] | None = None
+    best_key: tuple[int, float] | None = None  # (训练量未达标=1, |路径差|)
+    for n_folds in range(2, 21):
+        group_size = n_observations / n_folds
+        for n_test in range(1, n_folds):
+            paths = comb(n_folds - 1, n_test - 1)
+            train_size = group_size * (n_folds - n_test)
+            shortfall = 1 if train_size < target_train_size else 0
+            key = (shortfall, abs(paths - target_n_test_paths))
+            if best_key is None or key < best_key:
+                best_key = key
+                best = (n_folds, n_test)
+    assert best is not None
+    return best
+
+
+def _fold_bounds(n_samples: int, n_folds: int) -> list[tuple[int, int]]:
+    """把 ``n_samples`` 均分成 ``n_folds`` 段连续区间，返回 ``[(start, end), ...]``。
+
+    余数摊到前几段（与 ``numpy.array_split`` 同口径），保证覆盖 ``[0, n_samples)`` 且
+    末段 end == n_samples（含最新 bar）。
+    """
+    base, rem = divmod(n_samples, n_folds)
+    bounds: list[tuple[int, int]] = []
+    start = 0
+    for g in range(n_folds):
+        size = base + (1 if g < rem else 0)
+        bounds.append((start, start + size))
+        start += size
+    return bounds
+
+
+def _group_of(i: int, bounds: list[tuple[int, int]]) -> int:
+    """索引 ``i`` 落在第几组。"""
+    for g, (start, end) in enumerate(bounds):
+        if start <= i < end:
+            return g
+    return -1
+
+
+def _within_embargo(
+    i: int, test_ranges: list[tuple[int, int]], embargo: int
+) -> bool:
+    """``i`` 是否落在任一 test 区间前后 ``embargo`` 根内（purge+embargo 两侧）。"""
+    return any(start - embargo <= i < end + embargo for start, end in test_ranges)

--- a/services/paper/src/inalpha_paper/runner.py
+++ b/services/paper/src/inalpha_paper/runner.py
@@ -23,7 +23,7 @@ from psycopg import AsyncConnection
 
 from .config import get_paper_settings
 from .data_client import DataClient
-from .engine.backtest import BacktestEngine, run_cv_backtest
+from .engine.backtest import BacktestEngine, CVReport, run_cv_backtest
 from .engine.cv import (
     CombinatorialPurgedCV,
     InsufficientDataError,
@@ -595,7 +595,9 @@ async def run_cv(
             code="NO_BARS_AVAILABLE",
         )
 
-    # 策略类解析（内置 id 或 LLM 候选；候选二次过 ast_audit）
+    # 策略源解析（内置 id 或 LLM 候选源码字符串）。候选在 main 二次过 ast_audit；
+    # 策略**类的构建放到子进程 worker**（类对象不可 pickle，且 CPU 重活不应在事件循环里）。
+    candidate_code: str | None = None
     if req.candidate_id is not None:
         if conn is None:
             raise ValidationError(
@@ -612,27 +614,7 @@ async def run_cv(
                 f"candidate {req.candidate_id} failed re-audit: {reaudit.reason()}",
                 code="CANDIDATE_REAUDIT_FAILED",
             )
-        strategy_cls = load_strategy_class(row["code"])
-        strategy_name = f"candidate-{req.symbol}"
-    else:
-        strategy_cls = get_strategy_class(req.strategy_id)  # type: ignore[arg-type]
-        strategy_name = f"{req.strategy_id}-{req.symbol}"
-
-    def build_strategy(engine: BacktestEngine) -> Strategy:
-        kwargs: dict[str, Any] = dict(req.params)
-        sig = inspect.signature(strategy_cls.__init__)
-        if "initial_cash" in sig.parameters and "initial_cash" not in kwargs:
-            kwargs["initial_cash"] = req.initial_cash
-        if "position_pct" in sig.parameters and "position_pct" not in kwargs:
-            kwargs["position_pct"] = 1.0
-        return strategy_cls(  # type: ignore[call-arg]
-            name=strategy_name,
-            clock=engine.clock,
-            msgbus=engine.msgbus,
-            instrument_id=instrument_id,
-            timeframe=req.timeframe,
-            **kwargs,
-        )
+        candidate_code = row["code"]
 
     splitter: CombinatorialPurgedCV | PurgedKFold | WalkForward
     if req.splitter == "cpcv":
@@ -644,16 +626,38 @@ async def run_cv(
     else:
         splitter = WalkForward(req.wf_test_size, req.wf_train_size)
 
+    async def _offload(spl: CombinatorialPurgedCV | PurgedKFold | WalkForward) -> CVReport:
+        """把 N 路 CV 整体甩进 ProcessPool（#99 CR：别在事件循环里同步跑 30 条引擎）。
+
+        pool 未起（旧测试 / 同步入口）→ 同进程兜底跑（语义一致）。
+        """
+        from functools import partial
+
+        fn = partial(
+            run_cv_in_subprocess,
+            bars=bars,
+            instrument_id=instrument_id,
+            timeframe=req.timeframe,
+            strategy_id=req.strategy_id,
+            candidate_code=candidate_code,
+            params=req.params,
+            initial_cash=req.initial_cash,
+            fee_rate=req.fee_rate,
+            splitter=spl,
+        )
+        try:
+            pool = get_pool()
+        except RuntimeError:
+            pool = None
+        if pool is None:
+            return fn()
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(pool, fn)
+
     splitter_used = req.splitter
     note: str | None = None
     try:
-        report = run_cv_backtest(
-            build_strategy=build_strategy,
-            bars=bars,
-            splitter=splitter,
-            initial_cash=req.initial_cash,
-            fee_rate=req.fee_rate,
-        )
+        report = await _offload(splitter)
     except InsufficientDataError as exc:
         if req.splitter != "cpcv":
             raise ValidationError(
@@ -663,13 +667,7 @@ async def run_cv(
         splitter_used = "walk_forward"
         note = f"cpcv 数据不足（{len(bars)} bars），已回落 walk_forward：{exc}"
         try:
-            report = run_cv_backtest(
-                build_strategy=build_strategy,
-                bars=bars,
-                splitter=WalkForward(req.wf_test_size, req.wf_train_size),
-                initial_cash=req.initial_cash,
-                fee_rate=req.fee_rate,
-            )
+            report = await _offload(WalkForward(req.wf_test_size, req.wf_train_size))
         except InsufficientDataError as exc2:
             raise ValidationError(
                 f"CV data insufficient even for walk_forward: {exc2}",
@@ -692,6 +690,61 @@ async def run_cv(
         dsr=report.dsr,
         dsr_p_value=report.dsr_p_value,
         note=note,
+    )
+
+
+def run_cv_in_subprocess(
+    *,
+    bars: list[Bar],
+    instrument_id: InstrumentId,
+    timeframe: str,
+    strategy_id: str | None,
+    candidate_code: str | None,
+    params: dict[str, Any],
+    initial_cash: float,
+    fee_rate: float,
+    splitter: CombinatorialPurgedCV | PurgedKFold | WalkForward,
+) -> CVReport:
+    """**Top-level 可 pickle 函数**：在子进程里解析策略类 + 跑多路 CV，返 ``CVReport``。
+
+    与 ``run_engine_in_subprocess`` 同源（ADR-0025）：CPU 重活留子进程、main 协程不阻塞
+    （#99 CR）。``InsufficientDataError`` 经 future 原样传回 main 决定回落。candidate 路径的
+    AST 审计已在 main 做过，这里只 load。
+    """
+    if candidate_code is not None:
+        strategy_cls = load_strategy_class(candidate_code)
+        strategy_name = f"candidate-{instrument_id.symbol}"
+    elif strategy_id is not None:
+        strategy_cls = get_strategy_class(strategy_id)
+        strategy_name = f"{strategy_id}-{instrument_id.symbol}"
+    else:
+        raise ValidationError(
+            "internal: neither strategy_id nor candidate_code provided",
+            code="STRATEGY_MISSING",
+        )
+
+    def build_strategy(engine: BacktestEngine) -> Strategy:
+        kwargs: dict[str, Any] = dict(params)
+        sig = inspect.signature(strategy_cls.__init__)
+        if "initial_cash" in sig.parameters and "initial_cash" not in kwargs:
+            kwargs["initial_cash"] = initial_cash
+        if "position_pct" in sig.parameters and "position_pct" not in kwargs:
+            kwargs["position_pct"] = 1.0
+        return strategy_cls(  # type: ignore[call-arg]
+            name=strategy_name,
+            clock=engine.clock,
+            msgbus=engine.msgbus,
+            instrument_id=instrument_id,
+            timeframe=timeframe,
+            **kwargs,
+        )
+
+    return run_cv_backtest(
+        build_strategy=build_strategy,
+        bars=bars,
+        splitter=splitter,
+        initial_cash=initial_cash,
+        fee_rate=fee_rate,
     )
 
 

--- a/services/paper/src/inalpha_paper/runner.py
+++ b/services/paper/src/inalpha_paper/runner.py
@@ -580,6 +580,9 @@ async def run_cv(
     cpcv 在 bar 不足（< 200 或 < 2×n_folds）时**自动回落 walk_forward**（CLAUDE.md §3.1
     末段含最新 bar 由 splitter 保证）。
     """
+    # 拉数据——默认 fresh=True：先 backfill 再读，确保 to_ts 前数据完整（与 run_backtest 同
+    # 口径，CLAUDE.md §3.1）。CV 多为历史窗口但仍主动选 fresh，避免新 symbol / 新窗口
+    # 缺数据；如需纯历史不回填须显式说明再改 fresh=False（别误当遗忘默认）。
     raw_bars = await data_client.get_bars(
         venue=req.venue,
         symbol=req.symbol,
@@ -650,6 +653,12 @@ async def run_cv(
         except RuntimeError:
             pool = None
         if pool is None:
+            # pool 不可用（容器禁 fork / 启动失败 / 旧测试同步入口）→ 同进程兜底跑。
+            # 生产环境这是从"offload"降级回"阻塞事件循环",运维需可感知（#99 CR）。
+            logger.warning(
+                "cv_offload_pool_unavailable_running_sync",
+                extra={"n_bars": len(bars), "splitter": type(spl).__name__},
+            )
             return fn()
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(pool, fn)

--- a/services/paper/src/inalpha_paper/runner.py
+++ b/services/paper/src/inalpha_paper/runner.py
@@ -23,7 +23,13 @@ from psycopg import AsyncConnection
 
 from .config import get_paper_settings
 from .data_client import DataClient
-from .engine.backtest import BacktestEngine
+from .engine.backtest import BacktestEngine, run_cv_backtest
+from .engine.cv import (
+    CombinatorialPurgedCV,
+    InsufficientDataError,
+    PurgedKFold,
+    WalkForward,
+)
 from .engine.metrics import (
     bar_returns,
     max_drawdown_pct,
@@ -39,6 +45,8 @@ from .schemas import (
     BacktestRequest,
     BacktestResponse,
     BaselineSnapshot,
+    CVBacktestRequest,
+    CVBacktestResponse,
     EquityPoint,
     PositionSnapshot,
     SharpeCI,
@@ -49,6 +57,7 @@ from .storage import backtest_runs as backtest_runs_store
 from .storage import backtest_trades as backtest_trades_store
 from .storage import strategy_candidates as candidates_store
 from .strategies import BASELINE_BUY_AND_HOLD, get_strategy_class
+from .strategy.base import Strategy
 from .strategy_authoring import (
     FitnessInputs,
     audit_strategy_code,
@@ -556,6 +565,133 @@ def _fitness_from_report(report: Any, *, bars_per_year: float) -> float:
             num_trades=report.num_trades,
             num_bars_processed=report.num_bars_processed,
         )
+    )
+
+
+async def run_cv(
+    req: CVBacktestRequest,
+    data_client: DataClient,
+    *,
+    conn: AsyncConnection | None = None,
+) -> CVBacktestResponse:
+    """跑多路径时序交叉验证回测（ADR-0028）：拉数据 → 造策略工厂 → 切分 → 聚合分布。
+
+    与 ``run_backtest`` 平行的入口；CV 评估稳健性，不落 backtest_runs（多路径无单一 run）。
+    cpcv 在 bar 不足（< 200 或 < 2×n_folds）时**自动回落 walk_forward**（CLAUDE.md §3.1
+    末段含最新 bar 由 splitter 保证）。
+    """
+    raw_bars = await data_client.get_bars(
+        venue=req.venue,
+        symbol=req.symbol,
+        timeframe=req.timeframe,
+        from_ts=req.from_ts,
+        to_ts=req.to_ts,
+    )
+    instrument_id = InstrumentId(symbol=req.symbol, venue=req.venue)
+    bars = [_bar_from_dict(b, instrument_id, req.timeframe) for b in raw_bars]
+    if len(bars) < 2:
+        raise ValidationError(
+            f"CV needs >= 2 bars, got {len(bars)} for {req.symbol}@{req.venue}",
+            code="NO_BARS_AVAILABLE",
+        )
+
+    # 策略类解析（内置 id 或 LLM 候选；候选二次过 ast_audit）
+    if req.candidate_id is not None:
+        if conn is None:
+            raise ValidationError(
+                "candidate_id path requires database connection", code="CANDIDATE_NO_DB"
+            )
+        row = await candidates_store.get_candidate(conn, req.candidate_id)
+        if row is None:
+            raise NotFoundError(
+                f"candidate {req.candidate_id} not found", code="CANDIDATE_NOT_FOUND"
+            )
+        reaudit = audit_strategy_code(row["code"])
+        if not reaudit.ok:
+            raise ValidationError(
+                f"candidate {req.candidate_id} failed re-audit: {reaudit.reason()}",
+                code="CANDIDATE_REAUDIT_FAILED",
+            )
+        strategy_cls = load_strategy_class(row["code"])
+        strategy_name = f"candidate-{req.symbol}"
+    else:
+        strategy_cls = get_strategy_class(req.strategy_id)  # type: ignore[arg-type]
+        strategy_name = f"{req.strategy_id}-{req.symbol}"
+
+    def build_strategy(engine: BacktestEngine) -> Strategy:
+        kwargs: dict[str, Any] = dict(req.params)
+        sig = inspect.signature(strategy_cls.__init__)
+        if "initial_cash" in sig.parameters and "initial_cash" not in kwargs:
+            kwargs["initial_cash"] = req.initial_cash
+        if "position_pct" in sig.parameters and "position_pct" not in kwargs:
+            kwargs["position_pct"] = 1.0
+        return strategy_cls(  # type: ignore[call-arg]
+            name=strategy_name,
+            clock=engine.clock,
+            msgbus=engine.msgbus,
+            instrument_id=instrument_id,
+            timeframe=req.timeframe,
+            **kwargs,
+        )
+
+    splitter: CombinatorialPurgedCV | PurgedKFold | WalkForward
+    if req.splitter == "cpcv":
+        splitter = CombinatorialPurgedCV(
+            req.n_folds, req.n_test_folds, embargo_pct=req.embargo_pct
+        )
+    elif req.splitter == "purged_kfold":
+        splitter = PurgedKFold(req.n_folds, embargo_pct=req.embargo_pct)
+    else:
+        splitter = WalkForward(req.wf_test_size, req.wf_train_size)
+
+    splitter_used = req.splitter
+    note: str | None = None
+    try:
+        report = run_cv_backtest(
+            build_strategy=build_strategy,
+            bars=bars,
+            splitter=splitter,
+            initial_cash=req.initial_cash,
+            fee_rate=req.fee_rate,
+        )
+    except InsufficientDataError as exc:
+        if req.splitter != "cpcv":
+            raise ValidationError(
+                f"CV splitter data insufficient: {exc}", code="CV_INSUFFICIENT_DATA"
+            ) from exc
+        # cpcv 数据不足 → 回落 walk_forward（ADR-0028 D1）
+        splitter_used = "walk_forward"
+        note = f"cpcv 数据不足（{len(bars)} bars），已回落 walk_forward：{exc}"
+        try:
+            report = run_cv_backtest(
+                build_strategy=build_strategy,
+                bars=bars,
+                splitter=WalkForward(req.wf_test_size, req.wf_train_size),
+                initial_cash=req.initial_cash,
+                fee_rate=req.fee_rate,
+            )
+        except InsufficientDataError as exc2:
+            raise ValidationError(
+                f"CV data insufficient even for walk_forward: {exc2}",
+                code="CV_INSUFFICIENT_DATA",
+            ) from exc2
+
+    return CVBacktestResponse(
+        symbol=req.symbol,
+        timeframe=req.timeframe,
+        n_bars=len(bars),
+        splitter_used=splitter_used,
+        n_paths=report.n_paths,
+        n_splits=report.n_splits,
+        sharpe_per_path=report.sharpe_per_path,
+        max_dd_per_path=report.max_dd_per_path,
+        sharpe_p5=report.sharpe_p5,
+        sharpe_p50=report.sharpe_p50,
+        sharpe_p95=report.sharpe_p95,
+        sharpe_mean=report.sharpe_mean,
+        dsr=report.dsr,
+        dsr_p_value=report.dsr_p_value,
+        note=note,
     )
 
 

--- a/services/paper/src/inalpha_paper/schemas.py
+++ b/services/paper/src/inalpha_paper/schemas.py
@@ -93,6 +93,63 @@ class BacktestRequest(BaseModel):
         return self
 
 
+class CVBacktestRequest(BacktestRequest):
+    """``POST /backtest/cv`` 请求体（ADR-0028）—— 在 BacktestRequest 上加 splitter 配置。
+
+    继承 strategy_id/candidate_id 二选一校验 + 数据窗口字段；``validation_split`` 在 CV
+    路径无意义（被忽略）。
+    """
+
+    splitter: Literal["cpcv", "walk_forward", "purged_kfold"] = Field(
+        default="cpcv",
+        description="时序 CV 切分器：cpcv（组合式 purged，多路径，最强）/ walk_forward / "
+        "purged_kfold。bar < 200 时 cpcv 自动回落 walk_forward。",
+    )
+    n_folds: int = Field(default=6, ge=2, le=20, description="cpcv/kfold 分组数")
+    n_test_folds: int = Field(
+        default=2, ge=1, description="cpcv 每组合取作 test 的组数（须 < n_folds）"
+    )
+    embargo_pct: float = Field(
+        default=0.05, ge=0.0, lt=1.0, description="purge+embargo 占总 bar 比例（按 bar 数）"
+    )
+    wf_test_size: int = Field(default=21, ge=1, description="walk_forward 每折 test bar 数")
+    wf_train_size: int = Field(
+        default=252, ge=1, description="walk_forward train 窗口 bar 数"
+    )
+
+    @model_validator(mode="after")
+    def _check_cpcv_test_folds(self) -> CVBacktestRequest:
+        """cpcv 要求 n_test_folds < n_folds（> 1 才是组合式）。"""
+        if self.splitter == "cpcv" and not 1 <= self.n_test_folds < self.n_folds:
+            raise PydanticCustomError(
+                "cpcv_test_folds",
+                "n_test_folds must be in [1, n_folds) for cpcv",
+            )
+        return self
+
+
+class CVBacktestResponse(BaseModel):
+    """``POST /backtest/cv`` 响应（ADR-0028）—— 多路径 OOS Sharpe 分布 + DSR。"""
+
+    symbol: str
+    timeframe: str
+    n_bars: int
+    splitter_used: str = Field(description="实际用的 splitter（cpcv 不足回落时 != 请求值）")
+    n_paths: int
+    n_splits: int
+    sharpe_per_path: list[float]
+    max_dd_per_path: list[float]
+    sharpe_p5: float
+    sharpe_p50: float
+    sharpe_p95: float
+    sharpe_mean: float
+    dsr: float | None = None
+    dsr_p_value: float | None = None
+    note: str | None = Field(
+        default=None, description="回落 / 降级说明（如 cpcv → walk_forward）"
+    )
+
+
 class PositionSnapshot(BaseModel):
     instrument_id: str  # "BTC/USDT@binance"
     quantity: float

--- a/services/paper/tests/test_api_backtest.py
+++ b/services/paper/tests/test_api_backtest.py
@@ -228,3 +228,70 @@ def test_backtest_empty_bars_rejected(
     body = r.json()
     assert body["code"] == "NO_BARS_AVAILABLE"
     assert "backfill" in body["message"]
+
+
+# ─── CV 多路径回测（ADR-0028） ───
+
+
+@respx.mock
+def test_backtest_cv_cpcv_paths(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    """300 根 bar → cpcv(6,2) 出 5 条 OOS 路径 + DSR。"""
+    respx.get("http://data-mock.test/bars").mock(
+        return_value=Response(200, json=_bars_for_oscillating(300))
+    )
+    r = client.post(
+        "/backtest/cv",
+        headers=auth_headers,
+        json={
+            "strategy_id": "sma_cross",
+            "params": {"fast_period": 5, "slow_period": 15},
+            "symbol": "BTC/USDT",
+            "timeframe": "1h",
+            "from_ts": "2026-01-01T00:00:00Z",
+            "to_ts": "2026-02-01T00:00:00Z",
+            "splitter": "cpcv",
+            "n_folds": 6,
+            "n_test_folds": 2,
+        },
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["splitter_used"] == "cpcv"
+    assert body["n_paths"] == 5
+    assert len(body["sharpe_per_path"]) == 5
+    assert body["n_splits"] == 30
+    assert body["sharpe_p5"] <= body["sharpe_p50"] <= body["sharpe_p95"]
+    assert body["note"] is None
+
+
+@respx.mock
+def test_backtest_cv_falls_back_to_walkforward(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    """bar < 200 → cpcv 自动回落 walk_forward，splitter_used 改写 + note 说明。"""
+    respx.get("http://data-mock.test/bars").mock(
+        return_value=Response(200, json=_bars_for_oscillating(100))
+    )
+    r = client.post(
+        "/backtest/cv",
+        headers=auth_headers,
+        json={
+            "strategy_id": "sma_cross",
+            "symbol": "BTC/USDT",
+            "from_ts": "2026-01-01T00:00:00Z",
+            "to_ts": "2026-01-10T00:00:00Z",
+            "splitter": "cpcv",
+            "n_folds": 6,
+            "n_test_folds": 2,
+            "wf_test_size": 10,
+            "wf_train_size": 20,
+        },
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["splitter_used"] == "walk_forward"
+    assert body["note"] is not None
+    assert "回落" in body["note"]
+    assert body["n_paths"] == 1

--- a/services/paper/tests/test_cv.py
+++ b/services/paper/tests/test_cv.py
@@ -1,0 +1,140 @@
+"""CV splitter 单测（ADR-0028）—— 切分正确 / purging+embargo / 末段含最新 bar / 路径数。"""
+from __future__ import annotations
+
+import pytest
+
+from inalpha_paper.engine.cv import (
+    CombinatorialPurgedCV,
+    InsufficientDataError,
+    PurgedKFold,
+    WalkForward,
+    optimal_folds_number,
+)
+
+# ─── WalkForward ───
+
+
+def test_walkforward_rolling_windows() -> None:
+    wf = WalkForward(test_size=10, train_size=20)
+    splits = list(wf.split(60))
+    assert len(splits) == wf.get_n_splits(60) == 4
+    for s in splits:
+        assert len(s.test_idx) == 10
+        assert len(s.train_idx) == 20  # 滚动定长
+        assert s.path_id == 0
+        # train 紧贴 test 之前、不重叠
+        assert s.train_idx[-1] + 1 == s.test_idx[0]
+
+
+def test_walkforward_last_test_includes_latest_bar() -> None:
+    """末折 test 必须覆盖到最后一根 bar（CLAUDE.md §3.1 金融时效性硬约束）。"""
+    wf = WalkForward(test_size=7, train_size=20)
+    splits = list(wf.split(63))
+    assert splits[-1].test_idx[-1] == 62  # n_samples - 1
+
+
+def test_walkforward_expanding() -> None:
+    wf = WalkForward(test_size=10, train_size=20, expanding=True)
+    splits = list(wf.split(60))
+    # 扩展窗口：train 从 0 累积，越后越长
+    assert splits[0].train_idx[0] == 0
+    assert splits[-1].train_idx[0] == 0
+    assert len(splits[-1].train_idx) > len(splits[0].train_idx)
+
+
+def test_walkforward_insufficient_data() -> None:
+    wf = WalkForward(test_size=10, train_size=20)
+    with pytest.raises(InsufficientDataError):
+        list(wf.split(25))
+
+
+# ─── PurgedKFold ───
+
+
+def test_purged_kfold_covers_all_test_indices_once() -> None:
+    kf = PurgedKFold(n_splits=5, embargo_pct=0.0)
+    splits = list(kf.split(100))
+    assert len(splits) == 5
+    all_test = sorted(i for s in splits for i in s.test_idx)
+    assert all_test == list(range(100))  # 每个 bar 恰好做一次 test
+
+
+def test_purged_kfold_embargo_purges_neighbors() -> None:
+    """embargo 把 train 中紧邻 test 的 bar 剔除（防泄漏）。"""
+    kf = PurgedKFold(n_splits=5, embargo_pct=0.05)
+    splits = list(kf.split(100))
+    embargo = int(100 * 0.05)  # 5
+    for s in splits:
+        ts, te = s.test_idx[0], s.test_idx[-1]
+        for i in s.train_idx:
+            # train 不得落在 test 前后 embargo 根内
+            assert i < ts - embargo or i >= te + 1 + embargo
+        # train 与 test 不重叠
+        assert not (set(s.train_idx) & set(s.test_idx))
+
+
+def test_purged_kfold_last_fold_includes_latest_bar() -> None:
+    kf = PurgedKFold(n_splits=4, embargo_pct=0.05)
+    splits = list(kf.split(80))
+    assert splits[-1].test_idx[-1] == 79
+
+
+def test_purged_kfold_insufficient_data() -> None:
+    with pytest.raises(InsufficientDataError):
+        list(PurgedKFold(n_splits=5).split(9))
+
+
+# ─── CombinatorialPurgedCV ───
+
+
+def test_cpcv_path_and_split_counts() -> None:
+    cv = CombinatorialPurgedCV(n_folds=6, n_test_folds=2)
+    # 路径数 = C(5,1) = 5；Split 数 = C(6,2)*2 = 30
+    assert cv.n_paths() == 5
+    splits = list(cv.split(300))
+    assert len(splits) == cv.get_n_splits(300) == 30
+    # 每条 path 恰好由 n_folds 段组成（每组贡献一段）
+    by_path: dict[int, int] = {}
+    for s in splits:
+        by_path[s.path_id] = by_path.get(s.path_id, 0) + 1
+    assert set(by_path) == {0, 1, 2, 3, 4}
+    assert all(count == 6 for count in by_path.values())
+
+
+def test_cpcv_train_excludes_test_and_embargo() -> None:
+    cv = CombinatorialPurgedCV(n_folds=6, n_test_folds=2, embargo_pct=0.05)
+    splits = list(cv.split(300))
+    for s in splits:
+        assert not (set(s.train_idx) & set(s.test_idx))  # 不重叠
+
+
+def test_cpcv_path_segments_reconstruct_full_timeline() -> None:
+    """同 path_id 的所有 test 段拼起来应覆盖全时间轴（一条完整 OOS 路径）。"""
+    cv = CombinatorialPurgedCV(n_folds=6, n_test_folds=2)
+    splits = list(cv.split(300))
+    for path_id in range(cv.n_paths()):
+        seg = sorted(i for s in splits if s.path_id == path_id for i in s.test_idx)
+        assert seg == list(range(300))  # 无缺口、无重叠、含末根
+
+
+def test_cpcv_below_min_bars_raises() -> None:
+    with pytest.raises(InsufficientDataError):
+        list(CombinatorialPurgedCV(n_folds=6, n_test_folds=2).split(150))
+
+
+def test_cpcv_invalid_params() -> None:
+    with pytest.raises(ValueError):
+        CombinatorialPurgedCV(n_folds=1, n_test_folds=1)
+    with pytest.raises(ValueError):
+        CombinatorialPurgedCV(n_folds=5, n_test_folds=5)  # n_test 必须 < n_folds
+
+
+# ─── optimal_folds_number ───
+
+
+def test_optimal_folds_number_returns_valid_pair() -> None:
+    n_folds, n_test = optimal_folds_number(
+        2000, target_n_test_paths=10, target_train_size=252
+    )
+    assert 2 <= n_folds <= 20
+    assert 1 <= n_test < n_folds

--- a/services/paper/tests/test_cv_backtest.py
+++ b/services/paper/tests/test_cv_backtest.py
@@ -1,0 +1,97 @@
+"""``run_cv_backtest`` 集成测试（ADR-0028 D2）—— 多路径分布 + DSR + WF 单路径。
+
+策略复用内置 momentum_trend 骨架（main 上既有），经 dynamic_loader 加载，每个 split 由
+工厂造新实例。
+"""
+from __future__ import annotations
+
+import math
+
+from inalpha_paper.engine.backtest import BacktestEngine, run_cv_backtest
+from inalpha_paper.engine.cv import CombinatorialPurgedCV, WalkForward
+from inalpha_paper.kernel.identifiers import InstrumentId
+from inalpha_paper.model.data import Bar
+from inalpha_paper.strategy_authoring.archetypes import get_archetype
+from inalpha_paper.strategy_authoring.dynamic_loader import load_strategy_class
+
+
+def _btc() -> InstrumentId:
+    return InstrumentId(symbol="BTC/USDT", venue="binance")
+
+
+def _bars(prices: list[float]) -> list[Bar]:
+    step = 86_400 * 1_000_000_000  # 1d
+    return [
+        Bar(
+            instrument_id=_btc(),
+            timeframe="1d",
+            open=p,
+            high=p * 1.01,
+            low=p * 0.99,
+            close=p,
+            volume=1.0 + (i % 5),
+            ts_event=(i + 1) * step,
+            ts_init=(i + 1) * step,
+        )
+        for i, p in enumerate(prices)
+    ]
+
+
+def _momentum_factory():
+    cls = load_strategy_class(get_archetype("momentum_trend").code)
+
+    def build(engine: BacktestEngine):
+        return cls(
+            name="cv-mom",
+            clock=engine.clock,
+            msgbus=engine.msgbus,
+            instrument_id=_btc(),
+            timeframe="1d",
+            position_pct=1.0,
+            initial_cash=10_000.0,
+        )
+
+    return build
+
+
+def test_cpcv_backtest_produces_path_distribution() -> None:
+    # 前半上行 + 后半下行，叠振荡 → 不同 fold 表现差异大，制造 Sharpe 分布
+    prices = [
+        100 + (0.5 * i if i < 150 else 0.5 * 150 - 0.5 * (i - 150))
+        + 6 * math.sin(2 * math.pi * i / 15)
+        for i in range(300)
+    ]
+    cv = CombinatorialPurgedCV(n_folds=6, n_test_folds=2)
+    report = run_cv_backtest(
+        build_strategy=_momentum_factory(), bars=_bars(prices), splitter=cv
+    )
+    assert report.n_paths == cv.n_paths() == 5
+    assert len(report.sharpe_per_path) == 5
+    assert len(report.max_dd_per_path) == 5
+    assert report.n_splits == 30
+    # 分位单调
+    assert report.sharpe_p5 <= report.sharpe_p50 <= report.sharpe_p95
+    # DSR 可算
+    assert report.dsr is not None
+    assert report.dsr_p_value is not None
+
+
+def test_walkforward_backtest_single_path() -> None:
+    prices = [100 + 0.3 * i + 5 * math.sin(2 * math.pi * i / 12) for i in range(200)]
+    wf = WalkForward(test_size=20, train_size=40)
+    report = run_cv_backtest(
+        build_strategy=_momentum_factory(), bars=_bars(prices), splitter=wf
+    )
+    # WF 所有 test 段 path_id=0 → 拼成单条 OOS 路径
+    assert report.n_paths == 1
+    assert len(report.sharpe_per_path) == 1
+    assert report.sharpe_p50 == report.sharpe_per_path[0]
+
+
+def test_cv_report_max_dd_non_negative() -> None:
+    prices = [100 + 0.4 * i + 7 * math.sin(2 * math.pi * i / 20) for i in range(300)]
+    cv = CombinatorialPurgedCV(n_folds=5, n_test_folds=2)
+    report = run_cv_backtest(
+        build_strategy=_momentum_factory(), bars=_bars(prices), splitter=cv
+    )
+    assert all(dd >= 0.0 for dd in report.max_dd_per_path)


### PR DESCRIPTION
## 背景

补防过拟合体系的"时间维样本外"那条腿(博主反复强调的 walk-forward 多窗口):把策略在多条 OOS 路径上跑,看 Sharpe 分布 + DSR——单段好看的 forward-looking 策略,CPCV 多路径下中位 Sharpe 会塌。落地 ADR-0028。

## 改动

**`engine/cv.py`(新)**:`WalkForward` / `PurgedKFold` / `CombinatorialPurgedCV` + `optimal_folds_number`,纯索引数学、API 对齐 skfolio(不引入该包);末段 test 必含最新 bar(CLAUDE.md §3.1)、CPCV purge+embargo、bar<200 抛 `InsufficientDataError`。

**`backtest.py`**:`run_cv_backtest` + `CVReport`——每 split 起新引擎跑 train∪test、只取 test 段收益,同 path_id 按时间拼成完整 OOS 路径算 Sharpe;复用 `robustness.deflated_sharpe_ratio` 出 DSR。

**API/orchestration**:`runner.run_cv` + `POST /backtest/cv`(cpcv 不足自动回落 walk_forward);`paper.cv_backtest` tool + client + 注册 + 默认权限放行(TS+YAML) + orchestrator prompt(深度评估看中位 sharpe_p50)。

## 对 ADR-0028 的一处偏差

`CVReport` 落 **DSR**(单策略多路径多重检验校正,语义贴切),**未塞 PBO**——CSCV-PBO 需多个策略配置作输入,放进单策略报告是误用;PBO 留 grid 层(D4,多配置场景)。

## 验证

`ruff` 干净;paper `pytest` 784 passed(test_cv 14 + test_cv_backtest 3 + 2 api);orchestration typecheck + `vitest`(cv-backtest 4/4);`check-consistency.sh` 0 失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)