### PR TITLE
feat(data,paper): 财报 point-in-time 截断 + get_bars_pit (ADR-0053 阶段 A)

### DIFF
--- a/services/data/src/inalpha_data/api/fundamentals.py
+++ b/services/data/src/inalpha_data/api/fundamentals.py
@@ -22,15 +22,22 @@ async def get_fundamentals(
     _user: Annotated[User, Depends(get_current_user)],
     venue: Annotated[str, Query(description="数据源：akshare 或 yfinance")],
     symbol: Annotated[str, Query(description="ticker 标识（如 sh.600519 / AAPL）")],
+    as_of: Annotated[
+        str | None,
+        Query(
+            description="point-in-time 截断（ISO 8601，ADR-0053 阶段 A）：只返回该时点已"
+            "披露的财报，防回测看到未来财报。仅 akshare 生效；yfinance v1 不做 PIT。",
+        ),
+    ] = None,
 ) -> FinancialsResponse:
-    """拉指定 ticker 的最新财报基本面数据。
+    """拉指定 ticker 的财报基本面数据（``as_of`` 给定则做 PIT 截断）。
 
     venue 支持 akshare / yfinance；其它 venue 返 422。
     """
     if venue == "yfinance":
         try:
             conn = yfinance_conn.get_connector()
-            data = await conn.fetch_financials(symbol)
+            data = await conn.fetch_financials(symbol, as_of=as_of)
         except Exception as exc:
             return FinancialsResponse(
                 venue=venue,
@@ -48,7 +55,7 @@ async def get_fundamentals(
                 code="FUNDAMENTALS_NOT_SUPPORTED",
                 details={"venue": venue},
             )
-        data = await conn.fetch_financials(symbol)  # type: ignore[union-attr]
+        data = await conn.fetch_financials(symbol, as_of=as_of)  # type: ignore[union-attr]
         return FinancialsResponse(**data)
 
     raise ValidationError(

--- a/services/data/src/inalpha_data/connectors/akshare.py
+++ b/services/data/src/inalpha_data/connectors/akshare.py
@@ -465,6 +465,10 @@ def _flatten_financial_abstract(
             return {}
     if "指标" not in cols or not date_cols:
         # 不是预期的转置表 → 退回最后一行(旧行为)兜底,至少不丢数据。
+        # 但 PIT 模式下**绝不走 iloc[-1] 后门**：它返回全部列(含未披露报告期),会让
+        # 格式异常时偷看未来财报、PIT 约束失效(#100 CR)。宁可返空也不泄漏。
+        if as_of is not None:
+            return {}
         if len(raw) == 0:
             return {}
         row = raw.iloc[-1]

--- a/services/data/src/inalpha_data/connectors/akshare.py
+++ b/services/data/src/inalpha_data/connectors/akshare.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from inalpha_shared import get_logger
@@ -168,14 +168,19 @@ class AkshareConnector:
             out = out[-limit:]
         return out
 
-    async def fetch_financials(self, symbol: str) -> dict[str, Any]:
+    async def fetch_financials(
+        self, symbol: str, as_of: str | None = None
+    ) -> dict[str, Any]:
         """拉 A股 / 港股 财报基本面数据。
 
         A-share: ``ak.stock_financial_abstract(symbol=code)``
         HK stock: ``ak.stock_hk_financial_abstract(symbol=code)``
 
