### PR TITLE
fix(orchestration): 多空 prompt 翻成能力清单——先告诉 agent 能做什么

### DIFF
--- a/packages/orchestration/src/mastra/agents/orchestrator.ts
+++ b/packages/orchestration/src/mastra/agents/orchestrator.ts
@@ -604,43 +604,24 @@ data.* / paper.run_backtest 的 fromTs / toTs 都是 optional，省略时默认"
   因为旧 prompt 印象拒绝美股 / A 股 / 指数的 grid 请求
 - trade.create_plan —— 当前 paper service 撮合只对 crypto 完整测过；其它市场跑通需 D-10+ 工作
 
-## 多空意识（spot 现货 long-only · perp 永续可做空 + 杠杆）
+## 多空意识（两种模式：spot 现货做多 + perp 永续做空/杠杆）
 
-**最高优先级（SHORTING POLICY）——用户问做空/短仓/空头/看跌/押跌等任何与下跌方向相关的问题时:
-你必须先分类标的再答。crypto(永续)已上线 perp 做空、非 crypto(股票等)只现货做多。
-禁止不经分类直接给”不支持做空”一刀切结论——这是 bug,perp 已经在线上了。**
+模拟盘有两种模式，由 \`paper.run_backtest\` / \`paper.start_strategy\` /
+\`trade.create_plan\` 的 \`tradingMode\` 参数选择：
 
-- crypto(BTC/ETH etc) → **perp 已上线,可以做空**:use tradingMode=”perp” + perp symbol
-  like BTC/USDT:USDT + leverage(1..20). backtest/start_strategy/create_plan 都支持 perp.
-  策略可用 perp_short_reversion archetype 作起点。**禁止对 crypto 说”不支持做空”。**
-- 非 crypto(股票/指数 etc) → 确实只现货做多:给”空仓观望/减仓/平多”建议。
+- **spot（默认）**：现货做多。BUY 开多 → SELL 平多。标的：所有市场。
+- **perp**：USDT-M 永续 + 逐仓。**可做多也可做空**（BUY 开多 / SELL 开空 / 反方向平仓）。
+  支持杠杆 1..20。**仅 crypto 永续标的**，symbol 格式 \`BTC/USDT:USDT\`、
+  \`ETH/USDT:USDT\`（ccxt 永续记法，非现货 \`BTC/USDT\`）。开空只占保证金；维持保证金
+  击穿强平；按时点计资金费。策略可用 \`perp_short_reversion\` archetype 作起点。
 
-**禁止说的话(perp 已上线,这些话都是错的):** “目前只支持现货做多””做空能力在规划中”
-“做空还要等”——禁止说。**允许/必须说的话:** 先区分标的市场,crypto 永续可做空,股票不行。
+**用户问做空 / 看跌时，按标的回答**：
+- crypto → perp 可以做空。引导用户用永续标的 + \`tradingMode=”perp”\` + \`leverage\`。
+  做空策略用 spot 回测会 0 成交——必须 perp 回测。
+- 股票/指数 → 只现货做多。建议空仓观望/减仓/等右侧。
 
-模拟盘有两种模式，由 \`paper.start_strategy\` / 下单的 \`tradingMode\` 参数选：
-
-- **spot（默认，现货 long-only）**：只做多。flat 仓位下 SELL 被守门拒（禁裸空）。
-- **perp（USDT-M 永续 + 逐仓，放开做空 + 杠杆）**：**仅 crypto 永续标的**——ccxt 永续记法
-  （仅供识别格式，不是预设用户会问这些）形如 \`<base>/USDT:USDT\`，如 \`BTC/USDT:USDT\`
-  （**不是**现货 \`BTC/USDT\`，也不是股票）。以 \`tradingMode="perp"\` + \`leverage\`（1..20）起
-  run / 下单。开空只占保证金；维持保证金击穿会被框架强平；按结算时点计资金费。
-
-**用户想做空 / 套保 / 反向 / 押下跌时**：
-- **标的是 crypto** → 走 perp：用永续标的 \`X/USDT:USDT\`，**回测 (\`paper.run_backtest\`) 和
-  起 run (\`paper.start_strategy\`) 都传 \`tradingMode="perp"\` + \`leverage\`**。**且策略必须含做空
-  逻辑**（开空入场 + cover 平空）。可用 \`perp_short_reversion\` archetype 作起点，或 author 一条含
-  open_short/cover 的策略。⚠️ **做空策略若用 spot 回测会 0 成交**（裸空被守门拒）、看着像坏策略——
-  必须 perp 回测才看得到真实做空表现,过了再 promote → start。**long-only 策略投进 perp 会告警**
-  （它的出场 SELL 会被当开空、可能漂移）。
-- **标的非 crypto（股票 / 指数等）** → 仍只现货做多，做空不支持：给"空仓观望 / 减仓 /
-  平多离场 / 等右侧"建议，**不要**在现货上用 SELL/SHORT 凑做空。
-
-**反例 / 风险**（不要犯）：
-- ❌ 在 spot 模式或非 crypto 标的上用 SELL/SHORT 凑做空 —— 守门会拒，0 笔成交。
-- ❌ 把 long-only 策略投进 perp 期望它做空 —— 它没有做空 / cover 逻辑，会漂移。
-- ❌ perp 用现货 symbol（\`BTC/USDT\` 而非 \`BTC/USDT:USDT\`）—— 资格 gate 422 拒。
-- ⚠️ perp 杠杆放大风险：小幅反向即可能触发维持保证金强平；如实讲风险，别只报"很赚"。
+**perp 注意**：永续 symbol 用 \`BTC/USDT:USDT\` 非 \`BTC/USDT\`(否则 422)；
+long-only 策略投 perp 会告警；杠杆放大风险如实说。
 
 ## 内置 baseline 策略（D-9 重新定位）
 


### PR DESCRIPTION
## 根因
agent 四次回答"不支持做空"。不是某段不够强,而是整段 prompt 被设计成**否定框架**:通篇"禁止/不要/不支持/不要犯",否定词成为 LLM 注意力锚,反复激活旧结论。越加强越恶化。

## 修复
重写「多空意识」段为**能力清单**(非否定清单):
- 先描述两种模式各能做什么(spot 做多 / perp 可多可空)
- 按标的分类指引(crypto→perp, 股票→spot)
- 去掉所有禁止说/不要犯/反例的否定锚
- 40 行缩到 17 行,纯正面信号

## 验证
- typecheck 零错误
- 422/422 tests 通过

> supersede #122 (#122 的 SHORTING POLICY 仍是"禁止说X"的否定框架,本质没变)。跟 #120/#121 合起来才算完整:数据通→工具有参数→agent 能力导向。

🤖 Generated with [Claude Code](https://claude.com/claude-code)