### PR TITLE
infra: 生产部署上线(腾讯云新加坡)— 部署修复 + dashboard on-box + 备份 + CI 镜像

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,101 @@
+name: Build & Push Images
+
+# CI 构建 5 个生产镜像(data/paper/research/factor + mastra)并推送 GHCR。
+# VPS 端只 `docker compose pull` 不 `build`,绕开小内存机现场 build OOM。
+# 见 docs/miro/decisions/0058。部署仍是手动 `scripts/deploy.sh`(非自动 CD)。
+#
+# 镜像命名:ghcr.io/<owner>/inalpha-<service>:{latest,<sha>}
+# migrate 服务复用 inalpha-paper 镜像(不单独构建)。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/**"
+      - "packages/orchestration/**"
+      - "infra/docker/**"
+      - ".github/workflows/build-images.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-images-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  python:
+    name: build · ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [data, paper, research, factor]
+    steps:
+      - uses: actions/checkout@v4
+
+      # GHCR 仓库路径必须全小写;owner 可能含大写 → 转小写
+      - name: Resolve owner (lowercase)
+        id: meta
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 构建上下文 = services/(因 inalpha-shared 路径依赖,见 Dockerfile.python 注释)
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: services
+          file: infra/docker/Dockerfile.python
+          build-args: |
+            SERVICE=${{ matrix.service }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.meta.outputs.owner }}/inalpha-${{ matrix.service }}:latest
+            ${{ env.REGISTRY }}/${{ steps.meta.outputs.owner }}/inalpha-${{ matrix.service }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+  mastra:
+    name: build · mastra
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve owner (lowercase)
+        id: meta
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 构建上下文 = packages/orchestration(见 Dockerfile.mastra 注释)
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: packages/orchestration
+          file: infra/docker/Dockerfile.mastra
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.meta.outputs.owner }}/inalpha-mastra:latest
+            ${{ env.REGISTRY }}/${{ steps.meta.outputs.owner }}/inalpha-mastra:${{ github.sha }}
+          cache-from: type=gha,scope=mastra
+          cache-to: type=gha,mode=max,scope=mastra

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,6 +1,6 @@
 name: Build & Push Images
 
-# CI 构建 5 个生产镜像(data/paper/research/factor + mastra)并推送 GHCR。
+# CI 构建 6 个生产镜像(data/paper/research/factor + mastra + dashboard)并推送 GHCR。
 # VPS 端只 `docker compose pull` 不 `build`,绕开小内存机现场 build OOM。
 # 见 docs/miro/decisions/0058。部署仍是手动 `scripts/deploy.sh`(非自动 CD)。
 #
@@ -13,6 +13,7 @@ on:
     paths:
       - "services/**"
       - "packages/orchestration/**"
+      - "apps/dashboard/**"
       - "infra/docker/**"
       - ".github/workflows/build-images.yml"
   workflow_dispatch:
@@ -99,3 +100,35 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.meta.outputs.owner }}/inalpha-mastra:${{ github.sha }}
           cache-from: type=gha,scope=mastra
           cache-to: type=gha,mode=max,scope=mastra
+
+  dashboard:
+    name: build · dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve owner (lowercase)
+        id: meta
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 构建上下文 = apps/dashboard(Next16 standalone,见 Dockerfile.dashboard 注释)
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/dashboard
+          file: infra/docker/Dockerfile.dashboard
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.meta.outputs.owner }}/inalpha-dashboard:latest
+            ${{ env.REGISTRY }}/${{ steps.meta.outputs.owner }}/inalpha-dashboard:${{ github.sha }}
+          cache-from: type=gha,scope=dashboard
+          cache-to: type=gha,mode=max,scope=dashboard

--- a/apps/dashboard/.dockerignore
+++ b/apps/dashboard/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.open-next
+.git
+.env*
+*.log
+tsconfig.tsbuildinfo

--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -50,6 +50,9 @@ loadRootEnv();
  */
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  /* Docker 部署(腾讯服务器,ADR-0058):standalone 产物 = 精简 server.js + 仅 traced
+     依赖,运行镜像小、内存省。注意与被禁用的 `output:"export"`(静态导出)不是一回事。 */
+  output: "standalone",
   /* Next 16 dev 默认只认 localhost 为同源,从 127.0.0.1 打开会拦掉 /_next/* dev
      资源(HMR/RSC),页面永远卡在骨架屏。本机两种写法都常用,显式放行。 */
   allowedDevOrigins: ["127.0.0.1"],

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -6,12 +6,21 @@
 #   - 不要带任何 *_PROXY（本地代理拦 localhost 那套在云上会把 httpx 打挂）
 #   - secret 优先走平台 secret 管理，文件仅作单机起步
 
