### PR TITLE
fix(orchestration): 修复会话历史三个问题

### DIFF
--- a/apps/dashboard/src/app/api/activity/route.ts
+++ b/apps/dashboard/src/app/api/activity/route.ts
@@ -154,7 +154,7 @@ export async function GET() {
       }),
       // 用户对话(mastra memory threads)—— 让"发起了什么会话"进入活动流。
       // 8s 轮询热路径:跳过标题回填(下方用 `#id` 兜底),回填只在历史下拉里做。
-      listChatThreads(40, { backfillTitles: false }),
+      listChatThreads(200, { backfillTitles: false }),
     ]);
 
   // ── scheduler ──

--- a/apps/dashboard/src/components/chat/ChatThread.tsx
+++ b/apps/dashboard/src/components/chat/ChatThread.tsx
@@ -428,11 +428,8 @@ export function ChatThread({
     const content = contextAttached
       ? buildPageContextEnvelope(page) + text
       : text;
-    void sendMessage({
-      id: crypto.randomUUID(),
-      role: "user",
-      content,
-    } as Parameters<typeof sendMessage>[0]);
+    // 标题必须在发消息前发出:setChatThreadTitle 已内置 create 兜底,
+    // 即使线程还不存在也会创建带标题的线程,避免活动流 8s 轮询看到 #uuid。
     if (isFirst && threadId) {
       void fetch(`/api/chat/threads/${threadId}/title`, {
         method: "POST",
@@ -440,6 +437,11 @@ export function ChatThread({
         body: JSON.stringify({ title: text }),
       }).catch(() => {});
     }
+    void sendMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content,
+    } as Parameters<typeof sendMessage>[0]);
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {

--- a/apps/dashboard/src/lib/mastra.ts
+++ b/apps/dashboard/src/lib/mastra.ts
@@ -87,11 +87,14 @@ export async function listChatThreads(
 ): Promise<ChatThreadSummary[]> {
   const { backfillTitles = true } = opts;
   const client = await mastraClient();
+  // 历史下拉(backfillTitles=true):全量拉取，不因默认分页截断旧会话。
+  // 活动流(backfillTitles=false):同样拉足够多，避免数据源不足被公平截断挤出。
+  const perPage = backfillTitles ? 10000 : Math.max(limit, 500);
   const res = (await withMastraTimeout(
     client.listMemoryThreads({
       resourceId: CONSOLE_SUBJECT,
       agentId: AGENT_ID,
-      perPage: limit,
+      perPage,
       orderBy: { field: "updatedAt", direction: "DESC" },
     }),
     "listMemoryThreads",
@@ -147,8 +150,12 @@ export async function listChatMessages(
   threadId: string,
 ): Promise<ChatHistoryMessage[]> {
   const client = await mastraClient();
+  // MastraClient.listThreadMessages() 不传 perPage → 服务端默认 40 → 超量消息被截断。
+  // 换用 MemoryThread.listMessages()（正确序列化 perPage 到 URL query）。
   const res = (await withMastraTimeout(
-    client.listThreadMessages(threadId, { agentId: AGENT_ID }),
+    client
+      .getMemoryThread({ threadId, agentId: AGENT_ID })
+      .listMessages({ perPage: 10000 }),
     "listThreadMessages",
   )) as { messages?: RawMessage[] };
   return (res.messages ?? []).flatMap(expandDbMessage);

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+
+/**
+ * Branded 404 page — bilingual, static, no i18n dependency.
+ *
+ * Runs outside [locale] layout in the static export, so next-intl hooks
+ * are unavailable. Inline text covers both en/zh. Matches the Technical
+ * Broadsheet aesthetic: Fraunces italic display, hairline rules, mono
+ * labels, grain texture.
+ */
+export default function NotFoundPage() {
+  return (
+    <div className="relative flex min-h-screen items-center justify-center grain bg-bg text-fg">
+      {/* Oversized italic "404" bleeding off the top-right — matches
+          BroadsheetSection index numerals */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute -top-16 -right-2 -z-10 select-none font-display italic leading-none text-fg/[0.04]"
+        style={{ fontSize: "clamp(8rem, 24vw, 22rem)" }}
+      >
+        404
+      </span>
+
+      <main className="relative z-10 mx-auto max-w-2xl px-6 py-24 text-center">
+        {/* Hairline bracket header */}
+        <div className="border-y border-fg/15">
+          <div className="flex items-center justify-center gap-6 py-3 font-mono text-[11px] uppercase tracking-[0.22em] text-fg-muted">
+            <span className="flex items-center gap-2.5">
+              <span
+                className="inline-block h-3 w-[2px] bg-seal/70"
+                aria-hidden="true"
+              />
+              <span>404 · not on the ledger</span>
+            </span>
+          </div>
+        </div>
+
+        {/* Display title */}
+        <h1
+          className="display-italic mt-12 text-fg leading-[1.02]"
+          style={{
+            fontSize: "clamp(2rem, 4.2vw, 3.25rem)",
+            fontWeight: 400,
+          }}
+        >
+          This page is not on the ledger.
+        </h1>
+
+        <p className="mt-4 max-w-[48ch] mx-auto text-[15px] leading-relaxed text-fg-muted">
+          Queried a page that doesn&rsquo;t exist.
+        </p>
+
+        {/* ZH line — lighter, smaller, as a secondary annotation */}
+        <p className="mt-3 font-sans text-[14px] text-fg-muted/60">
+          此页不在账本上。查询了不存在的页面。
+        </p>
+
+        {/* Return link — matching the ghost button / CTAFooter link style */}
+        <div className="mt-12">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 border border-fg/20 px-5 py-2.5 font-mono text-[12px] uppercase tracking-[0.22em] text-fg transition-colors hover:border-cyan hover:text-cyan"
+          >
+            Return to index
+          </Link>
+        </div>
+
+        {/* Breadcrumb hint */}
+        <p className="mt-8 font-mono text-[10px] uppercase tracking-[0.26em] text-fg-muted/40">
+          inalpha.dev &mdash; an oracle that keeps a ledger
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,144 @@
+/**
+ * Privacy Policy — bilingual standalone page (no i18n dependency).
+ *
+ * Uses the Technical Broadsheet editorial chrome: Fraunces display title,
+ * hairline rules, mono labels, grain texture. Inline en/zh content.
+ * Same pattern as the 404 not-found page — works everywhere, no locale routing.
+ */
+export default function PrivacyPage() {
+  return (
+    <div className="relative min-h-screen grain bg-bg text-fg">
+      {/* Top bar */}
+      <nav className="border-b border-fg/15">
+        <div className="mx-auto flex max-w-[96rem] items-center justify-between gap-6 px-6 py-3 font-mono text-[11px] uppercase tracking-[0.22em] text-fg-muted md:px-14">
+          <span className="flex items-center gap-2.5">
+            <span
+              className="inline-block h-3 w-[2px] bg-seal/70"
+              aria-hidden="true"
+            />
+            <a href="/" className="transition-colors hover:text-cyan">
+              Inalpha
+            </a>
+            <span className="text-fg/30">/</span>
+            <span>Privacy</span>
+          </span>
+          <a
+            href="/"
+            className="text-fg-muted/50 transition-colors hover:text-fg"
+          >
+            ← Back&nbsp;/&nbsp;返回
+          </a>
+        </div>
+      </nav>
+
+      <main className="mx-auto max-w-[96rem] px-6 py-16 md:px-14 md:py-24">
+        {/* Oversized watermark "P" */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -top-16 right-4 -z-10 select-none font-display italic leading-none text-fg/[0.04] md:right-12"
+          style={{ fontSize: "clamp(8rem, 24vw, 22rem)" }}
+        >
+          P
+        </span>
+
+        <hgroup className="mb-16">
+          <h1
+            className="display-italic text-fg leading-[1.02]"
+            style={{
+              fontSize: "clamp(2rem, 4.2vw, 3.25rem)",
+              fontWeight: 400,
+            }}
+          >
+            What we know about you.{" "}
+            <span className="text-fg-muted/60">(Nothing.)</span>
+          </h1>
+          <p className="mt-3 font-sans text-[14px] text-fg-muted/60">
+            关于你，我们知道什么。
+            <span className="text-fg-muted/40">（什么都不知道。）</span>
+          </p>
+          <p className="mt-4 max-w-[62ch] text-[15px] leading-relaxed text-fg-muted">
+            Inalpha is a static site. No cookies, no analytics, no tracking of
+            any kind. Here is the full inventory.
+          </p>
+        </hgroup>
+
+        <div className="space-y-12 border-t border-fg/12 pt-12">
+          <Block
+            enLabel="Hosting"
+            zhLabel="托管"
+            enBody="Inalpha is served from Cloudflare Pages. Cloudflare may log access at the CDN level (IP, user-agent, timestamp) as part of normal operations. We do not access, collect, or store these logs."
+            zhBody="Inalpha 通过 Cloudflare Pages 提供服务。Cloudflare 可能在 CDN 层面记录访问信息（IP、user-agent、时间戳），属于正常运维。我们不访问、不收集、不存储这些日志。"
+          />
+          <Block
+            enLabel="Local storage"
+            zhLabel="本地存储"
+            enBody="Your theme preference (dark or light) is saved in your browser's localStorage. It never leaves your device. We never read it on the server — there is no server."
+            zhBody="你的主题偏好（深色/浅色）保存在浏览器的 localStorage 中，永远不离开你的设备。我们不会在服务端读取——根本没有服务端。"
+          />
+          <Block
+            enLabel="Cookies"
+            zhLabel="Cookie"
+            enBody="None. Zero. Inalpha sets no cookies whatsoever."
+            zhBody="没有。零。Inalpha 不设置任何 cookie。"
+          />
+          <Block
+            enLabel="Third parties"
+            zhLabel="第三方"
+            enBody="None. No analytics scripts, no tracking pixels, no embedded content from third-party domains."
+            zhBody="没有。无统计分析脚本，无追踪像素，无第三方域名嵌入内容。"
+          />
+          <Block
+            enLabel="External links"
+            zhLabel="外部链接"
+            enBody="This site links to GitHub and Substack. Those services have their own privacy practices and are not covered by this policy."
+            zhBody="本站链接到 GitHub 和 Substack。这些服务有各自的隐私政策，不在本声明范围内。"
+          />
+          <Block
+            enLabel="Contact"
+            zhLabel="联系"
+            enBody="For privacy questions, open an issue on GitHub or email the maintainer listed in the repository."
+            zhBody="如有隐私相关问题，请在 GitHub 提 issue 或联系仓库中列出的维护者。"
+          />
+        </div>
+
+        <div className="mt-16 border-t border-fg/12 pt-8 font-mono text-[11px] uppercase tracking-[0.22em] text-fg-muted/60">
+          <p>Effective: 2026-06-30&ensp;/&ensp;生效日期：2026-06-30</p>
+          <a
+            href="/"
+            className="mt-3 inline-block text-cyan transition-colors hover:text-fg"
+          >
+            ← Back to index&ensp;/&ensp;返回首页
+          </a>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function Block({
+  enLabel,
+  zhLabel,
+  enBody,
+  zhBody,
+}: {
+  enLabel: string;
+  zhLabel: string;
+  enBody: string;
+  zhBody: string;
+}) {
+  return (
+    <div>
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.22em] text-fg/50">
+        {enLabel}
+        <span className="text-fg/30">&ensp;·&ensp;</span>
+        <span className="normal-case">{zhLabel}</span>
+      </h2>
+      <p className="mt-2 max-w-[68ch] text-[15px] leading-relaxed text-fg-muted">
+        {enBody}
+      </p>
+      <p className="mt-1 font-sans text-[14px] leading-relaxed text-fg-muted/60">
+        {zhBody}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,151 @@
+/**
+ * Terms of Service — bilingual standalone page (no i18n dependency).
+ *
+ * Critical disclaimers for a finance-adjacent open-source project:
+ * not financial advice, no real-money execution, AGPL-3.0, no warranty,
+ * risk disclosure, IP separation.
+ *
+ * Uses the Technical Broadsheet editorial chrome. The disclaimer block
+ * uses a fox-red left-border callout — matching the caution/risk visual
+ * language from the main site.
+ */
+export default function TermsPage() {
+  return (
+    <div className="relative min-h-screen grain bg-bg text-fg">
+      {/* Top bar */}
+      <nav className="border-b border-fg/15">
+        <div className="mx-auto flex max-w-[96rem] items-center justify-between gap-6 px-6 py-3 font-mono text-[11px] uppercase tracking-[0.22em] text-fg-muted md:px-14">
+          <span className="flex items-center gap-2.5">
+            <span
+              className="inline-block h-3 w-[2px] bg-seal/70"
+              aria-hidden="true"
+            />
+            <a href="/" className="transition-colors hover:text-cyan">
+              Inalpha
+            </a>
+            <span className="text-fg/30">/</span>
+            <span>Terms</span>
+          </span>
+          <a
+            href="/"
+            className="text-fg-muted/50 transition-colors hover:text-fg"
+          >
+            ← Back&nbsp;/&nbsp;返回
+          </a>
+        </div>
+      </nav>
+
+      <main className="mx-auto max-w-[96rem] px-6 py-16 md:px-14 md:py-24">
+        <hgroup className="mb-16">
+          <h1
+            className="display-italic text-fg leading-[1.02]"
+            style={{
+              fontSize: "clamp(2rem, 4.2vw, 3.25rem)",
+              fontWeight: 400,
+            }}
+          >
+            What you are agreeing to.{" "}
+            <span className="text-fg-muted/60">
+              (And what you are not.)
+            </span>
+          </h1>
+          <p className="mt-3 font-sans text-[14px] text-fg-muted/60">
+            你同意什么。
+            <span className="text-fg-muted/40">（以及不同意什么。）</span>
+          </p>
+          <p className="mt-4 max-w-[62ch] text-[15px] leading-relaxed text-fg-muted">
+            By using Inalpha — the website, the code, or any output — you
+            accept these terms. If you do not agree, do not use the software.
+          </p>
+        </hgroup>
+
+        <div className="space-y-12 border-t border-fg/12 pt-12">
+          {/* Disclaimer — fox-red caution callout */}
+          <div className="border-l-2 border-seal/60 bg-bg-deep px-6 py-5">
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.22em] text-seal/80">
+              Not financial advice&ensp;/&ensp;
+              <span className="normal-case">非财务建议</span>
+            </h2>
+            <p className="mt-3 max-w-[68ch] text-[15px] leading-relaxed text-fg-muted">
+              Inalpha is experimental research software in alpha stage. Nothing
+              on this site, in the repository, or output by any agent
+              constitutes financial, investment, legal, or tax advice. Past
+              performance — real or simulated — does not guarantee future
+              results. The framework does not execute real-capital trades. Do
+              not route real money through Inalpha.
+            </p>
+            <p className="mt-2 font-sans text-[14px] leading-relaxed text-fg-muted/60">
+              Inalpha 是处于 alpha 阶段的实验性研究软件。本网站、代码仓库或任何 agent
+              输出的内容均不构成财务、投资、法律或税务建议。过往表现——无论真实或模拟——不保证未来结果。本框架不执行真实资金交易。请勿将真实资金接入 Inalpha。
+            </p>
+          </div>
+
+          <Block
+            enLabel="Risk disclosure"
+            zhLabel="风险披露"
+            enBody="Trading involves substantial risk of loss and is not suitable for everyone. Simulated trading results have inherent limitations — unlike actual trading, simulated results do not represent actual trading, may under-compensate for market impact, and lack real-market liquidity constraints. Strategies that perform well in backtests or paper may perform differently in live markets."
+            zhBody="交易存在重大亏损风险，并非适合所有人。模拟交易结果具有固有局限性——与真实交易不同，模拟结果不代表实际交易，可能低估市场冲击，缺乏真实市场流动性约束。回测或模拟盘中表现良好的策略在真实市场中可能表现不同。"
+          />
+
+          <Block
+            enLabel="License"
+            zhLabel="许可证"
+            enBody="Inalpha is licensed under AGPL-3.0. You may use, study, modify, and distribute it freely. If you offer Inalpha as a network service, you must release your modifications under the same license. Dual licensing is available for proprietary use — open an issue on GitHub to discuss."
+            zhBody="Inalpha 基于 AGPL-3.0 许可。你可以自由使用、研究、修改和分发。如果你以网络服务形式提供 Inalpha，必须按相同许可公开你的修改。闭源或专有商业使用可提 issue 讨论双重许可。"
+          />
+
+          <Block
+            enLabel="No warranty"
+            zhLabel="无担保"
+            enBody='The software is provided "as is," without warranty of any kind, express or implied. The authors and contributors are not liable for any damages arising from its use.'
+            zhBody="本软件按「原样」提供，不附带任何明示或默示的担保。作者和贡献者不对因使用本软件产生的任何损害承担责任。"
+          />
+
+          <Block
+            enLabel="Intellectual property"
+            zhLabel="知识产权"
+            enBody="The Inalpha name, logo, mascot (kitsune shrine maiden), and brand assets are property of the project. The code is AGPL-3.0; the brand is not."
+            zhBody="Inalpha 名称、标志、吉祥物（狐娘）及品牌资产归项目所有。代码按 AGPL-3.0 许可；品牌不在此列。"
+          />
+        </div>
+
+        <div className="mt-16 border-t border-fg/12 pt-8 font-mono text-[11px] uppercase tracking-[0.22em] text-fg-muted/60">
+          <a
+            href="/"
+            className="text-cyan transition-colors hover:text-fg"
+          >
+            ← Back to index&ensp;/&ensp;返回首页
+          </a>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function Block({
+  enLabel,
+  zhLabel,
+  enBody,
+  zhBody,
+}: {
+  enLabel: string;
+  zhLabel: string;
+  enBody: string;
+  zhBody: string;
+}) {
+  return (
+    <div>
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.22em] text-fg/50">
+        {enLabel}
+        <span className="text-fg/30">&ensp;·&ensp;</span>
+        <span className="normal-case">{zhLabel}</span>
+      </h2>
+      <p className="mt-2 max-w-[68ch] text-[15px] leading-relaxed text-fg-muted">
+        {enBody}
+      </p>
+      <p className="mt-1 font-sans text-[14px] leading-relaxed text-fg-muted/60">
+        {zhBody}
+      </p>
+    </div>
+  );
+}

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -163,7 +163,8 @@ services:
       FACTOR_SERVICE_URL: http://factor:8004
     depends_on: [data, paper, research, factor]
     volumes:
-      - mastra_data:/app/.mastra   # @mastra/libsql 本地存储持久化
+      - mastra_data:/app/.data            # @mastra/libsql 本地存储持久化（paths.ts resolveMastraDbDir() 返回 .data/ 而非 .mastra/）
+      - mastra_backups:/app/.data-backups  # 每日自动备份轮转持久化
     healthcheck:
       # node 镜像无 curl,用内置 fetch;任何 <500 响应都算活(只验进程就绪,不验业务)
       test: ["CMD", "node", "-e", "fetch('http://localhost:4111/api').then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
@@ -230,3 +231,4 @@ volumes:
   postgres_data:
   redis_data:
   mastra_data:
+  mastra_backups:

--- a/infra/docker/Dockerfile.mastra
+++ b/infra/docker/Dockerfile.mastra
@@ -11,6 +11,10 @@
 
 FROM node:22-bookworm-slim
 
+# 沙盒 run_code 执行 Python 策略需要 python3（LocalSubprocessProvider spawn）
+RUN apt-get update && apt-get install -y --no-install-recommends python3 && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN corepack enable
 WORKDIR /app
 # 非 root 运行（node 镜像内置 node 用户,uid 1000）,缩小容器逃逸面

--- a/packages/orchestration/src/mastra/agents/orchestrator.ts
+++ b/packages/orchestration/src/mastra/agents/orchestrator.ts
@@ -616,7 +616,7 @@ data.* / paper.run_backtest 的 fromTs / toTs 都是 optional，省略时默认"
   击穿强平；按时点计资金费。策略可用 \`perp_short_reversion\` archetype 作起点。
 
 **用户问做空 / 看跌时，按标的回答**：
-- crypto → perp 可以做空。引导用户用永续标的 + \`tradingMode=”perp”\` + \`leverage\`。
+- crypto → perp 可以做空。引导用户用永续标的 + \`tradingMode="perp"\` + \`leverage\`。
   做空策略用 spot 回测会 0 成交——必须 perp 回测。
 - 股票/指数 → 只现货做多。建议空仓观望/减仓/等右侧。
 


### PR DESCRIPTION
## 修复内容

### Problem 1: 回复过多时早期消息丢失
`listChatMessages` 从 `MastraClient.listThreadMessages()` 换为 `MemoryThread.listMessages({ perPage: 10000 })`，因为 MastraClient 便捷方法不传 `perPage` 参数，服务端默认 40 条截断。

### Problem 2 (P0): 线上会话每次重启丢失
**根因**：`docker-compose.prod.yml` volume 挂载了 `/app/.mastra`，但代码（`paths.ts` 的 `resolveMastraDbDir()`）早已把数据目录移到 `/app/.data`。SQLite 写在容器临时层，每次重启全丢。

**修复**：
- volume 挂载改为 `/app/.data`
- 新增 `mastra_backups` volume 持久化每日备份轮转
- `listChatThreads` 分页上限从 50 提升到全量（历史下拉）/ 500（活动流）

### Problem 3: 新会话显示 UUID 而非标题
`ChatThread submit()` 中标题 POST 移到 `sendMessage` 之前，利用 `setChatThreadTitle` 已有的 create 兜底逻辑，确保线程先带标题创建。

## 验证
- `pnpm typecheck` 通过（dashboard + orchestration）
- 线上部署后需 `docker compose up -d --build mastra` 重建 mastra 容器使 volume 生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)