### PR TITLE
feat(research,orchestration): 财报 PIT as_of 接进研究链路 + agent 工具 (ADR-0053 阶段 A 消费方)

### DIFF
--- a/packages/orchestration/src/clients/data.ts
+++ b/packages/orchestration/src/clients/data.ts
@@ -92,11 +92,16 @@ export class DataClient {
     });
   }
 
-  async getFundamentals(params: { venue: string; symbol: string }): Promise<Record<string, unknown>> {
+  async getFundamentals(params: {
+    venue: string;
+    symbol: string;
+    asOf?: string;
+  }): Promise<Record<string, unknown>> {
     try {
       return await this.http.get<Record<string, unknown>>("/fundamentals", {
         venue: params.venue,
         symbol: params.symbol,
+        ...(params.asOf ? { as_of: params.asOf } : {}),
       });
     } catch (err) {
       if (err instanceof HttpClientError) {

--- a/packages/orchestration/src/tools/data.ts
+++ b/packages/orchestration/src/tools/data.ts
@@ -326,8 +326,11 @@ export const dataGetFundamentalsTool = createTool({
     venue: z.string().default("akshare"),
     symbol: SymbolSchema,
     asOf: z
+      // offset:true 必须——akshare 响应回显 / Python isoformat 都用 +00:00，不带 offset
+      // 的 .datetime() 只认 Z 结尾会拒 +00:00，导致 agent 把上轮 as_of 复制回来即失败
+      // （与 factor.ts 同名字段一致，#102 CR）。
       .string()
-      .datetime()
+      .datetime({ offset: true })
       .optional()
       .describe("point-in-time 截断（ISO 8601）；只返回该时点已披露的财报，防未来函数"),
   }),

--- a/packages/orchestration/src/tools/data.ts
+++ b/packages/orchestration/src/tools/data.ts
@@ -316,11 +316,20 @@ export const dataGetFundamentalsTool = createTool({
     何时用：研究个股基本面 / 看估值是否合理 / deep_dive 前预拉数据
     何时不用：加密货币（无传统财报）/ 指数和宏观（走 FRED 或专用数据源）
 
-    坑：akshare 返回字段因市场不同有差异；缺失字段为 null 不抛错
+    坑：
+    - akshare 返回字段因市场不同有差异；缺失字段为 null 不抛错
+    - asOf（point-in-time，ADR-0053）：研究历史某时点时传入，只返回那时已披露的财报，
+      防未来函数（读到当时还没发布的报告期）；仅 akshare 生效，yfinance 不做 PIT、
+      响应 reason 会标注。研究"当下"不必传。
   `.trim(),
   inputSchema: z.object({
     venue: z.string().default("akshare"),
     symbol: SymbolSchema,
+    asOf: z
+      .string()
+      .datetime()
+      .optional()
+      .describe("point-in-time 截断（ISO 8601）；只返回该时点已披露的财报，防未来函数"),
   }),
   execute: async (inputData, ctx) => {
     const tc = ctx?.requestContext as ToolRequestContext | undefined;
@@ -328,6 +337,7 @@ export const dataGetFundamentalsTool = createTool({
     return await client.getFundamentals({
       venue: inputData.venue ?? "akshare",
       symbol: inputData.symbol,
+      asOf: inputData.asOf,
     });
   },
 });

--- a/packages/orchestration/src/tools/data.ts
+++ b/packages/orchestration/src/tools/data.ts
@@ -321,6 +321,9 @@ export const dataGetFundamentalsTool = createTool({
     - asOf（point-in-time，ADR-0053）：研究历史某时点时传入，只返回那时已披露的财报，
       防未来函数（读到当时还没发布的报告期）；仅 akshare 生效，yfinance 不做 PIT、
       响应 reason 会标注。研究"当下"不必传。
+    - A股（sh/sz）的 market_cap/pe_ratio/pb_ratio 来自**实时** Baidu 源、无历史回溯：传
+      **历史 asOf** 时这些估值字段留空（只有 ROE/毛利率等财报指标做 PIT），避免把当日估值
+      混进历史财报；asOf=今天/不传 时估值正常返回。
   `.trim(),
   inputSchema: z.object({
     venue: z.string().default("akshare"),

--- a/packages/orchestration/tests/data-fundamentals-pit.test.ts
+++ b/packages/orchestration/tests/data-fundamentals-pit.test.ts
@@ -64,6 +64,15 @@ describe("data.get_fundamentals · asOf PIT 透传", () => {
     expect(decodeURIComponent(capturedUrl)).toContain("2020-01-01T00:00:00Z");
   });
 
+  it("schema 接受 +00:00 与 Z 两种偏移格式（akshare/Python isoformat 回显，#102 CR）", () => {
+    // agent 把上一轮响应里的 as_of(+00:00)复制回来——schema 必须收，否则 round-trip 失败
+    const schema = dataGetFundamentalsTool.inputSchema!;
+    for (const asOf of ["2020-01-01T00:00:00+00:00", "2020-01-01T00:00:00Z"]) {
+      const r = schema.safeParse({ venue: "akshare", symbol: "sh.600519", asOf });
+      expect(r.success).toBe(true);
+    }
+  });
+
   it("不传 asOf → URL 不带 as_of（研究当下不做 PIT 截断）", async () => {
     let capturedUrl = "";
     mockFetch(async (url) => {

--- a/packages/orchestration/tests/data-fundamentals-pit.test.ts
+++ b/packages/orchestration/tests/data-fundamentals-pit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * ADR-0053 阶段 A · data.get_fundamentals 的 asOf（point-in-time）透传单测。
+ *
+ * 覆盖：asOf 传入 → GET /fundamentals?as_of=...；不传 → 不带 as_of。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearSettings, setSettings } from "../src/config.js";
+import { dataGetFundamentalsTool } from "../src/tools/index.js";
+
+const TEST_TOKEN = "test-token-doesnt-need-to-be-real";
+
+beforeEach(() => {
+  setSettings({
+    dataServiceUrl: "http://data-mock.test",
+    paperServiceUrl: "http://paper-mock.test",
+    researchServiceUrl: "http://research-mock.test",
+    jwtSecret: "test-secret-32-chars-or-more-xxxxxxx",
+    jwtAlgorithm: "HS256",
+  });
+});
+
+afterEach(() => {
+  clearSettings();
+  vi.restoreAllMocks();
+});
+
+function mockFetch(impl: (url: string, init?: RequestInit) => Promise<Response>) {
+  vi.stubGlobal("fetch", vi.fn(impl));
+}
+
+const ctx = (authToken: string | undefined = TEST_TOKEN): never =>
+  ({ requestContext: { authToken } }) as never;
+
+const FIN_RESPONSE = {
+  venue: "akshare",
+  symbol: "sh.600519",
+  available: false,
+  reason: "no financials published as of 2020-01-01T00:00:00.000Z",
+};
+
+describe("data.get_fundamentals · asOf PIT 透传", () => {
+  it("传 asOf → GET /fundamentals 带 as_of 查询参数", async () => {
+    let capturedUrl = "";
+    mockFetch(async (url) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify(FIN_RESPONSE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await dataGetFundamentalsTool.execute!(
+      {
+        venue: "akshare",
+        symbol: "sh.600519",
+        asOf: "2020-01-01T00:00:00Z",
+      } as never,
+      ctx(),
+    );
+
+    expect(capturedUrl).toContain("/fundamentals");
+    expect(capturedUrl).toContain("as_of=");
+    expect(decodeURIComponent(capturedUrl)).toContain("2020-01-01T00:00:00Z");
+  });
+
+  it("不传 asOf → URL 不带 as_of（研究当下不做 PIT 截断）", async () => {
+    let capturedUrl = "";
+    mockFetch(async (url) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify({ ...FIN_RESPONSE, available: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await dataGetFundamentalsTool.execute!(
+      { venue: "akshare", symbol: "sh.600519" } as never,
+      ctx(),
+    );
+
+    expect(capturedUrl).toContain("/fundamentals");
+    expect(capturedUrl).not.toContain("as_of");
+  });
+});

--- a/services/data/src/inalpha_data/connectors/akshare.py
+++ b/services/data/src/inalpha_data/connectors/akshare.py
@@ -81,24 +81,38 @@ class AkshareConnector:
     """akshare 包装 —— 同步库走 ``asyncio.to_thread``。"""
 
     def __init__(self) -> None:
-        # akshare 无 client 对象,import 即用。fundamentals 进程内 TTL 缓存:
-        # {symbol: (expires_monotonic, result_dict)},只缓存成功结果。
-        self._fin_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+        # akshare 无 client 对象,import 即用。fundamentals 进程内 TTL 缓存,**PIT-aware**:
+        # key = (symbol, as_of 截断到天 | None)。财报日级粒度,按天 key 安全——同一天的
+        # PIT 查询(含 as_of≈now 的实时研究,三 analyst 并行)命中同一格,不再各自打 akshare
+        # (#102 CR:原"PIT 绕过缓存"会让 live deep-dive 对同 ticker 打 3× 网络)。只缓存成功。
+        self._fin_cache: dict[tuple[str, str | None], tuple[float, dict[str, Any]]] = {}
 
-    def _fin_cache_get(self, symbol: str) -> dict[str, Any] | None:
-        hit = self._fin_cache.get(symbol)
+    @staticmethod
+    def _fin_cache_key(symbol: str, as_of: datetime | None) -> tuple[str, str | None]:
+        return (symbol, as_of.date().isoformat() if as_of is not None else None)
+
+    def _fin_cache_get(
+        self, symbol: str, as_of: datetime | None = None
+    ) -> dict[str, Any] | None:
+        key = self._fin_cache_key(symbol, as_of)
+        hit = self._fin_cache.get(key)
         if hit is None:
             return None
         expires, value = hit
         if time.monotonic() > expires:
-            self._fin_cache.pop(symbol, None)
+            self._fin_cache.pop(key, None)
             return None
         return value
 
-    def _fin_cache_put(self, symbol: str, value: dict[str, Any]) -> None:
+    def _fin_cache_put(
+        self, symbol: str, value: dict[str, Any], as_of: datetime | None = None
+    ) -> None:
         if len(self._fin_cache) > 128:  # 进程内软上限,超了清空(同 cn_market)
             self._fin_cache.clear()
-        self._fin_cache[symbol] = (time.monotonic() + _FIN_CACHE_TTL_S, value)
+        self._fin_cache[self._fin_cache_key(symbol, as_of)] = (
+            time.monotonic() + _FIN_CACHE_TTL_S,
+            value,
+        )
 
     async def fetch_bars(
         self,
@@ -205,11 +219,11 @@ class AkshareConnector:
                     "reason": f"invalid as_of datetime: {as_of!r}",
                 }
 
-        # 非 PIT 走缓存；PIT 查询绕过缓存（按 as_of 截断结果不可与默认结果共用一格）
-        if as_of_dt is None:
-            cached = self._fin_cache_get(symbol)
-            if cached is not None:
-                return cached
+        # PIT-aware 缓存：按 (symbol, as_of 截断到天) 命中——非 PIT(None)与各 as_of 各自一格，
+        # 同一天的 PIT 查询(含实时研究)复用，不再绕过缓存（#102 CR）。
+        cached = self._fin_cache_get(symbol, as_of_dt)
+        if cached is not None:
+            return cached
 
         _logger.debug(
             "akshare_fetch_financials", symbol=symbol, prefix=prefix, code=code, as_of=as_of
@@ -325,9 +339,8 @@ class AkshareConnector:
             "indicators": indicators,
             "raw": raw,
         }
-        # 只缓存非 PIT 成功结果;PIT 结果按 as_of 截断、不可与默认结果共格,失败路径不缓存
-        if as_of_dt is None:
-            self._fin_cache_put(symbol, result)
+        # 缓存成功结果（PIT-aware，按 (symbol, as_of 天) 分格）；失败路径不缓存,留待重试
+        self._fin_cache_put(symbol, result, as_of_dt)
         return result
 
     async def fetch_news(self, symbol: str, limit: int = 20) -> list[dict[str, Any]]:

--- a/services/data/src/inalpha_data/connectors/akshare.py
+++ b/services/data/src/inalpha_data/connectors/akshare.py
@@ -216,6 +216,9 @@ class AkshareConnector:
                 as_of_dt = datetime.fromisoformat(as_of.replace("Z", "+00:00"))
                 if as_of_dt.tzinfo is None:
                     as_of_dt = as_of_dt.replace(tzinfo=UTC)
+                # 归一到 UTC：否则带非 UTC offset(+08:00)时 .date() 是本地日期,与
+                # now(UTC).date() 比 / 缓存按天分格都会错位(#102 CR)。
+                as_of_dt = as_of_dt.astimezone(UTC)
             except ValueError:
                 return {
                     "venue": VENUE,

--- a/services/data/src/inalpha_data/connectors/akshare.py
+++ b/services/data/src/inalpha_data/connectors/akshare.py
@@ -193,8 +193,13 @@ class AkshareConnector:
         akshare 返回字段因市场不同有差异，做防御性字段映射；缺失字段置 None 不抛异常。
 
         ``as_of``（ISO 时间串，ADR-0053 阶段 A）：point-in-time 截断——只取"报告期末 +
-        发布滞后 <= as_of"的财报期，防回测看到当时还没披露的财报（未来函数）。给 as_of 时
-        **绕过缓存**（PIT 查询较少，避免与非 PIT 结果串味）。
+        发布滞后 <= as_of"的财报期，防回测看到当时还没披露的财报（未来函数）。缓存为
+        **PIT-aware**：按 ``(symbol, as_of 截断到天)`` 分格，同一天的 PIT 查询复用、非 PIT
+        (None) 自成一格（#102 CR）。
+
+        **限制（A股估值字段无 PIT）**：``sh/sz`` 的 ``market_cap/pe_ratio/pb_ratio`` 来自 Baidu
+        **实时**源，无历史回溯。故**历史 as_of**（早于今天）查询时**跳过估值**（留空），避免把当日
+        估值混进历史财报造成时序错配（未来函数）；``as_of=今天/None`` 的实时研究照常取（即时正确）。
         """
         prefix, code = _parse_symbol(symbol)
         if prefix not in ("sh", "sz", "hk"):
@@ -314,8 +319,17 @@ class AkshareConnector:
 
         # 估值(总市值/PE/PB)不在财报摘要里 → A股另走 Baidu 源补齐(best-effort,
         # 失败只记日志不阻断已拿到的盈利/成长/财务指标)。
-        if prefix in ("sh", "sz") and not all(
-            indicators.get(k) is not None for k in ("market_cap", "pe_ratio", "pb_ratio")
+        # **PIT 守门(#102 CR)**：Baidu 估值是**实时**源、无历史回溯。历史 as_of(早于今天)查询
+        # 时**跳过**——否则把当日估值混进 PIT 过滤后的历史财报 = 时序错配/未来函数(2020 的 ROE
+        # 配当日 PE 会让相对估值反向)。as_of=今天/None 的实时研究照取(即时正确)。
+        _is_historical = as_of_dt is not None and as_of_dt.date() < dt_dt.now(tz=UTC).date()
+        if (
+            prefix in ("sh", "sz")
+            and not _is_historical
+            and not all(
+                indicators.get(k) is not None
+                for k in ("market_cap", "pe_ratio", "pb_ratio")
+            )
         ):
             try:
                 valuation = await asyncio.to_thread(_fetch_valuation_sync, code)

--- a/services/data/tests/test_financials_pit.py
+++ b/services/data/tests/test_financials_pit.py
@@ -116,6 +116,37 @@ async def test_financials_cache_is_pit_aware(monkeypatch) -> None:
     assert calls["n"] == 2  # 不同天 → 另一格,再打一次
 
 
+async def test_ashare_valuation_skipped_for_historical_as_of(monkeypatch) -> None:
+    """#102 CR M2：历史 as_of 跳过 Baidu 实时估值（防时序混用）；今天/None 照取。"""
+    from datetime import UTC, datetime
+
+    from inalpha_data.connectors import akshare as ak
+
+    monkeypatch.setattr(
+        ak, "_fetch_financials_sync", lambda **kw: {"净资产收益率(ROE)": 18.0}
+    )
+    val_calls = {"n": 0}
+
+    def fake_val(code):
+        val_calls["n"] += 1
+        return {"market_cap": 1.0e12, "pe_ratio": 30.0, "pb_ratio": 5.0}
+
+    monkeypatch.setattr(ak, "_fetch_valuation_sync", fake_val)
+    conn = ak.AkshareConnector()
+
+    # 历史 as_of（去年）→ 跳过实时估值,估值字段留空
+    hist = await conn.fetch_financials("sh.600519", as_of="2020-01-01T00:00:00Z")
+    assert val_calls["n"] == 0
+    assert hist["indicators"].get("pe_ratio") is None
+    assert hist["indicators"].get("roe") == 0.18  # 财报指标仍在（18.0/100 归一）
+
+    # as_of=今天 → 实时估值照取
+    today = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    live = await conn.fetch_financials("sz.000001", as_of=today)
+    assert val_calls["n"] == 1
+    assert live["indicators"].get("pe_ratio") == 30.0
+
+
 def test_fundamentals_endpoint_threads_as_of(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:

--- a/services/data/tests/test_financials_pit.py
+++ b/services/data/tests/test_financials_pit.py
@@ -94,6 +94,28 @@ async def test_yfinance_as_of_marks_pit_not_supported(monkeypatch) -> None:
     assert "PIT" not in (out2.get("reason") or "")
 
 
+async def test_financials_cache_is_pit_aware(monkeypatch) -> None:
+    """#102 CR：PIT 缓存按 (symbol, as_of 天) 分格——同一天复用、不同天各打一次。"""
+    from inalpha_data.connectors import akshare as ak
+
+    calls = {"n": 0}
+
+    def fake_sync(*, prefix, code, as_of=None, publish_lag_days=120):
+        calls["n"] += 1
+        return {"净资产收益率(ROE)": 18.0}
+
+    monkeypatch.setattr(ak, "_fetch_financials_sync", fake_sync)
+    conn = ak.AkshareConnector()  # hk → 跳过 sh/sz 的 Baidu 估值网络调用
+
+    a1 = await conn.fetch_financials("hk.00700", as_of="2020-06-30T00:00:00Z")
+    a2 = await conn.fetch_financials("hk.00700", as_of="2020-06-30T23:00:00Z")  # 同一天
+    assert a1["available"] is True and a2["available"] is True
+    assert calls["n"] == 1  # 同 (symbol, 天) → 第二次命中缓存,不再打 akshare
+
+    await conn.fetch_financials("hk.00700", as_of="2020-09-30T00:00:00Z")  # 另一天
+    assert calls["n"] == 2  # 不同天 → 另一格,再打一次
+
+
 def test_fundamentals_endpoint_threads_as_of(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:

--- a/services/data/tests/test_financials_pit.py
+++ b/services/data/tests/test_financials_pit.py
@@ -147,6 +147,25 @@ async def test_ashare_valuation_skipped_for_historical_as_of(monkeypatch) -> Non
     assert live["indicators"].get("pe_ratio") == 30.0
 
 
+async def test_cache_key_normalizes_tz_to_utc(monkeypatch) -> None:
+    """#102 CR：as_of 归一到 UTC——+08:00 与其 UTC 等价串落同一缓存格（同 UTC 日）。"""
+    from inalpha_data.connectors import akshare as ak
+
+    calls = {"n": 0}
+
+    def fake_sync(**kw):
+        calls["n"] += 1
+        return {"净资产收益率(ROE)": 18.0}
+
+    monkeypatch.setattr(ak, "_fetch_financials_sync", fake_sync)
+    conn = ak.AkshareConnector()
+
+    # 两者都 = UTC 2020-06-29；未归一时 +08:00 的本地日期是 06-30 会落到另一格
+    await conn.fetch_financials("hk.00700", as_of="2020-06-30T07:00:00+08:00")
+    await conn.fetch_financials("hk.00700", as_of="2020-06-29T23:00:00Z")
+    assert calls["n"] == 1  # 同 UTC 日 → 同缓存格,只打一次
+
+
 def test_fundamentals_endpoint_threads_as_of(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:

--- a/services/research/src/inalpha_research/analysts/fundamental.py
+++ b/services/research/src/inalpha_research/analysts/fundamental.py
@@ -119,7 +119,7 @@ class FundamentalAnalyst(Analyst):
                 "Rely on on-chain / supply-schedule / web evidence below instead."
             )
         else:
-            financials = await self._data.get_fundamentals(venue=fund_venue, symbol=symbol)
+            financials = await self._data.get_fundamentals(venue=fund_venue, symbol=symbol, as_of=as_of)
             financials_block = _render_financials(financials)
 
         # 双档 confidence cap（run() 里代码级 clamp）：有 live 财报 0.75，无 0.55

--- a/services/research/src/inalpha_research/analysts/personas/base_persona.py
+++ b/services/research/src/inalpha_research/analysts/personas/base_persona.py
@@ -124,7 +124,7 @@ class PersonaAnalyst(Analyst):
         if fund_venue is None:
             financials = {"available": False, "reason": "crypto has no financial statements"}
         else:
-            financials = await self._data.get_fundamentals(venue=fund_venue, symbol=symbol)
+            financials = await self._data.get_fundamentals(venue=fund_venue, symbol=symbol, as_of=as_of)
         financials_block = _render_fundamentals(financials)
 
         # 双档 confidence cap（run() 里代码级 clamp）：与 fundamental/valuation 同纪律——

--- a/services/research/src/inalpha_research/analysts/valuation.py
+++ b/services/research/src/inalpha_research/analysts/valuation.py
@@ -120,7 +120,7 @@ class ValuationAnalyst(Analyst):
                 "reason": "crypto has no financial statements — use NVT/MVRV-style reasoning",
             }
         else:
-            financials = await self._data.get_fundamentals(venue=fund_venue, symbol=symbol)
+            financials = await self._data.get_fundamentals(venue=fund_venue, symbol=symbol, as_of=as_of)
         financials_block = _render_valuation_inputs(financials)
 
         # 双档 confidence cap（run() 里代码级 clamp）：有 live 指标 0.75，无 0.55

--- a/services/research/src/inalpha_research/data_client.py
+++ b/services/research/src/inalpha_research/data_client.py
@@ -169,15 +169,22 @@ class DataClient:
         items = payload.get("items") if isinstance(payload, dict) else None
         return items if isinstance(items, list) else []
 
-    async def get_fundamentals(self, venue: str, symbol: str) -> dict[str, Any]:
+    async def get_fundamentals(
+        self, venue: str, symbol: str, as_of: datetime | None = None
+    ) -> dict[str, Any]:
         """``GET /fundamentals`` —— 拉财报基本面数据。
+
+        ``as_of``（ADR-0053 阶段 A）：传入则做 point-in-time 截断——只返回该时点已披露的
+        财报，防 analyst 在 as_of 研究时刻读到当时还没发布的财报（未来函数）。仅 akshare
+        生效；yfinance v1 不做 PIT 但响应 reason 会标注。
 
         失败时返 ``{"available": False, ...}``（不阻断整条链路）。
         """
+        params: dict[str, str] = {"venue": venue, "symbol": symbol}
+        if as_of is not None:
+            params["as_of"] = as_of.isoformat()
         try:
-            r = await self._client.get(
-                "/fundamentals", params={"venue": venue, "symbol": symbol}
-            )
+            r = await self._client.get("/fundamentals", params=params)
         except Exception:
             return {"available": False, "reason": "request failed"}
         if r.status_code >= 400:

--- a/services/research/tests/test_fundamentals_pit.py
+++ b/services/research/tests/test_fundamentals_pit.py
@@ -1,0 +1,38 @@
+"""ADR-0053 阶段 A · research DataClient.get_fundamentals 的 as_of 透传单测。"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+import respx
+from httpx import Response
+
+from inalpha_research.data_client import DataClient
+
+pytestmark = pytest.mark.anyio
+
+
+@respx.mock
+async def test_get_fundamentals_threads_as_of() -> None:
+    """传 as_of → GET /fundamentals 带 as_of 查询参数（防 analyst 读未披露财报）。"""
+    route = respx.get("http://data-mock.test/fundamentals").mock(
+        return_value=Response(200, json={"available": False, "reason": "pit"})
+    )
+    async with DataClient("http://data-mock.test", "t") as data:
+        await data.get_fundamentals(
+            venue="akshare",
+            symbol="sh.600519",
+            as_of=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+    assert route.calls.last.request.url.params.get("as_of") == "2020-01-01T00:00:00+00:00"
+
+
+@respx.mock
+async def test_get_fundamentals_omits_as_of_when_none() -> None:
+    """不传 as_of → 不带 as_of 参数（研究当下不做 PIT 截断）。"""
+    route = respx.get("http://data-mock.test/fundamentals").mock(
+        return_value=Response(200, json={"available": True})
+    )
+    async with DataClient("http://data-mock.test", "t") as data:
+        await data.get_fundamentals(venue="akshare", symbol="sh.600519")
+    assert "as_of" not in route.calls.last.request.url.params


### PR DESCRIPTION
## 背景

#100 落了财报 Point-in-Time 能力(akshare `as_of` 过滤 + `GET /fundamentals?as_of=`),但**没有消费方**——研究链路 / agent 工具都没传 `as_of`,等于功能没在真实流程里生效。本 PR 把它接通。

## 改动

**research(真实研究链路)**:
- `DataClient.get_fundamentals` 加 `as_of` 透传;
- `valuation` / `fundamental` / `persona` 三个 analyst 拉财报时传各自的研究 `as_of`(它们本就有 as_of 在手,与 macro 的 FRED PIT 口径一致)→ analyst 在 as_of 研究时刻不再读到当时未披露的财报。

**orchestration(agent 工具)**:
- `data.get_fundamentals` tool + client 加 `asOf` 透传;description 补三段式说明(研究历史时点传 asOf 防未来函数、仅 akshare 生效、yfinance reason 标注)。

## 验证

- research `pytest` 140 passed(+2 新:as_of 进 query / 不传时省略)、ruff 干净
- orchestration typecheck + `vitest` 透传测试通过(+2:asOf→URL / 不传不带)
- `check-consistency.sh` 0 失败

## 仍未做(留后续)

yfinance 仍不做 PIT(只 reason 标注);回测层用 `get_bars_pit`(让回测也按 as_of 重建 bar)是更大改动,本 PR 不含。

🤖 Generated with [Claude Code](https://claude.com/claude-code)