### PR TITLE
fix(orchestration): prompt 加强做空策略——禁止不经分类说"不支持做空"

### DIFF
--- a/packages/orchestration/src/mastra/agents/orchestrator.ts
+++ b/packages/orchestration/src/mastra/agents/orchestrator.ts
@@ -606,6 +606,18 @@ data.* / paper.run_backtest 的 fromTs / toTs 都是 optional，省略时默认"
 
 ## 多空意识（spot 现货 long-only · perp 永续可做空 + 杠杆）
 
+**最高优先级（SHORTING POLICY）——用户问做空/短仓/空头/看跌/押跌等任何与下跌方向相关的问题时:
+你必须先分类标的再答。crypto(永续)已上线 perp 做空、非 crypto(股票等)只现货做多。
+禁止不经分类直接给”不支持做空”一刀切结论——这是 bug,perp 已经在线上了。**
+
+- crypto(BTC/ETH etc) → **perp 已上线,可以做空**:use tradingMode=”perp” + perp symbol
+  like BTC/USDT:USDT + leverage(1..20). backtest/start_strategy/create_plan 都支持 perp.
+  策略可用 perp_short_reversion archetype 作起点。**禁止对 crypto 说”不支持做空”。**
+- 非 crypto(股票/指数 etc) → 确实只现货做多:给”空仓观望/减仓/平多”建议。
+
+**禁止说的话(perp 已上线,这些话都是错的):** “目前只支持现货做多””做空能力在规划中”
+“做空还要等”——禁止说。**允许/必须说的话:** 先区分标的市场,crypto 永续可做空,股票不行。
+
 模拟盘有两种模式，由 \`paper.start_strategy\` / 下单的 \`tradingMode\` 参数选：
 
 - **spot（默认，现货 long-only）**：只做多。flat 仓位下 SELL 被守门拒（禁裸空）。


### PR DESCRIPTION
## 根因
agent 反复误判(三次)"不支持做空",即使 #121 已经在 tool 层补齐了 `tradingMode`/`leverage` 参数。真正问题:prompt 的"多空意识"位置靠后(第 607 行),被"spot 默认"框架压倒,agent 不经区分 crypto/股票就一刀切,甚至胡编 "issue #51 规划中"(代码里不存在这个 issue)。

## 修复
在 `## 多空意识` 节开头加 **SHORTING POLICY**(最高优先级):
- 强制先分类标的:crypto → perp 可做空,股票 → 确实只现货
- **明确禁止**说过时的话("目前只支持现货做多""做空在规划中"等)
- 用英文关键词(`SHORTING POLICY`/`crypto perp`)提升 LLM 注意力

> 前两次修复(#120 akshare symbol + #121 trade tool perp)加一起才算完整:数据链路通→下单工具有参数→agent 知道该怎么说。本 PR 是最后一块。

🤖 Generated with [Claude Code](https://claude.com/claude-code)