+# ---- 镜像仓库(CI 构建推 GHCR;VPS pull 只拉不 build,绕开小内存 build OOM)----
+# 见 docs/miro/decisions/0058 与 .github/workflows/build-images.yml。
+# IMAGE_PREFIX = ghcr.io/<你的 GitHub 用户名小写>;IMAGE_TAG 默认 latest(也可填某次 commit sha 锁版本)。
+# 仅本地 `compose up --build` 时这两个可不填(就地构建,镜像名无所谓)。
+IMAGE_PREFIX=ghcr.io/__CHANGE_ME__
+IMAGE_TAG=latest
+
 # ---- Postgres ----
 POSTGRES_USER=quant
 POSTGRES_PASSWORD=__CHANGE_ME__
 POSTGRES_DB=inalpha
-# 容器内服务用此 URL（服务名 postgres）；alembic / 各服务读
-DATABASE_URL=postgresql://quant:__CHANGE_ME__@postgres:5432/inalpha
+# 容器内服务用此 URL（服务名 postgres）；alembic / 各服务读。
+# 必须用 +psycopg 方言:alembic 的 SQLAlchemy 见 postgresql:// 会默认走 psycopg2(未装)而崩;
+# 各 Python 服务的 _normalize_url 会自动剥掉 +psycopg 给 psycopg3 连接池,兼容（ADR-0058 实测）。
+DATABASE_URL=postgresql+psycopg://quant:__CHANGE_ME__@postgres:5432/inalpha
 
 # ---- Redis（如服务用到）----
 REDIS_PASSWORD=__CHANGE_ME__

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -172,6 +172,32 @@ services:
       retries: 5
       start_period: 30s
 
+  # 操作者控制台(Next16 standalone)。BFF 经容器名直连后端,零 CORS、JWT 同源(共用 .env.prod)。
+  # 公网仅经 Cloudflare Tunnel 暴露 dashboard.inalpha.dev → dashboard:3001;后端服务一律不暴露。
+  dashboard:
+    image: ${IMAGE_PREFIX:-ghcr.io/__CHANGE_ME__}/inalpha-dashboard:${IMAGE_TAG:-latest}
+    build:
+      context: ../apps/dashboard
+      dockerfile: ../../infra/docker/Dockerfile.dashboard
+    container_name: inalpha-dashboard
+    restart: unless-stopped
+    env_file: [../infra/.env.prod]
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+      MASTRA_URL: http://mastra:4111
+      PAPER_SERVICE_URL: http://paper:8002
+      DATA_SERVICE_URL: http://data:8001
+      RESEARCH_SERVICE_URL: http://research:8003
+      FACTOR_SERVICE_URL: http://factor:8004
+    depends_on: [mastra, paper, data, research, factor]
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3001/en').then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 40s
+
   # 公网入口：Cloudflare Tunnel（无需在 VPS 开入站端口，TLS/防护走 CF）
   cloudflared:
     image: cloudflare/cloudflared:2026.6.0

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -8,6 +8,11 @@ name: inalpha-prod
 #
 # 拓扑：postgres + redis + migrate(一次性) + data/paper/research/factor + mastra + cloudflared
 # 仅 cloudflared 对公网；其余服务走容器内网，按服务名互访。
+#
+# 镜像策略(见 0058):各服务同时声明 image: + build:。
+#   - 默认部署(scripts/deploy.sh):`compose pull` 拉 GHCR 预构建镜像 → `up -d`,VPS 不 build。
+#   - 应急本地构建:`up -d --build`(小内存机注意 OOM)。
+#   image 路径由 IMAGE_PREFIX/IMAGE_TAG 注入(见 .env.prod.example);CI 见 build-images.yml。
 
 x-python-build: &python-build
   context: ../services
@@ -64,6 +69,7 @@ services:
 
   # 一次性：跑 DB 迁移到最新，app 服务依赖它 completed_successfully
   migrate:
