### PR TITLE
fix(paper): live/HTTP 下单补现货 long-only 守门,与回测同口径

### DIFF
--- a/services/paper/src/inalpha_paper/api/orders.py
+++ b/services/paper/src/inalpha_paper/api/orders.py
@@ -28,6 +28,7 @@ from ..data_client import DataClient
 from ..execution import risk_guard as risk_guard_mod
 from ..execution.currency_resolver import resolve_currency
 from ..execution.order_executor import OrderExecutor
+from ..execution.spot_guard import InsufficientPositionError, violates_spot_long_only
 from ..fills import apply_fill_to_positions_and_cash
 from ..fx import BaseCurrencyConverter
 from ..fx import needs_network as fx_needs_network
@@ -84,6 +85,23 @@ async def post_submit_order(
         factory, quantity=req.quantity, ref_price=ref_price,
         venue=req.venue, symbol=req.symbol,
     )
+
+    # 现货 long-only 网关守门（与回测 Portfolio.can_afford_sell 同口径）：OrderExecutor
+    # 无状态、撮合前不查持仓，apply_fill 又允许负仓——不在此拦则裸空 / 超卖翻空会落账成
+    # 凭空做空的负仓。SELL 量超当前 LONG 持仓 → 409 INSUFFICIENT_POSITION，不落账。
+    if req.side == "SELL":
+        cur_pos = await positions_store.get(
+            db, account_id=account_id, venue=req.venue, symbol=req.symbol
+        )
+        current_qty = Decimal(str(cur_pos["quantity"])) if cur_pos else Decimal(0)
+        if violates_spot_long_only(
+            side=req.side, quantity=req.quantity, current_qty=current_qty
+        ):
+            raise InsufficientPositionError(
+                f"卖出 {req.quantity} 超持仓 {current_qty}（spot 模式禁裸 SHORT）",
+                details={"venue": req.venue, "symbol": req.symbol,
+                         "requested": req.quantity, "current_qty": str(current_qty)},
+            )
 
     # 算成交（纯函数，不依赖 DB）
     result = OrderExecutor.execute(

--- a/services/paper/src/inalpha_paper/execution/spot_guard.py
+++ b/services/paper/src/inalpha_paper/execution/spot_guard.py
@@ -1,0 +1,63 @@
+"""``spot_guard`` —— 网关层现货 long-only 守门(禁裸空 / 禁超卖翻空)。
+
+设计动机:
+
+回测路径的撮合器 :class:`SimulatedExchange` 在 ``_try_fill`` 里会调
+:meth:`Portfolio.can_afford_sell`(``portfolio.py``)——"spot 模式禁裸 SHORT":
+SELL 量超过当前 LONG 持仓即拒。但 **live runner 与 ``POST /orders/submit``** 走的是
+无状态纯函数 :class:`OrderExecutor`(``order_executor.py``),撮合前**不查持仓**,
+成交后 ``apply_fill_to_positions_and_cash``(``fills.py``)又允许仓位变负 → 现货
+long-only 策略的 SELL 在空仓时被照单成交成裸空、账户挂上策略平不掉的空头(漂移)。
+
+本模块把"是否违反 spot long-only"提炼成一个纯函数,供 live / HTTP 两条写路径在撮合
+**之前**调用,使它们与回测 ``can_afford_sell`` **完全同口径**——让 live==回测,堵住漂移。
+
+边界约定:
+
+- 只管 SELL(做空方向);BUY 恒放行(现金透支守门 ``can_afford_buy`` 是兄弟 gap,不在本模块范围)
+- ``positions`` 表底层仍保留**负仓表示能力**(``apply_fill`` 不变),为未来 opt-in
+  做空 / 保证金(后续单独设计)保留;本守门只在**网关层**拦截 spot long-only 违规,
+  接合约 / margin 后可按 risk rule 配置放宽
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from inalpha_shared.errors import InalphaError
+
+
+class InsufficientPositionError(InalphaError):
+    """SELL 量超过当前 LONG 持仓(裸空 / 超卖翻空):现货 long-only 禁止。"""
+
+    code = "INSUFFICIENT_POSITION"
+    status_code = 409
+
+
+def violates_spot_long_only(
+    *,
+    side: str,
+    quantity: float | Decimal,
+    current_qty: float | Decimal,
+) -> bool:
+    """判一笔订单是否违反现货 long-only(禁裸空 / 禁超卖翻空)。
+
+    与 :meth:`Portfolio.can_afford_sell` 同口径:``side=="SELL"`` 且卖出量
+    **严格大于**当前 LONG 持仓量时违规(等量平仓放行)。BUY 恒不违规。
+
+    Parameters
+    ----------
+    side : str
+        订单方向 ``"BUY"`` / ``"SELL"``。
+    quantity : float | Decimal
+        本笔订单数量(正数)。
+    current_qty : float | Decimal
+        当前持仓**带符号**数量(LONG 为正、SHORT 为负、flat 为 0)。
+
+    Returns
+    -------
+    bool
+        ``True`` = 违反 spot long-only,调用方应拒单。
+    """
+    if side != "SELL":
+        return False
+    return Decimal(str(quantity)) > Decimal(str(current_qty))

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -33,6 +33,7 @@ from .execution import risk_guard as risk_guard_mod
 from .execution.currency_resolver import resolve_currency
 from .execution.order_executor import OrderExecutor
 from .execution.risk_guard_factory import RiskGuardFactory
+from .execution.spot_guard import violates_spot_long_only
 from .factor_patrol import capture_factor_baseline
 from .fills import apply_fill_to_positions_and_cash
 from .fx import BaseCurrencyConverter, needs_network
@@ -802,6 +803,38 @@ class LiveRunnerManager:
             # notional 上限（MaxOrderNotional）无 lock_scope，故 .get 返 None，不误判。
             scope = e.details.get("lock_scope") if e.details else None
             return "circuit_break" if scope == "global" else "risk_rejected"
+
+        # 1.5 现货 long-only 网关守门（与回测 Portfolio.can_afford_sell 同口径）：
+        # OrderExecutor 是无状态纯函数、撮合前不查持仓，apply_fill 又允许负仓——若不在此
+        # 拦截，long-only 策略空仓时的 SELL 会被照单成交成裸空、滚出策略平不掉的空头（漂移）。
+        # 读 DB 持仓（权威：apply_fill 落账的真实持仓，且能防 session/DB 视图分叉）。
+        # 框架保护性出场卖的是真实持仓（quantity <= current）→ 自然放行，无需额外豁免。
+        if side == "SELL":
+            async with get_conn() as conn:
+                cur_pos = await positions_store.get(
+                    conn, account_id=account_id, venue=venue, symbol=symbol
+                )
+            current_qty = Decimal(str(cur_pos["quantity"])) if cur_pos else Decimal(0)
+            if violates_spot_long_only(
+                side=side, quantity=order.quantity, current_qty=current_qty
+            ):
+                reason = (
+                    f"INSUFFICIENT_POSITION: 卖出 {order.quantity} 超持仓 {current_qty}"
+                    f"（spot 模式禁裸 SHORT）"
+                )
+                session.reject_order(
+                    order=order, strategy_id=strategy_id,
+                    reason=reason, ts_event=bar.ts_event,
+                )
+                async with get_conn() as conn:
+                    await runs_store.append_log(
+                        conn, run_id, "warn", f"order rejected by spot guard: {reason}"
+                    )
+                    await self._record_decision(
+                        conn, run, order, bar, outcome="rejected", intent=intent,
+                        reason=reason,
+                    )
+                return "rejected"
 
         # 2. 撮合（纯函数，ref_price = bar.close）
         result = OrderExecutor.execute(

--- a/services/paper/tests/test_api_orders.py
+++ b/services/paper/tests/test_api_orders.py
@@ -220,3 +220,29 @@ def test_submit_negative_quantity_rejected(
         },
     )
     assert r.status_code == 400
+
+
+def test_submit_naked_short_rejected(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    """空仓现货 SELL → 409 INSUFFICIENT_POSITION（spot 模式禁裸 SHORT），不落账。
+
+    用独立 symbol(ETH/USDT)确保该账户在此品种上无持仓。
+    """
+    r = client.post(
+        "/orders/submit",
+        headers=auth_headers,
+        json={
+            "symbol": "ETH/USDT",
+            "side": "SELL",
+            "type": "MARKET",
+            "quantity": 0.01,
+            "ref_price": 3_000.0,
+        },
+    )
+    assert r.status_code == 409, r.json()
+    assert r.json()["code"] == "INSUFFICIENT_POSITION"
+    # 不落账：该品种不应出现订单
+    listed = client.get("/orders", headers=auth_headers, params={"symbol": "ETH/USDT"})
+    assert listed.status_code == 200
+    assert listed.json() == []

--- a/services/paper/tests/test_live_runner.py
+++ b/services/paper/tests/test_live_runner.py
@@ -17,7 +17,9 @@ from inalpha_shared.errors import InalphaError
 
 from inalpha_paper.config import get_paper_settings
 from inalpha_paper.engine.live_session import LiveEngineSession
+from inalpha_paper.kernel.identifiers import ClientOrderId
 from inalpha_paper.live_runner import LiveRunnerManager, _closed_bars
+from inalpha_paper.model.orders import Order, OrderSide, OrderType
 from inalpha_paper.storage import accounts as accounts_store
 from inalpha_paper.storage import closed_trades as closed_trades_store
 from inalpha_paper.storage import orders as orders_store
@@ -1061,3 +1063,99 @@ async def test_list_all_running_returns_running_only(app_with_lifespan: Any) -> 
     ids = {r["id"] for r in running}
     assert r_running["id"] in ids
     assert r_stopped["id"] not in ids
+
+
+# ─── 现货 long-only 网关守门（禁裸空 / 禁超卖翻空）───
+
+
+class _SellOnceStrategy(Strategy):
+    """第一根 bar 市价卖 ``sell_qty`` 单位（测 spot long-only 守门用）。"""
+
+    def __init__(  # type: ignore[no-untyped-def]
+        self, name, clock, msgbus, instrument_id, timeframe, sell_qty=1.0, **_kw
+    ) -> None:
+        super().__init__(name, clock, msgbus)
+        self._instrument_id = instrument_id
+        self._timeframe = timeframe
+        self._sell_qty = sell_qty
+        self._sent = False
+
+    def on_start(self) -> None:
+        self.subscribe_bars(self._instrument_id, self._timeframe)
+
+    def on_bar(self, bar: Any) -> None:
+        if not self._sent:
+            self._sent = True
+            self.submit_order(
+                Order(
+                    client_order_id=ClientOrderId(f"sell-{uuid4().hex[:8]}"),
+                    instrument_id=self._instrument_id,
+                    side=OrderSide.SELL,
+                    type=OrderType.MARKET,
+                    quantity=self._sell_qty,
+                )
+            )
+
+
+def _sell_session(sell_qty: float) -> LiveEngineSession:
+    return LiveEngineSession(
+        strategy_cls=_SellOnceStrategy, instrument_id=_INSTRUMENT, timeframe="1h",
+        params={"sell_qty": sell_qty}, initial_cash=10_000.0, fee_rate=0.001,
+    )
+
+
+async def test_process_bar_naked_short_rejected(app_with_lifespan: Any) -> None:
+    """空仓现货 SELL → spot long-only 守门拒（禁裸空）：不落单 / 不建空仓 / 记 rejected / run 不挂。
+
+    复现 d4404933 漂移根因:OrderExecutor 无状态不查持仓,若不守门则空仓 SELL 会成交成裸空。
+    """
+    manager = LiveRunnerManager(risk_guard_factory=None, settings=get_paper_settings())
+    session = _sell_session(1.0)
+    account_id = uuid4()
+    run = await _insert_run(account_id)
+
+    await manager._process_bar(session, run, _bar(1_700_000_000_000_000_000, close=50_000.0))
+
+    async with get_conn() as conn:
+        orders = await orders_store.list_by_account(conn, account_id)
+        positions = await positions_store.list_by_account(conn, account_id)
+        decisions = await runs_store.list_decisions(conn, run["id"])
+        run_fresh = await runs_store.get(conn, run["id"])
+
+    assert orders == []  # 裸空不落账
+    assert positions == []  # 不建空仓
+    assert len(decisions) == 1
+    d = decisions[0]
+    assert d["outcome"] == "rejected"
+    assert d["side"] == "SELL"
+    assert d["intent"] == "open_short"  # 空仓 SELL 判 open_short，但被守门拒
+    assert "INSUFFICIENT_POSITION" in d["reason"]
+    assert d["order_id"] is None and d["plan_id"] is None  # 没真下单 → 无交叉引用
+    assert run_fresh is not None and run_fresh["status"] == "running"  # 不杀 run
+
+
+async def test_process_bar_oversell_no_flip_to_short(app_with_lifespan: Any) -> None:
+    """持多 1.0 后 SELL 2.0（超卖）→ 守门拒，持仓维持 +1.0 不翻空（d4404933 漂移不变量）。
+
+    守门读 DB 持仓(权威),即便新 session 视图为空仓也按真实 +1.0 判,拒掉会翻空的那笔。
+    对齐回测 ``test_backtest_e2e.py`` 的 ``pos.quantity >= 0`` 不变量。
+    """
+    manager = LiveRunnerManager(risk_guard_factory=None, settings=get_paper_settings())
+    account_id = uuid4()
+    run = await _insert_run(account_id)
+
+    # bar1：_BuyOnceStrategy 建多 1.0
+    await manager._process_bar(
+        _make_session(), run, _bar(1_700_000_000_000_000_000, close=50_000.0)
+    )
+    # bar2：另起 session 提交 SELL 2.0（超过 DB 实际持仓 1.0）
+    await manager._process_bar(
+        _sell_session(2.0), run, _bar(1_700_000_003_600_000_000, close=49_000.0)
+    )
+
+    async with get_conn() as conn:
+        pos = await positions_store.get(
+            conn, account_id=account_id, venue="binance", symbol="BTC/USDT"
+        )
+    assert pos is not None
+    assert Decimal(str(pos["quantity"])) == Decimal("1.0")  # 维持多仓，未翻空

--- a/services/paper/tests/test_spot_guard.py
+++ b/services/paper/tests/test_spot_guard.py
@@ -1,0 +1,42 @@
+"""``spot_guard.violates_spot_long_only`` 纯函数边界单测（禁裸空 / 禁超卖翻空）。
+
+与回测 ``Portfolio.can_afford_sell`` 同口径:SELL 量严格大于当前 LONG 持仓即违规。
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from inalpha_paper.execution.spot_guard import violates_spot_long_only
+
+
+def test_buy_never_violates() -> None:
+    # BUY 不归本守门管（现金透支守门是兄弟 gap）
+    assert violates_spot_long_only(side="BUY", quantity=999, current_qty=0) is False
+
+
+def test_flat_sell_violates() -> None:
+    # 空仓 SELL = 裸空 → 违规
+    assert violates_spot_long_only(side="SELL", quantity=1.0, current_qty=0) is True
+
+
+def test_sell_equal_holding_ok() -> None:
+    # 等量平多 → 放行
+    assert violates_spot_long_only(side="SELL", quantity=1.0, current_qty=1.0) is False
+
+
+def test_sell_partial_ok() -> None:
+    # 减仓（卖出量少于持仓）→ 放行
+    assert violates_spot_long_only(side="SELL", quantity=0.5, current_qty=1.0) is False
+
+
+def test_oversell_violates() -> None:
+    # 超卖翻空（卖出量 > 持仓）→ 违规（d4404933 漂移的直接成因）
+    assert violates_spot_long_only(side="SELL", quantity=2.0, current_qty=1.0) is True
+
+
+def test_sell_against_existing_short_violates() -> None:
+    # 已是空仓再 SELL（加空）→ current<0，任何正 qty 都违规
+    assert (
+        violates_spot_long_only(side="SELL", quantity=1.0, current_qty=Decimal("-2.0"))
+        is True
+    )


### PR DESCRIPTION
## 问题

现货 long-only 策略在 **live runner** 与 **HTTP `/orders/submit`** 两条写路径上,空仓时的 SELL 会被照单成交成**裸空**,滚出策略平不掉的空头、产出虚假盈利。

根因:这两条路径走无状态 `OrderExecutor.execute`,撮合前**不查持仓**,`apply_fill` 又允许仓位变负;而回测撮合器有 `Portfolio.can_afford_sell`(禁裸空)守门——**live 与回测口径不一致**。

(实际有一个跑了一周多的 run 因此漂移成空头,已单独停 run + 平仓处置。)

## 修复

- 新增 `execution/spot_guard.py`:纯函数 `violates_spot_long_only` + `InsufficientPositionError`,与回测 `can_afford_sell` **完全同口径**(SELL 量 > 当前 LONG 持仓即违规:禁裸空 + 禁超卖翻空)。
- `live_runner._route_through_plan_exec`:撮合前读 DB 持仓拦截 → 记 `rejected` 决策 + 清理 session 态 + 不杀 run。
- `api/orders.post_submit_order`:撮合前拦截 → 返 `409 INSUFFICIENT_POSITION`、不落账。
- 框架保护性出场卖的是真实持仓,自然放行,无需额外豁免。

## 测试

- 纯函数边界 6 例(`test_spot_guard.py`)
- live 裸空被拒 / 超卖不翻空(`test_live_runner.py`)
- HTTP 裸空 409(`test_api_orders.py`)
- 本地 ruff + 57 测试通过;**已在运行的模拟盘实测**:重启部署后裸空探针返 409。

## 影响

默认 `spot` 行为零回归(未触发守门的路径完全不变);只在 SELL 量超持仓时拒单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)