-        akshare 返回字段因市场不同有差异，做防御性字段映射；
-        缺失字段置 None 不抛异常。
+        akshare 返回字段因市场不同有差异，做防御性字段映射；缺失字段置 None 不抛异常。
+
+        ``as_of``（ISO 时间串，ADR-0053 阶段 A）：point-in-time 截断——只取"报告期末 +
+        发布滞后 <= as_of"的财报期，防回测看到当时还没披露的财报（未来函数）。给 as_of 时
+        **绕过缓存**（PIT 查询较少，避免与非 PIT 结果串味）。
         """
         prefix, code = _parse_symbol(symbol)
         if prefix not in ("sh", "sz", "hk"):
@@ -186,14 +191,38 @@ class AkshareConnector:
                 "reason": f"financials not supported for akshare prefix {prefix!r}",
             }
 
-        cached = self._fin_cache_get(symbol)
-        if cached is not None:
-            return cached
+        as_of_dt: datetime | None = None
+        if as_of is not None:
+            try:
+                as_of_dt = datetime.fromisoformat(as_of.replace("Z", "+00:00"))
+                if as_of_dt.tzinfo is None:
+                    as_of_dt = as_of_dt.replace(tzinfo=UTC)
+            except ValueError:
+                return {
+                    "venue": VENUE,
+                    "symbol": symbol,
+                    "available": False,
+                    "reason": f"invalid as_of datetime: {as_of!r}",
+                }
 
-        _logger.debug("akshare_fetch_financials", symbol=symbol, prefix=prefix, code=code)
+        # 非 PIT 走缓存；PIT 查询绕过缓存（按 as_of 截断结果不可与默认结果共用一格）
+        if as_of_dt is None:
+            cached = self._fin_cache_get(symbol)
+            if cached is not None:
+                return cached
+
+        _logger.debug(
+            "akshare_fetch_financials", symbol=symbol, prefix=prefix, code=code, as_of=as_of
+        )
 
         try:
-            raw = await asyncio.to_thread(_fetch_financials_sync, prefix=prefix, code=code)
+            raw = await asyncio.to_thread(
+                _fetch_financials_sync,
+                prefix=prefix,
+                code=code,
+                as_of=as_of_dt,
+                publish_lag_days=FINANCIALS_PUBLISH_LAG_DAYS,
+            )
         except Exception as exc:
             _logger.warning("akshare_financials_fetch_failed", symbol=symbol, error=str(exc))
             return {
@@ -204,11 +233,16 @@ class AkshareConnector:
             }
 
         if raw is None or (isinstance(raw, (dict, list)) and len(raw) == 0):
+            reason = (
+                f"no financials published as of {as_of}"
+                if as_of_dt is not None
+                else "akshare returned empty financial data"
+            )
             return {
                 "venue": VENUE,
                 "symbol": symbol,
                 "available": False,
-                "reason": "akshare returned empty financial data",
+                "reason": reason,
             }
 
         from datetime import datetime as dt_dt
@@ -277,15 +311,23 @@ class AkshareConnector:
             except Exception as exc:
                 _logger.warning("akshare_valuation_fetch_failed", symbol=symbol, error=str(exc))
 
+        # as_of 回填：PIT 查询回显请求的 as_of（数据有效时点）；非 PIT 回填取数时刻
+        as_of_echo = (
+            as_of_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if as_of_dt is not None
+            else dt_dt.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
         result = {
             "venue": VENUE,
             "symbol": symbol,
             "available": True,
-            "as_of": dt_dt.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "as_of": as_of_echo,
             "indicators": indicators,
             "raw": raw,
         }
-        self._fin_cache_put(symbol, result)  # 只缓存成功结果;失败路径不缓存,留待重试
+        # 只缓存非 PIT 成功结果;PIT 结果按 as_of 截断、不可与默认结果共格,失败路径不缓存
+        if as_of_dt is None:
+            self._fin_cache_put(symbol, result)
         return result
 
     async def fetch_news(self, symbol: str, limit: int = 20) -> list[dict[str, Any]]:
@@ -351,7 +393,28 @@ class AkshareConnector:
         return None
 
 
-def _fetch_financials_sync(*, prefix: str, code: str) -> dict[str, Any]:
+#: 财报发布滞后保守估计（ADR-0053 阶段 A · point-in-time）：报告期末 + 此天数 ≈ 法定披露
+#: 上限（A股年报次年 4/30 ≈ 120 天；季报法定更早，取 120 天对"as_of 时是否已发布"的判定
+#: 偏保守——宁可晚一期也不偷看未发布财报。拿不到真实公告日时的兜底口径（ADR-0053 OQ1）。
+FINANCIALS_PUBLISH_LAG_DAYS = 120
+
+
+def _period_publishable(period: str, as_of: datetime, lag_days: int) -> bool:
+    """报告期(YYYYMMDD)在 ``as_of`` 时是否已发布：报告期末 + lag_days <= as_of。"""
+    try:
+        end = datetime.strptime(str(period), "%Y%m%d").replace(tzinfo=UTC)
+    except ValueError:
+        return False
+    return end + timedelta(days=lag_days) <= as_of
+
+
+def _fetch_financials_sync(
+    *,
+    prefix: str,
+    code: str,
+    as_of: datetime | None = None,
+    publish_lag_days: int = FINANCIALS_PUBLISH_LAG_DAYS,
+) -> dict[str, Any]:
     """同步调 akshare 财报接口 —— 按前缀路由,返回 ``{指标名: 最新期值}``。
 
     ``stock_financial_abstract`` / ``stock_hk_financial_abstract`` 返回的是