+    image: ${IMAGE_PREFIX:-ghcr.io/__CHANGE_ME__}/inalpha-paper:${IMAGE_TAG:-latest}
     build:
       <<: *python-build
       args: { SERVICE: paper }   # 复用 paper 镜像（含 DB 依赖）；alembic 由 _shared/paper 提供
@@ -78,10 +84,13 @@ services:
     working_dir: /app
     # alembic 已是 paper 的**显式直接依赖**(services/paper/pyproject.toml,
     # 不再依赖 optuna 的传递依赖,上游换后端也不会让迁移静默消失)
-    command: ["sh", "-c", "uv --project paper run alembic -c /app/migrations/alembic.ini upgrade head"]
+    # 必须先 cd 到 migrations 目录:alembic.ini 的 script_location=. 按 CWD 解析,
+    # 否则在 /app 下找不到 env.py（ADR-0058 真机实测修复）。--project 用绝对路径。
+    command: ["sh", "-c", "cd /app/migrations && uv --project /app/paper run alembic -c alembic.ini upgrade head"]
 
   data:
     <<: *svc-common
+    image: ${IMAGE_PREFIX:-ghcr.io/__CHANGE_ME__}/inalpha-data:${IMAGE_TAG:-latest}
     build: { <<: *python-build, args: { SERVICE: data } }
     container_name: inalpha-data
     environment:
@@ -96,6 +105,7 @@ services:
 
   paper:
     <<: *svc-common
+    image: ${IMAGE_PREFIX:-ghcr.io/__CHANGE_ME__}/inalpha-paper:${IMAGE_TAG:-latest}
     build: { <<: *python-build, args: { SERVICE: paper } }
     container_name: inalpha-paper
     environment:
@@ -112,6 +122,7 @@ services:
 
   research:
     <<: *svc-common
+    image: ${IMAGE_PREFIX:-ghcr.io/__CHANGE_ME__}/inalpha-research:${IMAGE_TAG:-latest}
     build: { <<: *python-build, args: { SERVICE: research } }
     container_name: inalpha-research
     environment: { PORT: 8003, WORKERS: 1 }
@@ -124,6 +135,7 @@ services:
 
   factor:
     <<: *svc-common
+    image: ${IMAGE_PREFIX:-ghcr.io/__CHANGE_ME__}/inalpha-factor:${IMAGE_TAG:-latest}
     build: { <<: *python-build, args: { SERVICE: factor } }
     container_name: inalpha-factor
     environment: { PORT: 8004, WORKERS: 1 }
@@ -135,6 +147,7 @@ services:
       start_period: 40s
 
   mastra:
+    image: ${IMAGE_PREFIX:-ghcr.io/__CHANGE_ME__}/inalpha-mastra:${IMAGE_TAG:-latest}
     build:
       context: ../packages/orchestration
       dockerfile: ../../infra/docker/Dockerfile.mastra

--- a/infra/docker/Dockerfile.dashboard
+++ b/infra/docker/Dockerfile.dashboard
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+#
+# Inalpha dashboard 生产镜像（Next 16 · standalone）—— 见 docs/miro/decisions/0058
+#
+# 构建上下文 = apps/dashboard（自带 pnpm-lock / pnpm-workspace，无 root workspace 依赖）。
+# 运行时只跑 standalone 的 server.js：BFF 经 docker 内网调后端（http://mastra:4111 等，
+# 走 .env.prod 的容器名 URL），JWT_SECRET 与后端同源 —— 零 CORS、无需公网子域。
+#
+# 用法（见 docker-compose.prod.yml 的 dashboard 服务）：
+#   docker build -f infra/docker/Dockerfile.dashboard -t inalpha-dashboard apps/dashboard
+
+FROM node:22-bookworm-slim AS builder
+RUN corepack enable
+WORKDIR /app
+# 依赖清单先行做层缓存。pnpm-workspace.yaml 必须带上 —— 它含 allowBuilds(批准
+# sharp/@swc/@parcel-watcher 的 build script，否则 pnpm 11 ERR_PNPM_IGNORED_BUILDS exit 1)
+# 与 overrides(@ag-ui/* 钉 0.0.53)。漏了它 frozen install 直接失败、装不出 node_modules。
+COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+# 源码（node_modules / .next / .open-next 已在 .dockerignore 排除）
+COPY . .
+ENV NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+FROM node:22-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 PORT=3001 HOSTNAME=0.0.0.0
+# 非 root 运行，缩小容器逃逸面
+RUN useradd --create-home --uid 10001 app && chown app:app /app
+USER app
+# standalone：精简 server.js + 仅 traced 的 node_modules
+COPY --from=builder --chown=app:app /app/.next/standalone ./
+COPY --from=builder --chown=app:app /app/.next/static ./.next/static
+COPY --from=builder --chown=app:app /app/public ./public
+# next-intl 的 messages（动态 import，保险起见显式带上）
+COPY --from=builder --chown=app:app /app/messages ./messages
+EXPOSE 3001
+# 健康检查端点用根路径；standalone server 监听 0.0.0.0:3001
+CMD ["node", "server.js"]

