### PR TITLE
fix(paper): live runner 保护性出场遇 session/DB 分叉钳到实仓全平

### DIFF
--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -953,6 +953,7 @@ class LiveRunnerManager:
                     fill_price=Decimal(str(result["avg_fill_price"])) if filled else None,
                     fee=Decimal(str(result["fee"])) if filled else None,
                     reason=None if filled else str(result.get("rejection_reason") or "not filled"),
+                    quantity=Decimal(str(exec_qty)),  # 钳量分叉时 = 钳后量,与 orders 落账同源
                 )
         except InsufficientPositionError as e:
             # 事务内 FOR UPDATE 守门命中并发竞态：事务已回滚（无 plan/order/fill），
@@ -973,6 +974,12 @@ class LiveRunnerManager:
             return "rejected"
 
         # 4. 回灌 session：成交更新 portfolio + 策略持仓视图；未成交清理 ExecutionEngine 状态
+        # 已知残差（保护性钳量场景）：confirm_fill 按钳后量（如 0.5）增量减仓，而 DB 已被钳到
+        # 全平（0）——若前置分叉源自 HTTP 卖单，session 视图会残留分叉（session 0.5 vs DB 0）。
+        # 后续 bar PositionGuard 仍按 session 残仓触发保护性 SELL，但每次都打到事务内权威闸
+        # （DB=0 → locked_qty=0 → raise → rejected），**不静默、run 不崩**，仅产生连续 rejected
+        # 决策行噪音。彻底消除残差属 session/DB 对账范畴（restart 或 _restore_position reconcile
+        # 可清），不在本「止损不再被静默吃掉」修复范围内。
         if result["status"] == "FILLED":
             session.confirm_fill(
                 order=order, strategy_id=strategy_id,
@@ -1002,15 +1009,21 @@ class LiveRunnerManager:
         fill_price: Decimal | None = None,
         fee: Decimal | None = None,
         reason: str | None = None,
+        quantity: Decimal | None = None,
     ) -> None:
-        """记一行决策复盘日志（策略在某根 bar 的下单意图 + 撮合结果）。"""
+        """记一行决策复盘日志（策略在某根 bar 的下单意图 + 撮合结果）。
+
+        ``quantity`` 缺省记 ``order.quantity``（策略意图量）；保护性出场钳量分叉时显式传
+        钳后量（``exec_qty``），让决策行的 quantity 与 ``orders`` 表落账量一致，避免复盘
+        面板显示「SELL 1.0 filled」而落账实为 0.5 的对不上。
+        """
         await runs_store.insert_decision(
             conn,
             run_id=run["id"],
             bar_ts=_ns_to_dt(bar.ts_event),
             bar_close=Decimal(str(bar.close)),
             side=order.side.value,
-            quantity=Decimal(str(order.quantity)),
+            quantity=quantity if quantity is not None else Decimal(str(order.quantity)),
             order_type=order.type.value,
             limit_price=Decimal(str(order.price)) if order.price is not None else None,
             tag=order.tag,  # 策略可经 Order.tag 透传语义意图（stop_loss / take_profit / ...）

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -857,9 +857,13 @@ class LiveRunnerManager:
         )
 
         # 3. 走 plan/exec 链路落账（机器自动审批）
-        # exec_qty = 实际撮合 / 落账量。保护性出场遇 session/DB 分叉时会在下方事务内被钳到
-        # 真实持仓（见 step 1.5 注释），届时同步更新 result / order_params / 落账 quantity。
+        # exec_qty = 实际撮合 / 落账量（float，喂 OrderExecutor / order_params）。保护性出场遇
+        # session/DB 分叉时会在下方事务内被钳到真实持仓（见 step 1.5 注释）。
+        # clamped_fill：钳量场景下的**精确 Decimal** 成交量（= 锁内读到的 locked_qty），直接喂
+        # apply_fill / 决策日志，绕开 Decimal→float→Decimal 往返——避免未来 12+ 位精度品种
+        # （高精度 altcoin / 合约乘数）浮点舍入在持仓表留极小微尘仓位、误触后续守门。
         exec_qty = order.quantity