@@ -367,11 +430,20 @@ def _fetch_financials_sync(*, prefix: str, code: str) -> dict[str, Any]:
     else:
         raw = ak.stock_hk_financial_abstract(symbol=code)
 
-    return _flatten_financial_abstract(raw)
+    return _flatten_financial_abstract(raw, as_of=as_of, publish_lag_days=publish_lag_days)
 
 
-def _flatten_financial_abstract(raw: Any) -> dict[str, Any]:
-    """转置财报表 → ``{指标名: 最新非空值}``;结构不符时退化兜底,绝不抛错。"""
+def _flatten_financial_abstract(
+    raw: Any,
+    *,
+    as_of: datetime | None = None,
+    publish_lag_days: int = FINANCIALS_PUBLISH_LAG_DAYS,
+) -> dict[str, Any]:
+    """转置财报表 → ``{指标名: 最新非空值}``;结构不符时退化兜底,绝不抛错。
+
+    ``as_of`` 非空时只保留"报告期末 + 发布滞后 <= as_of"的报告期列（PIT 防未来函数：
+    回测在 as_of 时刻不应看到当时还没披露的财报）；过滤后无可用期 → 返回 ``{}``。
+    """
     import math
 
     if raw is None:
@@ -386,6 +458,11 @@ def _flatten_financial_abstract(raw: Any) -> dict[str, Any]:
         key=lambda c: str(c),
         reverse=True,
     )
+    # PIT 截断：剔除 as_of 时尚未发布的报告期（ADR-0053 阶段 A）
+    if as_of is not None:
+        date_cols = [c for c in date_cols if _period_publishable(str(c), as_of, publish_lag_days)]
+        if not date_cols:
+            return {}
     if "指标" not in cols or not date_cols:
         # 不是预期的转置表 → 退回最后一行(旧行为)兜底,至少不丢数据。
         if len(raw) == 0:

--- a/services/data/src/inalpha_data/connectors/yfinance_conn.py
+++ b/services/data/src/inalpha_data/connectors/yfinance_conn.py
@@ -190,15 +190,21 @@ class YfinanceConnector:
         rows = await asyncio.to_thread(_fetch_news_sync, symbol, limit)
         return rows
 
-    async def fetch_financials(self, symbol: str) -> dict[str, Any]:
+    async def fetch_financials(
+        self, symbol: str, as_of: str | None = None
+    ) -> dict[str, Any]:
         """拉 Yahoo Finance 财报基本面数据。
 
         Uses ``yf.Ticker(symbol).info`` for key metrics +
         ``.quarterly_financials`` for revenue/earnings.
 
         Returns standardized dict with same structure as akshare version.
+
+        ``as_of``（ADR-0053 阶段 A）：接受参数以与 akshare 端签名对称，但 **v1 不对 yfinance
+        财报做 PIT 截断**（yfinance .info 只给"最新"快照、不带历史报告期列，无法可靠按
+        as_of 回溯）；如需 yfinance 财报 PIT 须改用带报告期的数据源，留后续。
         """
-        _logger.debug("yfinance_fetch_financials", symbol=symbol)
+        _logger.debug("yfinance_fetch_financials", symbol=symbol, as_of=as_of)
 
         try:
             result = await asyncio.to_thread(_fetch_financials_sync, symbol)

--- a/services/data/src/inalpha_data/connectors/yfinance_conn.py
+++ b/services/data/src/inalpha_data/connectors/yfinance_conn.py
@@ -224,6 +224,14 @@ class YfinanceConnector:
                 "available": False,
                 "reason": "yfinance returned empty financial data",
             }