--- a/infra/docker/Dockerfile.mastra
+++ b/infra/docker/Dockerfile.mastra
@@ -19,16 +19,12 @@ USER node
 
 # 依赖清单先行做层缓存
 COPY --chown=node:node package.json pnpm-lock.yaml* ./
-# pnpm 11 默认拦截依赖的构建脚本并以非零退出（ERR_PNPM_IGNORED_BUILDS）——这是"装完之后"的守门，
-# 此时依赖已正确链接,故容忍该退出码;但**必须验证关键依赖真的链接成功**——
-# 只查 .pnpm 目录存在不够(网络半途失败会留下残目录但包未链接),改为解析
-# esbuild 包 + mastra 可执行文件,失败在构建期响亮报错而非运行时才崩。
-RUN (pnpm install --frozen-lockfile || pnpm install || true) \
- && { node -e "require.resolve('esbuild/package.json')" >/dev/null 2>&1 \
-      && [ -e node_modules/.bin/mastra ]; } \
- || { echo "pnpm install 失败:关键依赖(esbuild / mastra CLI)未就绪" >&2; exit 1; }
-# 显式 rebuild esbuild 确保其原生二进制就绪（mastra 打包器需要;若真未就绪,
-# 下面的 `mastra build` 会响亮失败,故此处可容错）
+# pnpm 11 默认拦截 esbuild 等的构建脚本并可能非零退出（ERR_PNPM_IGNORED_BUILDS）。
+# 容忍该退出码:依赖此时已正确链接;真正的"就绪"由后面的 `mastra build` 验证——
+# 它若缺 esbuild/mastra CLI 会响亮失败。
+# （旧版另用 `node_modules/.bin/mastra` 存在性守门,在 pnpm 11 下误判致构建失败,
+#   已移除 —— 见 ADR-0058 新加坡真机部署实测）
+RUN pnpm install --frozen-lockfile 2>&1 | tail -20 || pnpm install 2>&1 | tail -20 || true
 RUN pnpm rebuild esbuild 2>&1 | tail -3 || true
 
 # 源码（node_modules / .mastra 已在 .dockerignore 排除）

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Inalpha 生产部署入口(VPS 手动)—— 见 docs/miro/decisions/0058
+#
+# 默认走「拉 GHCR 预构建镜像」路径:CI(build-images.yml)已 build 好,
+# VPS 只 pull 不 build,绕开小内存机现场 build OOM。
+#
+# 在 VPS 仓库根目录运行:
+#   bash scripts/deploy.sh            # git pull + compose pull + up -d(推荐)
+#   bash scripts/deploy.sh --no-pull  # 跳过 git pull(已 checkout 指定版本时)
+#   bash scripts/deploy.sh --build    # 就地 build 而非拉镜像(应急;4G 机器慎用,可能 OOM)
+#
+# 前置:
+#   - infra/.env.prod 已填好(含 IMAGE_PREFIX / IMAGE_TAG 指向 GHCR)
+#   - 若 GHCR 包为 private:先 `docker login ghcr.io`(PAT 需 read:packages 权限)
+#
+set -euo pipefail
+
+# 仓库根 = 本脚本上一级目录
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+COMPOSE_FILE="infra/docker-compose.prod.yml"
+ENV_FILE="infra/.env.prod"
+DC=(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE")
+
+do_git_pull=1
+mode="image" # image | build
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-pull) do_git_pull=0 ;;
+    --build)   mode="build" ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "未知参数: $arg(用 --help 看用法)" >&2; exit 2 ;;
+  esac
+done
+
+[ -f "$ENV_FILE" ] || {
+  echo "缺 $ENV_FILE —— 从 infra/.env.prod.example 复制并填值" >&2
+  exit 1
+}
+
+if [ "$do_git_pull" -eq 1 ]; then
+  echo "==> git pull --ff-only"
+  git pull --ff-only
+fi
+
+if [ "$mode" = "image" ]; then
+  echo "==> 拉取镜像(GHCR)"
+  "${DC[@]}" pull
+  echo "==> 起栈(migrate 先跑 alembic upgrade head,再起各服务)"
+  "${DC[@]}" up -d
+else
+  echo "==> 就地构建并起栈(--build;小内存机注意 OOM)"
+  "${DC[@]}" up -d --build
+fi
+
+echo "==> 当前状态"
+"${DC[@]}" ps
+
+echo "==> 完成。排障:'${DC[*]} logs -f <service>';健康看上方 ps 的 STATUS。"