+        clamped_fill: Decimal | None = None
         order_params = {
             "side": side, "type": order.type.value,
             "quantity": exec_qty, "price": order.price,
@@ -889,6 +893,7 @@ class LiveRunnerManager:
                             # 即 #109 CR medium）。用钳后量在锁内重算 fill，下方 insert /
                             # apply_fill / plan 全部用 exec_qty / result 同口径。
                             exec_qty = float(locked_qty)
+                            clamped_fill = locked_qty  # 精确 Decimal,绕开 float 往返
                             order_params["quantity"] = exec_qty
                             result = OrderExecutor.execute(
                                 venue=venue, symbol=symbol,
@@ -925,9 +930,13 @@ class LiveRunnerManager:
                     trade_plan_id=plan_id,
                 )
                 if result["status"] == "FILLED":
+                    fill_qty_decimal = (
+                        clamped_fill if clamped_fill is not None
+                        else Decimal(str(result["filled_quantity"]))
+                    )
                     realized_pnl = await apply_fill_to_positions_and_cash(
                         conn, account_id=account_id, venue=venue, symbol=symbol, side=side,
-                        quantity=Decimal(str(result["filled_quantity"])),
+                        quantity=fill_qty_decimal,
                         fill_price=Decimal(str(result["avg_fill_price"])),
                         fee=Decimal(str(result["fee"])),
                         ts_event=result["ts_event"], order_id=result["client_order_id"],
@@ -953,7 +962,9 @@ class LiveRunnerManager:
                     fill_price=Decimal(str(result["avg_fill_price"])) if filled else None,
                     fee=Decimal(str(result["fee"])) if filled else None,
                     reason=None if filled else str(result.get("rejection_reason") or "not filled"),
-                    quantity=Decimal(str(exec_qty)),  # 钳量分叉时 = 钳后量,与 orders 落账同源
+                    # 钳量分支 = 精确 locked_qty（与 orders 落账 / apply_fill 同源）；
+                    # 普通 / rejected 路径 = 意图量 exec_qty。
+                    quantity=clamped_fill if clamped_fill is not None else Decimal(str(exec_qty)),
                 )
         except InsufficientPositionError as e:
             # 事务内 FOR UPDATE 守门命中并发竞态：事务已回滚（无 plan/order/fill），

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -811,8 +811,13 @@ class LiveRunnerManager:
         # OrderExecutor 是无状态纯函数、撮合前不查持仓，apply_fill 又允许负仓——若不在此
         # 拦截，long-only 策略空仓时的 SELL 会被照单成交成裸空、滚出策略平不掉的空头（漂移）。
         # 读 DB 持仓（权威：apply_fill 落账的真实持仓，且能防 session/DB 视图分叉）。
-        # 框架保护性出场卖的是真实持仓（quantity <= current）→ 自然放行，无需额外豁免。
-        if side == "SELL":
+        #
+        # **框架保护性出场（stop_loss / trailing / take_profit）跳过本乐观快闸**：单一路径下
+        # 它卖的就是真实持仓（quantity == current）自然放行；但若同账户被 HTTP /orders/submit
+        # 卖过一笔（DB 实仓 < 策略视图），整单拒会让止损被静默吃掉、实仓无保护、暴露持续扩大。
+        # 故保护性出场不在此提前拒，下放到下方事务内 FOR UPDATE 权威闸——按真实持仓**钳量全平**
+        # （既不超卖翻空，也不丢保护）。
+        if side == "SELL" and not is_protective_exit:
             async with get_conn() as conn:
                 cur_pos = await positions_store.get(
                     conn, account_id=account_id, venue=venue, symbol=symbol
@@ -852,9 +857,12 @@ class LiveRunnerManager:
         )
 
         # 3. 走 plan/exec 链路落账（机器自动审批）
+        # exec_qty = 实际撮合 / 落账量。保护性出场遇 session/DB 分叉时会在下方事务内被钳到
+        # 真实持仓（见 step 1.5 注释），届时同步更新 result / order_params / 落账 quantity。
+        exec_qty = order.quantity
         order_params = {
             "side": side, "type": order.type.value,
-            "quantity": order.quantity, "price": order.price,
+            "quantity": exec_qty, "price": order.price,
         }
         rationale = (
             f"[live_runner run:{run_id}] candidate:{run['candidate_id']} on_bar {side} signal"
@@ -872,12 +880,28 @@ class LiveRunnerManager:
                     )
                     locked_qty = Decimal(str(locked["quantity"])) if locked else Decimal(0)
                     if violates_spot_long_only(
-                        side=side, quantity=order.quantity, current_qty=locked_qty
+                        side=side, quantity=exec_qty, current_qty=locked_qty
                     ):
-                        raise InsufficientPositionError(
-                            f"INSUFFICIENT_POSITION: sell {order.quantity} exceeds position "
-                            f"{locked_qty} (spot long-only guard)"
-                        )
+                        if is_protective_exit and locked_qty > 0:
+                            # 框架保护性出场遇 session/DB 视图分叉（DB 实仓 < 策略视图，例如
+                            # 同账户被 HTTP /orders/submit 卖过一笔）：钳到 DB 实仓**全平**——
+                            # 既不超卖翻空（裸空），也不整单拒（拒则实仓无保护、暴露持续扩大，
+                            # 即 #109 CR medium）。用钳后量在锁内重算 fill，下方 insert /
+                            # apply_fill / plan 全部用 exec_qty / result 同口径。
+                            exec_qty = float(locked_qty)
+                            order_params["quantity"] = exec_qty
+                            result = OrderExecutor.execute(
+                                venue=venue, symbol=symbol,
+                                side=side,  # type: ignore[arg-type]
+                                order_type=order.type.value,  # type: ignore[arg-type]
+                                quantity=exec_qty, price=order.price,
+                                ref_price=float(bar.close), fee_rate=_FEE_RATE,
+                            )
+                        else:
+                            raise InsufficientPositionError(
+                                f"INSUFFICIENT_POSITION: sell {exec_qty} exceeds position "
+                                f"{locked_qty} (spot long-only guard)"
+                            )
                 plan = await plans_store.create(
                     conn, account_id=account_id, intent=intent, venue=venue, symbol=symbol,
                     order_params=order_params, rationale=rationale,
@@ -894,7 +918,7 @@ class LiveRunnerManager:
                 await orders_store.insert(
                     conn, account_id=account_id, client_order_id=result["client_order_id"],
                     venue=venue, symbol=symbol, side=side, order_type=order.type.value,
-                    quantity=order.quantity, price=order.price, status=result["status"],
+                    quantity=exec_qty, price=order.price, status=result["status"],
                     filled_quantity=result["filled_quantity"],
                     avg_fill_price=result["avg_fill_price"], fee=result["fee"],
                     notional=result["notional"], ts_event=result["ts_event"],

--- a/services/paper/src/inalpha_paper/live_runner.py
+++ b/services/paper/src/inalpha_paper/live_runner.py
@@ -985,12 +985,15 @@ class LiveRunnerManager:
             return "rejected"
 
         # 4. 回灌 session：成交更新 portfolio + 策略持仓视图；未成交清理 ExecutionEngine 状态
-        # 已知残差（保护性钳量场景）：confirm_fill 按钳后量（如 0.5）增量减仓，而 DB 已被钳到
-        # 全平（0）——若前置分叉源自 HTTP 卖单，session 视图会残留分叉（session 0.5 vs DB 0）。
-        # 后续 bar PositionGuard 仍按 session 残仓触发保护性 SELL，但每次都打到事务内权威闸
-        # （DB=0 → locked_qty=0 → raise → rejected），**不静默、run 不崩**，仅产生连续 rejected
-        # 决策行噪音。彻底消除残差属 session/DB 对账范畴（restart 或 _restore_position reconcile
-        # 可清），不在本「止损不再被静默吃掉」修复范围内。
+        # 已知残差（保护性钳量场景）：confirm_fill 按钳后量（如 0.5）增量减仓，DB 已被钳到全平
+        # （0），故 session 视图残留分叉（session 0.5 vs DB 0；前置分叉源自 HTTP 卖单）。注意
+        # PositionGuard 首次触发时已把该 inst 记入 _pending_exit_insts，而 confirm_fill 不清它
+        # （只有 reject_order 的保护性单分支、或 pos 转 flat 才清，见 position_guard.evaluate）——
+        # session 残仓非 flat → 后续 bar guard.evaluate 命中 pending 去重 → **对该 inst 静默 skip、
+        # 不再发出场单**（不是反复 rejected 噪音）。此刻 DB 实仓已 0、无即时暴露；但若策略此后在该
+        # inst 重新建仓，guard 因 pending 未清仍跳过 → 新仓得不到 guard 保护。这属 session/DB 对账
+        # 缺口（restart 或 _restore_position reconcile 可一并清 session + pending），不在本「止损不再
+        # 被静默吃掉」修复范围内，留作 follow-up。
         if result["status"] == "FILLED":
             session.confirm_fill(
                 order=order, strategy_id=strategy_id,

--- a/services/paper/tests/test_live_runner.py
+++ b/services/paper/tests/test_live_runner.py
@@ -17,6 +17,7 @@ from inalpha_shared.errors import InalphaError
 
 from inalpha_paper.config import get_paper_settings
 from inalpha_paper.engine.live_session import LiveEngineSession
+from inalpha_paper.fills import apply_fill_to_positions_and_cash
 from inalpha_paper.kernel.identifiers import ClientOrderId
 from inalpha_paper.live_runner import LiveRunnerManager, _closed_bars
 from inalpha_paper.model.orders import (
@@ -1301,3 +1302,41 @@ async def test_protective_exit_on_flat_position_still_rejected(
     assert decisions[-1]["outcome"] == "rejected"
     assert "INSUFFICIENT_POSITION" in decisions[-1]["reason"]
     assert run_fresh is not None and run_fresh["status"] == "running"
+
+
+async def test_protective_exit_clamp_preserves_high_precision(
+    app_with_lifespan: Any,
+) -> None:
+    """钳量全平用精确 Decimal（locked_qty）落账，高精度持仓不留浮点微尘仓位。
+
+    持仓 NUMERIC 列无精度上限，可存超 float 精度的量（高精度 altcoin / 合约乘数）。若钳量走
+    Decimal→float→Decimal 往返，``apply_fill`` 减去的量 ≠ 原持仓 → 留极小残差（≠0）误触后续
+    守门。本例直接建一个超 float 精度的持仓，保护性出场钳量全平，断言持仓**精确归零**。
+    """
+    manager = LiveRunnerManager(risk_guard_factory=None, settings=get_paper_settings())
+    account_id = uuid4()
+    run = await _insert_run(account_id)
+
+    # 直接建一个超 float 精度（18 位小数）的多仓——绕开 strategy 路径以精确控制持仓量
+    hi_qty = Decimal("1.123456789012345678")
+    seed_ts = datetime(2023, 11, 14, tzinfo=UTC)
+    async with get_conn() as conn, conn.transaction():
+        await accounts_store.get_or_create(conn, account_id)
+        await apply_fill_to_positions_and_cash(
+            conn, account_id=account_id, venue="binance", symbol="BTC/USDT",
+            side="BUY", quantity=hi_qty, fill_price=Decimal("100"),
+            fee=Decimal("0"), ts_event=seed_ts, order_id="seed-hiprec",
+        )
+
+    # 保护性出场 SELL 2.0（> hi_qty）→ 钳到 hi_qty 全平
+    await manager._process_bar(
+        _protective_sell_session(2.0), run, _bar(1_700_000_000_000_000_000, close=100.0)
+    )
+
+    async with get_conn() as conn:
+        pos = await positions_store.get(
+            conn, account_id=account_id, venue="binance", symbol="BTC/USDT"
+        )
+    # 精确归零：钳量走 Decimal(locked_qty)，无 float 往返微尘（旧 float 往返会留 ≠0 残差）
+    assert pos is not None
+    assert Decimal(str(pos["quantity"])) == Decimal("0")

--- a/services/paper/tests/test_live_runner.py
+++ b/services/paper/tests/test_live_runner.py
@@ -19,7 +19,12 @@ from inalpha_paper.config import get_paper_settings
 from inalpha_paper.engine.live_session import LiveEngineSession
 from inalpha_paper.kernel.identifiers import ClientOrderId
 from inalpha_paper.live_runner import LiveRunnerManager, _closed_bars
-from inalpha_paper.model.orders import Order, OrderSide, OrderType
+from inalpha_paper.model.orders import (
+    GUARD_ORDER_PREFIX,
+    Order,
+    OrderSide,
+    OrderType,
+)
 from inalpha_paper.storage import accounts as accounts_store
 from inalpha_paper.storage import closed_trades as closed_trades_store
 from inalpha_paper.storage import orders as orders_store
@@ -1159,3 +1164,138 @@ async def test_process_bar_oversell_no_flip_to_short(app_with_lifespan: Any) -> 
         )
     assert pos is not None
     assert Decimal(str(pos["quantity"])) == Decimal("1.0")  # 维持多仓，未翻空
+
+
+# ─── 框架保护性出场遇 session/DB 视图分叉：钳到实仓全平（#109 CR medium）───
+
+
+class _ProtectiveSellStrategy(Strategy):
+    """第一根 bar 提交一笔框架保护性出场单（``guard-`` 前缀 + ``stop_loss`` tag），量 = sell_qty。
+
+    三因子（side=SELL + 保护性 tag + guard 前缀）→ ``is_protective_order`` 判真，复现
+    PositionGuard 触发的灾难止损在 live runner 路径上的撮合行为。
+    """
+
+    def __init__(  # type: ignore[no-untyped-def]
+        self, name, clock, msgbus, instrument_id, timeframe, sell_qty=1.0, **_kw
+    ) -> None:
+        super().__init__(name, clock, msgbus)
+        self._instrument_id = instrument_id
+        self._timeframe = timeframe
+        self._sell_qty = sell_qty
+        self._sent = False
+
+    def on_start(self) -> None:
+        self.subscribe_bars(self._instrument_id, self._timeframe)
+
+    def on_bar(self, bar: Any) -> None:
+        if not self._sent:
+            self._sent = True
+            self.submit_order(
+                Order(
+                    client_order_id=ClientOrderId(f"{GUARD_ORDER_PREFIX}{uuid4().hex[:8]}"),
+                    instrument_id=self._instrument_id,
+                    side=OrderSide.SELL,
+                    type=OrderType.MARKET,
+                    quantity=self._sell_qty,
+                    tag="stop_loss",
+                )
+            )
+
+
+def _protective_sell_session(sell_qty: float) -> LiveEngineSession:
+    return LiveEngineSession(
+        strategy_cls=_ProtectiveSellStrategy, instrument_id=_INSTRUMENT, timeframe="1h",
+        params={"sell_qty": sell_qty}, initial_cash=10_000.0, fee_rate=0.001,
+    )
+
+
+async def test_protective_exit_clamps_to_position_on_divergence(
+    app_with_lifespan: Any,
+) -> None:
+    """保护性出场量 > DB 实仓（session/DB 分叉）→ 钳到实仓全平，不超卖翻空、不整单拒。
+
+    场景：bar1 建多 1.0；bar2 另一路径（模拟同账户 HTTP /orders/submit）卖掉 0.5 → DB=0.5；
+    bar3 框架保护性出场按策略视图 SELL 1.0。守门读 DB=0.5，若整单拒则实仓 0.5 无止损保护、
+    暴露持续扩大（#109 CR medium）；若照单成交则翻空 −0.5（裸空）。正确行为：钳到 0.5 全平。
+    """
+    manager = LiveRunnerManager(risk_guard_factory=None, settings=get_paper_settings())
+    account_id = uuid4()
+    run = await _insert_run(account_id)
+
+    # bar1：建多 1.0
+    await manager._process_bar(
+        _make_session(), run, _bar(1_700_000_000_000_000_000, close=50_000.0)
+    )
+    # bar2：另一 session 卖掉 0.5（模拟同账户被别的写路径减仓 → DB 落到 0.5）
+    await manager._process_bar(
+        _sell_session(0.5), run, _bar(1_700_000_003_600_000_000, close=50_000.0)
+    )
+    # bar3：框架保护性出场 SELL 1.0（策略视图仍记 1.0，但 DB 实仓只剩 0.5）
+    await manager._process_bar(
+        _protective_sell_session(1.0), run, _bar(1_700_000_007_200_000_000, close=49_000.0)
+    )
+
+    async with get_conn() as conn:
+        pos = await positions_store.get(
+            conn, account_id=account_id, venue="binance", symbol="BTC/USDT"
+        )
+        orders = await orders_store.list_by_account(conn, account_id)
+        decisions = await runs_store.list_decisions(conn, run["id"])
+        run_fresh = await runs_store.get(conn, run["id"])
+
+    # 钳量全平：DB 实仓 → 0（既非 −0.5 裸空，也非维持 0.5 无保护）
+    assert pos is not None
+    assert Decimal(str(pos["quantity"])) == Decimal("0")
+    # 保护性出场单（bar3 收盘 49000 撮合）按钳后量 0.5 落账、成交
+    guard_filled = [
+        o for o in orders
+        if o["side"] == "SELL"
+        and o["status"] == "FILLED"
+        and Decimal(str(o["avg_fill_price"])) == Decimal("49000")
+    ]
+    assert len(guard_filled) == 1
+    assert Decimal(str(guard_filled[0]["quantity"])) == Decimal("0.5")  # 落账量 = 钳后量
+    assert Decimal(str(guard_filled[0]["filled_quantity"])) == Decimal("0.5")
+    # 决策复盘：本笔保护性出场记 filled（不是 rejected）
+    assert decisions[-1]["outcome"] == "filled"
+    assert run_fresh is not None and run_fresh["status"] == "running"
+
+
+async def test_protective_exit_on_flat_position_still_rejected(
+    app_with_lifespan: Any,
+) -> None:
+    """DB 实仓为 0（已全平）时的保护性出场 → 仍拒单、不翻空：钳量豁免不放过裸空。
+
+    钳量只在「有实仓可平」时生效；实仓为 0 无可钳 → 走权威闸 raise → rejected，
+    DB 维持 0（绝不因 is_protective_exit 而放过裸空 −1.0）。
+    """
+    manager = LiveRunnerManager(risk_guard_factory=None, settings=get_paper_settings())
+    account_id = uuid4()
+    run = await _insert_run(account_id)
+
+    # bar1：建多 1.0；bar2：全平 1.0 → DB=0
+    await manager._process_bar(
+        _make_session(), run, _bar(1_700_000_000_000_000_000, close=50_000.0)
+    )
+    await manager._process_bar(
+        _sell_session(1.0), run, _bar(1_700_000_003_600_000_000, close=50_000.0)
+    )
+    # bar3：实仓已 0，保护性出场 SELL 1.0
+    await manager._process_bar(
+        _protective_sell_session(1.0), run, _bar(1_700_000_007_200_000_000, close=49_000.0)
+    )
+
+    async with get_conn() as conn:
+        pos = await positions_store.get(
+            conn, account_id=account_id, venue="binance", symbol="BTC/USDT"
+        )
+        decisions = await runs_store.list_decisions(conn, run["id"])
+        run_fresh = await runs_store.get(conn, run["id"])
+
+    # 维持平仓，未翻空
+    assert pos is not None
+    assert Decimal(str(pos["quantity"])) == Decimal("0")
+    assert decisions[-1]["outcome"] == "rejected"
+    assert "INSUFFICIENT_POSITION" in decisions[-1]["reason"]
+    assert run_fresh is not None and run_fresh["status"] == "running"

--- a/services/paper/tests/test_live_runner.py
+++ b/services/paper/tests/test_live_runner.py
@@ -1257,8 +1257,10 @@ async def test_protective_exit_clamps_to_position_on_divergence(
     assert len(guard_filled) == 1
     assert Decimal(str(guard_filled[0]["quantity"])) == Decimal("0.5")  # 落账量 = 钳后量
     assert Decimal(str(guard_filled[0]["filled_quantity"])) == Decimal("0.5")
-    # 决策复盘：本笔保护性出场记 filled（不是 rejected）
+    # 决策复盘：本笔保护性出场记 filled（不是 rejected），且 quantity = 钳后量 0.5
+    # （与 orders 落账同源，不是策略意图量 1.0——否则复盘面板与落账对不上）
     assert decisions[-1]["outcome"] == "filled"
+    assert Decimal(str(decisions[-1]["quantity"])) == Decimal("0.5")
     assert run_fresh is not None and run_fresh["status"] == "running"
 
 


### PR DESCRIPTION
## 问题

closed PR #109 的代码审查里有一条 medium 至今仍残留在 main：

live runner 的现货 long-only 守门(step 1.5 乐观闸 + 事务内 FOR UPDATE 权威闸)对**框架保护性出场**(stop_loss / trailing_stop_loss / take_profit)没有任何豁免。

- **单一路径**(只走 live runner)下没问题：session 与 DB 持仓同步，保护性出场卖的就是真实持仓，`SELL qty == current` 自然放行。
- **跨路径分叉**时出问题：若同账户同标的被 HTTP `/orders/submit` 卖过一笔(DB 实仓 `1.0 → 0.5`)，而 live runner 的策略视图仍记 `1.0`，`PositionGuard` 触发的止损 `SELL 1.0` 被守门按 DB `0.5` 整单拒 → **止损被静默吃掉、实仓 0.5 无保护、暴露持续扩大**。

## 为什么不能简单豁免

审查里建议的 `and not is_protective_exit`(直接放行保护性出场)会**反向开洞**：当出场量 > 实仓时(如策略视图 `1.0` 但 DB 只有 `0.5`)，`apply_fill` 允许负仓 → 翻空成 **裸空 −0.5**，正是守门本身要堵的漂移。

## 修复 —— 按"钳量"而非"豁免"

- **step 1.5**：保护性出场跳过乐观快闸，下放到事务内权威闸统一判定。
- **事务内权威闸(FOR UPDATE)**：保护性出场命中违规且**实仓 > 0** 时，钳到 DB 实仓量在锁内重算 fill **全平**——既不超卖翻空(裸空)，也不整单拒(丢保护)；**实仓 = 0** 仍走 `raise` 拒单，绝不因 `is_protective_exit` 放过裸空。
- `exec_qty` 贯穿 `result` / `order_params` / 落账 `quantity`，钳后口径一致(plan / order / apply_fill / 决策日志同源)。
- 普通策略单行为零变化(未触发分叉的保护性出场也零变化：`qty == current` 不命中违规)。

## 测试

- `test_protective_exit_clamps_to_position_on_divergence`：建多 1.0 → 另一路径卖 0.5 → 保护性 SELL 1.0 → 钳到 0.5 全平(DB → 0、落账 0.5、决策 filled)。
- `test_protective_exit_on_flat_position_still_rejected`：实仓为 0 时保护性 SELL 1.0 → 仍拒、不翻空。
- 本地 `ruff` 干净、`paper` 全套 **810 通过**、consistency 0 失败。

## 背景

PR #109 是这块守门的并行重复早期版(已 close)；现货 long-only 守门主体 + 两条路径 TOCTOU 修复已分别经 main 合入，本 PR 收掉其审查残留的最后一条 medium。

🤖 Generated with [Claude Code](https://claude.com/claude-code)