### PR TITLE
fix(data): akshare 归一化 Yahoo Finance 后缀格式(600036.SH→sh.600036)

### DIFF
--- a/services/data/src/inalpha_data/connectors/akshare.py
+++ b/services/data/src/inalpha_data/connectors/akshare.py
@@ -61,6 +61,13 @@ def _parse_symbol(symbol: str) -> tuple[str, str]:
     Raises:
         ValueError: 格式不符（缺 ``.`` 分隔 / prefix 不在允许集合）
     """
+    # 归一化 Yahoo Finance 后缀格式(600036.SH → sh.600036; 000001.SZ → sz.000001),
+    # 对上游(backfill/orchestrator)透明——orchestrator 透传用户输入的任意格式 symbol,
+    # connector 内部做格式适配。只匹配纯数字代码 + 已知市场后缀。
+    if "." in symbol and symbol.rsplit(".", 1)[1].lower() in {"sh", "sz"}:
+        code, suffix = symbol.rsplit(".", 1)
+        if code.replace(".", "", 1).isdigit():
+            symbol = f"{suffix.lower()}.{code}"
     if "." not in symbol:
         raise ValueError(
             f"akshare symbol must be '<prefix>.<code>'，prefix in (sh/sz/hk/jp/uk/de)，"


### PR DESCRIPTION
## 根因
orchestrator 把 `600036.SH` 透传给 data 服务,akshare connector 的 `_parse_symbol` 只认 `sh.600036` 格式,对反向的 `.SH`/`.SZ` 后缀直接抛 ValueError → backfill `fetched:0`。

## 修复
在 `_parse_symbol` 入口加 Yahoo Finance 后缀归一化:`600036.SH`→`sh.600036`,`000001.SZ`→`sz.000001`,对上/下游透明。

## 验证
- 157 tests 全绿,ruff 零报错
- `600036.SH` / `.sz` / `.Sh` 均正确归一化;`sh.600036`(原有格式)无回归;`600036.XX`(非法)仍拒

> 线上新加坡服务器已验证:_parse_symbol 行为正确。需合 main 后 CI 出新 GHCR 镜像并 deploy 到服务器,解决当前 A股 backfill fetched:0 问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)