+        # PIT 防误用（#100 CR）：yfinance v1 不按 as_of 截断，但响应 as_of 字段回显的是
+        # 取数时刻(now)——调用方若对 yfinance 传 as_of 做回测,会把当前快照当历史用 = 静默
+        # 未来函数。给 as_of 时显式写 reason 提示 PIT 未生效,让调用方能据此察觉、别误信。
+        if as_of is not None and isinstance(result, dict):
+            result["reason"] = (
+                "yfinance PIT not supported in v1; indicators reflect current snapshot, "
+                "not requested as_of"
+            )
         return result
 
     async def close(self) -> None:

--- a/services/data/tests/test_financials_pit.py
+++ b/services/data/tests/test_financials_pit.py
@@ -61,6 +61,16 @@ def test_flatten_as_of_before_any_publication_returns_empty() -> None:
     assert out == {}
 
 
+def test_flatten_as_of_no_indicator_column_does_not_leak() -> None:
+    """#100：PIT 模式 + 缺「指标」列(格式异常)→ 返空，绝不走 iloc[-1] 后门泄漏未来列。"""
+    # 缺「指标」列的异常表（含未披露报告期 20260331）
+    df = pd.DataFrame({"name": ["x"], "20251231": [10.0], "20260331": [12.0]})
+    # 非 PIT：维持旧兜底（返 iloc[-1] 全列）
+    assert _flatten_financial_abstract(df) != {}
+    # PIT：即便 as_of 后有已发布期，缺「指标」列也返空（不泄漏全列）
+    assert _flatten_financial_abstract(df, as_of=_as_of("2026-08-01")) == {}
+
+
 def test_fundamentals_endpoint_threads_as_of(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:

--- a/services/data/tests/test_financials_pit.py
+++ b/services/data/tests/test_financials_pit.py
@@ -71,6 +71,29 @@ def test_flatten_as_of_no_indicator_column_does_not_leak() -> None:
     assert _flatten_financial_abstract(df, as_of=_as_of("2026-08-01")) == {}
 
 
+async def test_yfinance_as_of_marks_pit_not_supported(monkeypatch) -> None:
+    """#100：yfinance 接 as_of 但不截断 → 响应 reason 写明 PIT 未生效，防调用方误信。"""
+    from inalpha_data.connectors import yfinance_conn as yf
+
+    def fake_sync(symbol):
+        return {
+            "venue": "yfinance",
+            "symbol": symbol,
+            "available": True,
+            "as_of": "2026-06-18T00:00:00Z",  # 取数时刻(now)，非请求 as_of
+            "indicators": {"pe_ratio": 30.0},
+        }
+
+    monkeypatch.setattr(yf, "_fetch_financials_sync", fake_sync)
+    conn = yf.YfinanceConnector()
+    # 给 as_of → reason 提示 PIT 未生效
+    out = await conn.fetch_financials("AAPL", as_of="2020-01-01T00:00:00Z")
+    assert "PIT not supported" in (out.get("reason") or "")
+    # 不给 as_of → 不注入 reason（维持原行为）
+    out2 = await conn.fetch_financials("AAPL")
+    assert "PIT" not in (out2.get("reason") or "")
+
+
 def test_fundamentals_endpoint_threads_as_of(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:

--- a/services/data/tests/test_financials_pit.py
+++ b/services/data/tests/test_financials_pit.py
@@ -1,0 +1,97 @@
+"""财报 point-in-time 截断单测（ADR-0053 阶段 A）。
+
+纯函数测试（合成 DataFrame，免 akshare / 网络）：报告期发布判定 + as_of 过滤。
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from inalpha_data.connectors.akshare import (
+    FINANCIALS_PUBLISH_LAG_DAYS,
+    _flatten_financial_abstract,
+    _period_publishable,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _as_of(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=UTC)
+
+
+def test_period_publishable() -> None:
+    lag = FINANCIALS_PUBLISH_LAG_DAYS  # 120
+    # 20260331 + 120d ≈ 2026-07-29
+    assert _period_publishable("20260331", _as_of("2026-08-01"), lag) is True
+    assert _period_publishable("20260331", _as_of("2026-05-01"), lag) is False
+    # 非法报告期 → False（不抛）
+    assert _period_publishable("not-a-date", _as_of("2026-08-01"), lag) is False
+
+
+def _abstract_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "指标": ["净资产收益率", "毛利率"],
+            "20251231": [10.0, 50.0],
+            "20260331": [12.0, 52.0],
+        }
+    )
+
+
+def test_flatten_no_as_of_picks_latest_period() -> None:
+    out = _flatten_financial_abstract(_abstract_df())
+    assert out["净资产收益率"] == 12.0  # 最新期 20260331
+    assert out["毛利率"] == 52.0
+
+
+def test_flatten_as_of_skips_unpublished_period() -> None:
+    # 2026-05-01：20260331 还没披露（+120d=07-29），只能用 20251231（+120d=04-30 已过）
+    out = _flatten_financial_abstract(_abstract_df(), as_of=_as_of("2026-05-01"))
+    assert out["净资产收益率"] == 10.0
+    assert out["毛利率"] == 50.0
+
+
+def test_flatten_as_of_before_any_publication_returns_empty() -> None:
+    # 2026-01-01：连 20251231 都没披露 → 无可用期
+    out = _flatten_financial_abstract(_abstract_df(), as_of=_as_of("2026-01-01"))
+    assert out == {}
+
+
+def test_fundamentals_endpoint_threads_as_of(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    """GET /fundamentals?as_of=... 把 as_of 透传到 connector。"""
+    from inalpha_data.connectors import akshare as ak
+
+    captured: dict[str, str | None] = {}
+    original = ak._connector.fetch_financials
+
+    async def mock_fin(symbol, as_of=None):
+        captured["as_of"] = as_of
+        return {
+            "venue": "akshare",
+            "symbol": symbol,
+            "available": False,
+            "reason": f"no financials published as of {as_of}",
+        }
+
+    ak._connector.fetch_financials = mock_fin
+    try:
+        r = client.get(
+            "/fundamentals",
+            headers=auth_headers,
+            params={
+                "venue": "akshare",
+                "symbol": "sh.600519",
+                "as_of": "2026-01-01T00:00:00Z",
+            },
+        )
+        assert r.status_code == 200
+        assert captured["as_of"] == "2026-01-01T00:00:00Z"
+        assert r.json()["available"] is False
+    finally:
+        ak._connector.fetch_financials = original

--- a/services/data/tests/test_fundamentals.py
+++ b/services/data/tests/test_fundamentals.py
@@ -21,7 +21,7 @@ def test_fundamentals_akshare_venue(
 
     original = ak._connector.fetch_financials
 
-    async def mock_fin(symbol):
+    async def mock_fin(symbol, as_of=None):
         return {
             "venue": "akshare",
             "symbol": symbol,
@@ -60,7 +60,7 @@ def test_fundamentals_yfinance_venue(
 
     original = yf._connector.fetch_financials
 
-    async def mock_fin(symbol):
+    async def mock_fin(symbol, as_of=None):
         return {
             "venue": "yfinance",
             "symbol": symbol,
@@ -106,7 +106,7 @@ def test_fundamentals_unavailable_data(
 
     original = ak._connector.fetch_financials
 
-    async def mock_fin(symbol):
+    async def mock_fin(symbol, as_of=None):
         return {
             "venue": "akshare",
             "symbol": symbol,

--- a/services/paper/src/inalpha_paper/data_client.py
+++ b/services/paper/src/inalpha_paper/data_client.py
@@ -10,7 +10,7 @@
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
@@ -199,6 +199,52 @@ class DataClient:
                 f"unexpected response shape from data-service: {type(result).__name__}"
             )
         return result
+
+    async def get_bars_pit(
+        self,
+        *,
+        venue: str,
+        symbol: str,
+        timeframe: str,
+        from_ts: datetime,
+        as_of: datetime,
+        limit: int = 10_000,
+        publish_lag: timedelta = timedelta(0),
+    ) -> list[dict[str, Any]]:
+        """point-in-time 取 bars（ADR-0053 阶段 A）：只返回 ``ts <= as_of - publish_lag``
+        的 K 线——回测在 ``as_of`` 时刻不应看到当时还没收盘 / 还没发布的 bar（防未来函数）。
+
+        与 ``get_bars`` 的区别：
+        - ``to_ts`` 上限钉死在 ``as_of``（不拉 as_of 之后的数据）；
+        - 用 ``fresh=False``（PIT 是历史重建，不需要把最新行情补进来）；
+        - 客户端侧再按 ``as_of - publish_lag`` 兜底过滤（多数 venue 的 K 线 publish_lag=0：
+          bar 在自身 ts 收盘即已知；带发布滞后的非 bar 数据走各自 connector 的 PIT 口径）。
+        """
+        cutoff = as_of - publish_lag
+        bars = await self.get_bars(
+            venue=venue,
+            symbol=symbol,
+            timeframe=timeframe,
+            from_ts=from_ts,
+            to_ts=as_of,
+            limit=limit,
+            fresh=False,
+        )
+        out: list[dict[str, Any]] = []
+        for b in bars:
+            ts_raw = b.get("ts")
+            if ts_raw is None:
+                continue
+            ts = (
+                datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+                if isinstance(ts_raw, str)
+                else ts_raw
+            )
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            if ts <= cutoff:
+                out.append(b)
+        return out
 
     async def backfill_bars(
         self,

--- a/services/paper/src/inalpha_paper/data_client.py
+++ b/services/paper/src/inalpha_paper/data_client.py
@@ -14,7 +14,10 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
+from inalpha_shared import get_logger
 from inalpha_shared.errors import InalphaError
+
+_logger = get_logger(__name__)
 
 
 class DataServiceError(InalphaError):
@@ -237,6 +240,8 @@ class DataClient:
         for b in bars:
             ts_raw = b.get("ts")
             if ts_raw is None:
+                # 残损记录(venue 返回缺 ts)——告警而非静默吞,否则掩盖数据质量问题(#100 CR)
+                _logger.warning("get_bars_pit_missing_ts", bar=b)
                 continue
             ts = (
                 datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))

--- a/services/paper/src/inalpha_paper/data_client.py
+++ b/services/paper/src/inalpha_paper/data_client.py
@@ -220,6 +220,9 @@ class DataClient:
         - 客户端侧再按 ``as_of - publish_lag`` 兜底过滤（多数 venue 的 K 线 publish_lag=0：
           bar 在自身 ts 收盘即已知；带发布滞后的非 bar 数据走各自 connector 的 PIT 口径）。
         """
+        # tz-naive as_of 兜底转 UTC（#100 CR）：否则与 UTC-aware 的 bar ts 比较抛 TypeError
+        if as_of.tzinfo is None:
+            as_of = as_of.replace(tzinfo=UTC)
         cutoff = as_of - publish_lag
         bars = await self.get_bars(
             venue=venue,

--- a/services/paper/tests/test_data_client_pit.py
+++ b/services/paper/tests/test_data_client_pit.py
@@ -61,3 +61,22 @@ async def test_get_bars_pit_applies_publish_lag() -> None:
         publish_lag=timedelta(days=3),
     )
     assert [b["ts"] for b in out] == ["2026-01-01T00:00:00Z"]
+
+
+async def test_get_bars_pit_accepts_naive_as_of() -> None:
+    """#100：tz-naive as_of 入口兜底转 UTC，不与 UTC-aware bar ts 比较抛 TypeError。"""
+    dc = DataClient("http://data.test", "tok")
+    all_bars = [_bar("2026-01-01T00:00:00Z"), _bar("2026-01-10T00:00:00Z")]
+
+    async def fake_get_bars(**kwargs: Any) -> list[dict[str, Any]]:
+        return all_bars
+
+    dc.get_bars = fake_get_bars  # type: ignore[method-assign]
+    out = await dc.get_bars_pit(
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1d",
+        from_ts=datetime(2026, 1, 1),  # naive
+        as_of=datetime(2026, 1, 6),  # naive → 应兜底转 UTC，不抛 TypeError
+    )
+    assert [b["ts"] for b in out] == ["2026-01-01T00:00:00Z"]

--- a/services/paper/tests/test_data_client_pit.py
+++ b/services/paper/tests/test_data_client_pit.py
@@ -1,0 +1,63 @@
+"""``DataClient.get_bars_pit`` 单测（ADR-0053 阶段 A）—— PIT 截断过滤未来 bar。"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from inalpha_paper.data_client import DataClient
+
+pytestmark = pytest.mark.anyio
+
+
+def _bar(ts: str) -> dict[str, Any]:
+    return {"ts": ts, "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0, "volume": 1.0}
+
+
+async def test_get_bars_pit_drops_bars_after_as_of() -> None:
+    dc = DataClient("http://data.test", "tok")
+    all_bars = [
+        _bar("2026-01-01T00:00:00Z"),
+        _bar("2026-01-05T00:00:00Z"),
+        _bar("2026-01-10T00:00:00Z"),  # as_of 之后 → 应被丢
+    ]
+    captured: dict[str, Any] = {}
+
+    async def fake_get_bars(**kwargs: Any) -> list[dict[str, Any]]:
+        captured.update(kwargs)
+        return all_bars
+
+    dc.get_bars = fake_get_bars  # type: ignore[method-assign]
+    out = await dc.get_bars_pit(
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1d",
+        from_ts=datetime(2026, 1, 1, tzinfo=UTC),
+        as_of=datetime(2026, 1, 6, tzinfo=UTC),
+    )
+    # 只保留 ts <= as_of 的两根
+    assert [b["ts"] for b in out] == ["2026-01-01T00:00:00Z", "2026-01-05T00:00:00Z"]
+    # PIT 历史重建：to_ts 钉在 as_of、fresh=False
+    assert captured["to_ts"] == datetime(2026, 1, 6, tzinfo=UTC)
+    assert captured["fresh"] is False
+
+
+async def test_get_bars_pit_applies_publish_lag() -> None:
+    dc = DataClient("http://data.test", "tok")
+    all_bars = [_bar("2026-01-01T00:00:00Z"), _bar("2026-01-05T00:00:00Z")]
+
+    async def fake_get_bars(**kwargs: Any) -> list[dict[str, Any]]:
+        return all_bars
+
+    dc.get_bars = fake_get_bars  # type: ignore[method-assign]
+    # as_of=01-06 但 publish_lag=3d → cutoff=01-03，只剩 01-01 那根
+    out = await dc.get_bars_pit(
+        venue="binance",
+        symbol="BTC/USDT",
+        timeframe="1d",
+        from_ts=datetime(2026, 1, 1, tzinfo=UTC),
+        as_of=datetime(2026, 1, 6, tzinfo=UTC),
+        publish_lag=timedelta(days=3),
+    )
+    assert [b["ts"] for b in out] == ["2026-01-01T00:00:00Z"]


### PR DESCRIPTION
## 背景

补防未来函数的数据层缺口(阶段 A:无表改、低风险)。博主吐槽的七星 ETF 存活者偏差 + 未来函数,根因之一是回测看到了当时还没披露的数据。FRED 宏观 PIT 早已在 research 落地(ADR-0044),本阶段把**财报 / bar** 向其口径对齐。

## 改动

**data-service**:
- `akshare.fetch_financials(symbol, as_of=None)`:给 as_of 时按"报告期末 + `FINANCIALS_PUBLISH_LAG_DAYS`(120,法定披露上限保守估计) ≤ as_of"过滤报告期,剔除未披露期;无可用期 → `available=False`;PIT 查询绕过缓存、as_of 回显数据时点
- `_flatten_financial_abstract` / `_period_publishable` 纯函数化(合成 DataFrame 可测)
- yfinance 接 as_of(签名对称,v1 不做 PIT,已标注);`GET /fundamentals` 加 `as_of` query 透传

**paper-service**:
- `DataClient.get_bars_pit(as_of, publish_lag)`:`to_ts` 钉 as_of + `fresh=False` + 客户端按 `as_of−publish_lag` 兜底过滤未来 bar

## 验证

data `ruff` 干净 + `pytest` 138 passed;paper `ruff` 干净 + `pytest` 767 passed;新测试 test_financials_pit + test_data_client_pit 全过;`check-consistency.sh` 0 失败。

阶段 B(bars 表 PIT 列 + 复权,需迁移)/ C(成分股快照)按需再做。设计依据:ADR-0053(`docs/miro/decisions/`,gitignored)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)