### PR TITLE
fix(orchestration): trade.create_plan 补 perp 做空下单参数(tradingMode/leverage)

### DIFF
--- a/packages/orchestration/src/clients/paper.ts
+++ b/packages/orchestration/src/clients/paper.ts
@@ -433,6 +433,10 @@ export type CreatePlanParams = {
   price?: number;
   rationale: string;
   expireInSeconds?: number;
+  /** spot(默认) 或 perp(USDT-M 永续做空/杠杆);仅 crypto 永续标的。 */
+  tradingMode?: "spot" | "perp";
+  /** 杠杆倍数(perp 用,1..20);spot 恒 1。 */
+  leverage?: number;
 };
 
 export type ExecutePlanResult = {
@@ -761,6 +765,8 @@ export class PaperClient {
       price: params.price,
       rationale: params.rationale,
       expire_in_seconds: params.expireInSeconds ?? 300,
+      trading_mode: params.tradingMode ?? "spot",
+      leverage: params.leverage ?? 1,
     });
   }
 

--- a/packages/orchestration/src/tools/trade-plan.ts
+++ b/packages/orchestration/src/tools/trade-plan.ts
@@ -113,6 +113,20 @@ export const createTradePlanTool = createTool({
       .optional()
       .describe("D-8c 血缘：触发本次下单的 paper.run_backtest 的 run_id"),
     expireInSeconds: z.number().int().positive().max(3600).default(300),
+    tradingMode: z
+      .enum(["spot", "perp"])
+      .default("spot")
+      .describe(
+        "spot（默认，现货 long-only）或 perp（USDT-M 永续 + 逐仓，放开做空 / 杠杆）。" +
+        "**做空单必须用 perp**——spot 下 open_short/SELL 无持仓会被守门拒。仅 crypto 永续标的。",
+      ),
+    leverage: z
+      .number()
+      .int()
+      .min(1)
+      .max(20)
+      .default(1)
+      .describe("杠杆倍数（perp 用，1..20）；spot 恒 1"),
   }),
   execute: async (inputData, ctx) => {
     const tc = ctx?.requestContext as ToolRequestContext | undefined;
@@ -135,6 +149,8 @@ export const createTradePlanTool = createTool({
         price: inputData.price,
         rationale: rationaleWithLineage,
         expireInSeconds: inputData.expireInSeconds ?? 300,
+        tradingMode: inputData.tradingMode,
+        leverage: inputData.leverage,
       });
       return {
         ok: true as const,


### PR DESCRIPTION
## 根因
paper 服务端早已支持 perp 做空下单(`trading_mode="perp"`+leverage),但 orchestrator 的工具链两层缺失:
1. `trade.create_plan` 的 inputSchema 没有 `tradingMode`/`leverage`
2. `PaperClient.createPlan` 不传给服务端 HTTP

导致 agent 在这个对话里反复误判"不支持做空"——不是偶发、不是 prompt 问题,是工具链根本没接上。

## 修复
对齐三层(各 ~5 行):
- `tools/trade-plan.ts`:inputSchema 加 `tradingMode`(`spot`|`perp`,默认 spot)+ `leverage`(1..20,默认 1)
- `clients/paper.ts`:type + HTTP 传 `trading_mode`/`leverage` 给服务端
- 默认值二进制兼容(不传 = spot/1),不影响已有的现货下单

## 验证
- typecheck 零错误
- 421 tests 全绿

> 部署后需合并+重建 mastra 镜像让 agent 工具生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)