--- a/scripts/pg-backup.sh
+++ b/scripts/pg-backup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Inalpha Postgres 每日备份:pg_dump→gzip→本地留14份 + 上传R2(留15天),独立目录防 down -v
+set -euo pipefail
+DIR="$HOME/pg-backups"; mkdir -p "$DIR"
+TS=$(date +%Y%m%d-%H%M%S); OUT="$DIR/inalpha-$TS.sql.gz"
+if ! sudo docker ps --format '{{.Names}}' | grep -q '^inalpha-postgres$'; then
+  echo "$(date '+%F %T') ERROR: inalpha-postgres 没在跑,跳过"; exit 1; fi
+sudo docker exec inalpha-postgres sh -c \
+  'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --no-owner --no-privileges' \
+  | gzip > "$OUT.tmp"
+mv "$OUT.tmp" "$OUT"
+ls -1t "$DIR"/inalpha-*.sql.gz 2>/dev/null | tail -n +15 | xargs -r rm -f
+if rclone copy "$OUT" r2:inalpha-backups/ 2>/dev/null; then
+  rclone delete --min-age 15d r2:inalpha-backups/ 2>/dev/null || true; R2="R2 OK"
+else R2="R2 上传失败(本地已留)"; fi
+echo "$(date '+%F %T') 本地 OK: $(basename "$OUT") ($(du -h "$OUT" | cut -f1)) | $R2 | 本地存 $(ls -1 "$DIR"/inalpha-*.sql.gz | wc -l) 份"


### PR DESCRIPTION
## 背景
把整套 Inalpha 真正部署上公网(7×24)。平台几经风控辗转(Hetzner 3DS / Vultr 充值后退款锁号)最终落 **腾讯云 Lighthouse 新加坡 2核4G**。本 PR 是这次落地中对仓库的全部改动,**线上已部署并验证通过**。

## 改动(3 个 commit)
1. **修通生产部署三处阻断**(真机实测)
   - migrate 找不到 env.py:alembic `script_location=.` 按 CWD 解析 → 命令先 `cd /app/migrations`
   - migrate 缺 psycopg2:`DATABASE_URL` 改 `postgresql+psycopg://`(服务侧 `_normalize_url` 兼容)
   - mastra 构建挂 pnpm11 守门:移除 `node_modules/.bin/mastra` 误判,以 `mastra build` 为真关卡
2. **dashboard on-box Docker 部署(Next16 standalone)**
   - opennextjs 上 CF Workers 被 Next16 新 Proxy 架构挡死(issue #13755)→ 改为与后端同机跑 Docker
   - `output:standalone` + `Dockerfile.dashboard`(313MB);compose 加 dashboard 服务,BFF 经容器名内网直连后端 + 同源 JWT,零 CORS
   - 公网仅经 Cloudflare Tunnel 暴露 `dashboard.inalpha.dev`,后端服务全私有
   - Dockerfile 必须 COPY `pnpm-workspace.yaml`(allowBuilds/overrides),否则 frozen install 失败
3. **Postgres 每日备份**:`pg_dump`→本地14份 + Cloudflare R2 异地(留15天),cron 18:00 UTC
4. **CI 镜像流水线**:`build-images.yml` 构建 6 镜像推 GHCR + `scripts/deploy.sh`(VPS 只 pull 不 build,绕开小内存 build OOM)+ compose `image:` 引用

## 部署记录
详见 ADR-0058(`docs/miro/decisions/`,gitignored)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)