### PR TITLE
fix(infra): dashboard 凭据隔离 + depends_on 健康 + pg-backup R2 报告(PR #116 review)

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -181,16 +181,28 @@ services:
       dockerfile: ../../infra/docker/Dockerfile.dashboard
     container_name: inalpha-dashboard
     restart: unless-stopped
-    env_file: [../infra/.env.prod]
+    # 凭据隔离(最小权限):dashboard 是公网前端,**不挂 env_file** —— 那会把 DB/Redis/LLM/
+    # Binance/tunnel 全部凭据注入前端容器(RCE 即全泄)。BFF 实际只需 JWT_SECRET + 5 个内网 URL;
+    # JWT_SECRET 经 compose 从 .env.prod 插值,只此一个 secret 进容器。
     environment:
       NODE_ENV: production
       PORT: 3001
+      JWT_SECRET: ${JWT_SECRET:?required}
+      JWT_ALGORITHM: ${JWT_ALGORITHM:-HS256}
+      CONSOLE_SUBJECT: ${CONSOLE_SUBJECT:-console:dev}
+      CONSOLE_EMAIL: ${CONSOLE_EMAIL:-console@inalpha.dev}
       MASTRA_URL: http://mastra:4111
       PAPER_SERVICE_URL: http://paper:8002
       DATA_SERVICE_URL: http://data:8001
       RESEARCH_SERVICE_URL: http://research:8003
       FACTOR_SERVICE_URL: http://factor:8004
-    depends_on: [mastra, paper, data, research, factor]
+    # 等后端 healthy 再起,避免冷启动期 BFF 路由全 502
+    depends_on:
+      mastra: { condition: service_healthy }
+      paper: { condition: service_healthy }
+      data: { condition: service_healthy }
+      research: { condition: service_healthy }
+      factor: { condition: service_healthy }
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3001/en').then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
       interval: 10s

--- a/scripts/pg-backup.sh
+++ b/scripts/pg-backup.sh
@@ -10,7 +10,12 @@ sudo docker exec inalpha-postgres sh -c \
   | gzip > "$OUT.tmp"
 mv "$OUT.tmp" "$OUT"
 ls -1t "$DIR"/inalpha-*.sql.gz 2>/dev/null | tail -n +15 | xargs -r rm -f
-if rclone copy "$OUT" r2:inalpha-backups/ 2>/dev/null; then
-  rclone delete --min-age 15d r2:inalpha-backups/ 2>/dev/null || true; R2="R2 OK"
-else R2="R2 上传失败(本地已留)"; fi
+# 上传与清理分别报告:清理失败(如令牌缺 DeleteObject)不能再被吞成 "R2 OK",
+# 否则 R2 存量无限增长而日志永远正常。
+if rclone copy "$OUT" r2:inalpha-backups/; then
+  R2="R2 上传 OK"
+  if rclone delete --min-age 15d r2:inalpha-backups/; then R2="$R2 / 清理 OK"; else R2="$R2 / ⚠️清理失败"; fi
+else
+  R2="⚠️R2 上传失败(本地已留)"
+fi
 echo "$(date '+%F %T') 本地 OK: $(basename "$OUT") ($(du -h "$OUT" | cut -f1)) | $R2 | 本地存 $(ls -1 "$DIR"/inalpha-*.sql.gz | wc -l) 份"


### PR DESCRIPTION
处理 PR #116 的 auto-review 必修/优化项(那个 PR 已合,这是跟进修复)。

## [major·安全] dashboard 凭据隔离
dashboard(公网前端)原挂 `env_file: .env.prod` → 把 DB/Redis 密码、所有 LLM key、Binance key、CF tunnel token 全注入容器。RCE/恶意依赖即全泄。
→ 去掉 `env_file`,只显式传 `JWT_SECRET`(经 compose 从 .env.prod 插值)+ `JWT_ALGORITHM`/`CONSOLE_*` + 5 个内网 `*_URL`。最小权限。

## [medium] depends_on 健康等待
dashboard `depends_on` 数组形式只等 started 不等 healthy → 冷启动期 BFF 路由全 502。改 `condition: service_healthy`。

## [medium] pg-backup R2 清理报告
`rclone delete` 失败被 `2>/dev/null + ||true` 吞成 "R2 OK" → 清理永久静默失败、R2 无限增长而日志正常。改为上传/清理分别报告。

> 同步已应用到线上服务器并重建 dashboard 容器(凭据隔离即时生效)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)