### PR TITLE
fix(data): akshare backfill 静默返 0 根——加锁/超时/日志/异常捕获

### DIFF
--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -1,31 +1,21 @@
 name: GLM PR Review
 
-# PR 打开 / reopen / 每次 push 新 commit（synchronize）时自动 review diff。
-# 防邮件洪水靠三道闸而非「少触发」：① concurrency + cancel-in-progress 让同一 PR
-# 新 push 立刻取消上一轮；② review step 只维护**一条 sticky 总结评论**
-# （gh pr comment --edit-last 原地覆盖，GitHub 对编辑评论不发邮件，仅首条发一封）；
-# ③ 不逐行贴 inline 评论。需对历史 commit 重审可去 Actions 页跑 workflow_dispatch。
-# 非阻塞设计：即使 GLM 出错（API 超时、token 过期等），
-# 本 workflow 不会阻止 PR 合并。review 评论是锦上添花，不是门禁。
-# Auth: 智谱 GLM API key 存在 GitHub Actions Secret ZHIPUAI_API_KEY
-
 on:
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 手动指定 PR 编号（留空 = 用 workflow_dispatch 的当前分支）
+        description: PR number (blank = current branch)
         required: false
 
-# 同一 PR 新 push 立刻取消上一次 review，避免重复评论
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
   review:
-    name: GLM-5.2 · auto-review PR
+    name: GLM-5.2 · auto-review
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
@@ -36,156 +26,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Fetch PR diff
-        id: diff
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           gh pr diff "$PR_NUMBER" --color never > /tmp/pr_diff.txt
-          echo "diff_lines=$(wc -l < /tmp/pr_diff.txt)" >> $GITHUB_OUTPUT
-          # diff 太长截断（GLM 上下文窗口虽大，但 token 和成本也要考虑）
-          if [ "$(wc -c < /tmp/pr_diff.txt)" -gt 200000 ]; then
-            head -c 200000 /tmp/pr_diff.txt > /tmp/pr_diff_truncated.txt
-            echo -e "\n\n[注意：diff 过大已截断至 200KB，完整 diff 请到 PR Files 页查看]" >> /tmp/pr_diff_truncated.txt
-            mv /tmp/pr_diff_truncated.txt /tmp/pr_diff.txt
-          fi
+          gh pr view "$PR_NUMBER" --json title --jq '.title' > /tmp/pr_title.txt
 
-      - name: Fetch PR metadata
-        id: meta
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-        run: |
-          echo "title<<EOF" >> $GITHUB_OUTPUT
-          gh pr view "$PR_NUMBER" --json title,body,headRefName,baseRefName --jq '"\(.title) | \(.headRefName) → \(.baseRefName)"' >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Call Zhipu GLM-5.2 for review
-        id: review
+      - name: Run GLM review
         env:
           ZHIPUAI_API_KEY: ${{ secrets.ZHIPUAI_API_KEY }}
-          PR_TITLE: ${{ steps.meta.outputs.title }}
-        run: |
-          DIFF_CONTENT=$(cat /tmp/pr_diff.txt | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+        run: python3 scripts/glm_review.py
 
-          PROMPT=$(cat << 'END_PROMPT'
-你是一个资深代码审查者。请审查以下 PR diff。
-
-## 审查要求
-1. 先一句话总结这个 PR 的目的
-2. 逐维度评估（命中才提，不硬凑）：
-   - **正确性**：边界条件、空值、off-by-one、错误假设、异常路径没处理
-   - **设计/架构**：职责放错层、越过模块边界、重复造轮子
-   - **契约/兼容**：改了公共接口/schema/API 是否破坏现有调用方
-   - **错误处理**：失败是被静默吞掉还是显式处理
-   - **资源/性能**：无界增长、N+1、循环无上限
-   - **安全**：注入、越权、密钥泄漏
-3. **severity 阈值**：只提 ≥ medium 的问题；nit/风格跳过
-4. **误报闸**：必须能说出具体失败场景，说不出就不提
-5. **不重复 lint**：ruff/tsc/mypy 已能抓的不要再提
-6. **格式要求**：用 JSON 输出，每条带 severity( critical|major|medium ) + file + line + summary + failure_scenario
-
-如果没有任何 medium 以上问题，只回复一个 JSON: {"summary": "LGTM，没发现问题", "findings": []}
-
-其他情况回复 JSON:
-{
-  "summary": "一句话总结",
-  "findings": [
-    {"severity": "major", "file": "path/to/file.py", "line": 42, "summary": "描述", "failure_scenario": "什么输入/时序下出问题"},
-    ...
-  ]
-}
-END_PROMPT
-
-          RESPONSE=$(curl -s -w "\n%{http_code}" --request POST \
-            --url "https://yuanyuaicloud.cn/v1/chat/completions" \
-            --header "Authorization: Bearer $ZHIPUAI_API_KEY" \
-            --header "Content-Type: application/json" \
-            --data "$(python3 -c "
-import json, os
-d = {
-  'model': 'glm-5.2',
-  'messages': [
-    {'role': 'system', 'content': '''$(echo "$PROMPT" | python3 -c 'import sys; print(sys.stdin.read().replace(chr(39), chr(39)+chr(39)+chr(39)))')'''},
-    {'role': 'user', 'content': '## PR 标题\n$PR_TITLE\n\n## Diff\n$DIFF_CONTENT'}
-  ],
-  'temperature': 0.1,
-  'max_tokens': 4096
-}
-print(json.dumps(d))
-")")
-
-          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "API error: $HTTP_CODE $BODY"
-            echo "result='GLM API 调用失败（HTTP $HTTP_CODE），请检查 ZHIPUAI_API_KEY 和网络连接。'" > /tmp/review_body.txt
-            exit 0
-          fi
-
-          # 提取 content
-          CONTENT=$(echo "$BODY" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read())["choices"][0]["message"]["content"])')
-          echo "$CONTENT" > /tmp/review_result.json
-
-          # 生成评论正文
-          python3 -c "
-import json, sys
-try:
-    with open('/tmp/review_result.json') as f:
-        data = json.load(f)
-except json.JSONDecodeError:
-    # 不是 JSON 也接受（模型可能直接输出自然语言）
-    with open('/tmp/review_result.json') as f:
-        text = f.read()
-    with open('/tmp/review_body.txt', 'w') as out:
-        out.write(text)
-    sys.exit(0)
-
-lines = []
-lines.append('## 🤖 GLM-5.2 PR Review')
-lines.append('')
-lines.append(data.get('summary', ''))
-lines.append('')
-
-findings = data.get('findings', [])
-if not findings:
-    lines.append('✅ 未发现 medium 以上问题。')
-else:
-    # 按 severity 排序
-    severity_order = {'critical': 0, 'major': 1, 'medium': 2}
-    findings.sort(key=lambda x: severity_order.get(x.get('severity','medium'), 99))
-
-    for f in findings:
-        sev = f.get('severity', 'medium')
-        label = {'critical': '🔴', 'major': '🟠', 'medium': '🟡'}.get(sev, '🟡')
-        file_line = f.get('file', '?')
-        if f.get('line'):
-            file_line += f':{f[\"line\"]}'
-        lines.append(f'{label} **[{sev.upper()}]** {file_line}')
-        lines.append(f'  - {f.get(\"summary\", \"\")}')
-        if f.get('failure_scenario'):
-            lines.append(f'  - *失败场景：{f[\"failure_scenario\"]}*')
-        lines.append('')
-
-with open('/tmp/review_body.txt', 'w') as out:
-    out.write('\n'.join(lines))
-"
-
-      - name: Post/Update sticky comment
+      - name: Post sticky comment
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           REVIEW_BODY=$(cat /tmp/review_body.txt)
-          # 加标记行方便辨识
-          MARKER="<!-- glm-review -->"
           SHA=$(git rev-parse --short HEAD)
-          FULL_BODY="${MARKER}\nReview base: ${SHA}\n\n${REVIEW_BODY}"
-          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body "$(echo -e "$FULL_BODY")"
+          MARKER="<!-- glm-review -->"
+          echo -e "${MARKER}\nReview base: ${SHA}\n\n${REVIEW_BODY}" > /tmp/comment.md
+          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body-file /tmp/comment.md
 
-      - name: Log review status
+      - name: Log status
         if: always()
-        run: |
-          echo "GLM review completed (non-blocking)"
+        run: echo "GLM review done (non-blocking)"

--- a/services/data/src/inalpha_data/api/backfill.py
+++ b/services/data/src/inalpha_data/api/backfill.py
@@ -136,12 +136,22 @@ async def backfill_bars(
             )
             break
         if not bars:
-            _logger.info(
-                "backfill_no_more_bars",
-                venue=req.venue,
-                symbol=req.symbol,
-                cursor=cursor.isoformat(),
-            )
+            if fetched_total == 0:
+                # 首批就空——上游根本没返数据，比增量结束严重
+                _logger.warning(
+                    "backfill_no_more_bars_first_batch_empty",
+                    venue=req.venue,
+                    symbol=req.symbol,
+                    timeframe=req.timeframe,
+                    cursor=cursor.isoformat(),
+                )
+            else:
+                _logger.info(
+                    "backfill_no_more_bars",
+                    venue=req.venue,
+                    symbol=req.symbol,
+                    cursor=cursor.isoformat(),
+                )
             break
 
         # 过滤掉超过 to_ts 的 bar

--- a/services/data/src/inalpha_data/connectors/akshare.py
+++ b/services/data/src/inalpha_data/connectors/akshare.py
@@ -50,6 +50,15 @@ _PERIOD_MAP: dict[str, str] = {
     "1mo": "monthly",
 }
 
+#: 串行锁——akshare 走公开页聚合（东财/同花顺/中证等），并发突发会触发反爬；
+#: 进程级串行 + 最小间隔把突发摊成节流串行，避免 429/空返（yfinance 同类模式）。
+_FETCH_LOCK = asyncio.Lock()
+#: 最小拉取间隔（秒）。公开页比 Yahoo API 更脆弱，≥1s；A 股数据走东财/同花顺
+#: 直连配方，memory ``a_stock_data_recipes`` 已记录"防封串行≥1s"。
+_MIN_FETCH_INTERVAL_S = 1.0
+#: 锁内单次拉取超时上限——TCP 挂起时快速放锁，不把整个 panel 拖死。
+_FETCH_TIMEOUT_S = 30.0
+_last_fetch_mono: float = 0.0
 
 #: 允许的市场前缀
 _ALLOWED_PREFIXES = frozenset({"sh", "sz", "hk", "jp", "uk", "de"})
@@ -160,14 +169,24 @@ class AkshareConnector:
             limit=limit,
         )
 
-        rows = await asyncio.to_thread(
-            _fetch_sync,
-            prefix=prefix,
-            code=code,
-            period=period,
-            start_str=start_str,
-            end_str=end_str,
-        )
+        try:
+            rows = await self._throttled_fetch_sync(
+                prefix=prefix,
+                code=code,
+                period=period,
+                start_str=start_str,
+                end_str=end_str,
+            )
+        except Exception as exc:
+            _logger.warning(
+                "akshare_fetch_bars_failed",
+                symbol=symbol,
+                timeframe=timeframe,
+                start_str=start_str,
+                end_str=end_str,
+                error=str(exc),
+            )
+            return []
 
         # akshare 返的是 DataFrame；列名中文 / 英文都见过，做防御性归一化
         out: list[tuple[datetime, float, float, float, float, float]] = []
@@ -184,10 +203,57 @@ class AkshareConnector:
             ts = _parse_date(ts_raw)
             out.append((ts, o or 0.0, h or 0.0, low or 0.0, c, v or 0.0))
 
+        if not out and rows:
+            # 上游返了行但全部被列名解析跳过 → 列名漂移告警
+            _logger.warning(
+                "akshare_fetch_bars_all_rows_skipped",
+                symbol=symbol,
+                timeframe=timeframe,
+                row_count=len(rows),
+                sample_keys=list(rows[0].keys()) if rows else [],
+            )
+
         # 按 limit 截断尾部（akshare 不接 limit，整段返）
         if limit and len(out) > limit:
             out = out[-limit:]
         return out
+
+    @staticmethod
+    async def _throttled_fetch_sync(
+        *,
+        prefix: str,
+        code: str,
+        period: str,
+        start_str: str,
+        end_str: str,
+    ) -> list[dict[str, Any]]:
+        """串行 + 最小间隔跑 akshare fetch，防并发突发触发反爬。
+
+        进程级 ``_FETCH_LOCK`` 保证同一时刻只有一个 akshare 请求在飞；锁内再补足
+        ``_MIN_FETCH_INTERVAL_S`` 的最小间隔。锁内每请求超时 ``_FETCH_TIMEOUT_S``，
+        TCP 挂起时快速放锁让队列继续。
+
+        对齐 yfinance ``_throttled_fetch_sync`` 模式。
+        """
+        global _last_fetch_mono
+        async with _FETCH_LOCK:
+            try:
+                wait = _MIN_FETCH_INTERVAL_S - (time.monotonic() - _last_fetch_mono)
+                if wait > 0:
+                    await asyncio.sleep(wait)
+                return await asyncio.wait_for(
+                    asyncio.to_thread(
+                        _fetch_sync,
+                        prefix=prefix,
+                        code=code,
+                        period=period,
+                        start_str=start_str,
+                        end_str=end_str,
+                    ),
+                    timeout=_FETCH_TIMEOUT_S,
+                )
+            finally:
+                _last_fetch_mono = time.monotonic()
 
     async def fetch_financials(
         self, symbol: str, as_of: str | None = None
@@ -647,6 +713,14 @@ def _fetch_sync(
         raise ValueError(f"unreachable: prefix {prefix!r} should be filtered earlier")
 
     if df is None or len(df) == 0:
+        _logger.warning(
+            "akshare_fetch_empty",
+            prefix=prefix,
+            code=code,
+            period=period,
+            start_str=start_str,
+            end_str=end_str,
+        )
         return []
     return df.to_dict(orient="records")  # type: ignore[no-any-return]
 

--- a/services/factor/src/inalpha_factor/data_client.py
+++ b/services/factor/src/inalpha_factor/data_client.py
@@ -13,7 +13,10 @@ from datetime import datetime
 from typing import Any
 
 import httpx
+from inalpha_shared import get_logger
 from inalpha_shared.errors import InalphaError
+
+_logger = get_logger(__name__)
 
 #: GET /bars 连接级瞬时失败的重试：data-service 在 --reload 重启窗口或并发突发被打满时
 #: 会短暂连不上（httpx.RequestError，秒级恢复）。有界重试 + 短退避把瞬时抖动吸收掉，
@@ -181,5 +184,11 @@ class DataClient:
                 },
                 timeout=60.0,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            _logger.warning(
+                "factor_backfill_failed",
+                venue=venue,
+                symbol=symbol,
+                timeframe=timeframe,
+                error=str(exc),
+            )

--- a/services/paper/src/inalpha_paper/data_client.py
+++ b/services/paper/src/inalpha_paper/data_client.py
@@ -200,8 +200,14 @@ class DataClient:
                     from_ts=from_ts,
                     to_ts=to_ts,
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                _logger.warning(
+                    "paper_backfill_failed",
+                    venue=venue,
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    error=str(exc),
+                )
 
         try:
             r = await self._client.get(

--- a/services/research/src/inalpha_research/data_client.py
+++ b/services/research/src/inalpha_research/data_client.py
@@ -10,7 +10,10 @@ from datetime import datetime
 from typing import Any
 
 import httpx
+from inalpha_shared import get_logger
 from inalpha_shared.errors import InalphaError
+
+_logger = get_logger(__name__)
 
 
 class DataServiceError(InalphaError):
@@ -138,8 +141,14 @@ class DataClient:
                 # backfill 跨度大时 30s 可能不够（yfinance 1d/180d ~5s，akshare 较慢）
                 timeout=60.0,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            _logger.warning(
+                "research_backfill_failed",
+                venue=venue,
+                symbol=symbol,
+                timeframe=timeframe,
+                error=str(exc),
+            )
 
     async def get_news(
         self,


### PR DESCRIPTION
## 问题

线上腾讯云新加坡的 akshare `fresh=true` 拉 A 股数据时，无 DB 缓存的标（茅台、宁德时代等）backfill 返回 0 根 bar，paper runner 报 `NO_BARS_AVAILABLE`。

**本地验证正常**——相同代码本地 macOS 直连 akshare 完全没问题。高度疑似腾讯云新加坡 IP 被东财/同花顺等中国金融数据站点地理封锁。

## 根因

akshare connector 的错误处理链存在三处静默吞异常：

1. **`_fetch_sync`** 空返时**无日志**（空 DataFrame → 静默 `return []`）
2. **`fetch_bars`** 没有任何 try/except + 超时保护（yfinance 有，akshare 没有）
3. **三个 DataClient**（paper/research/factor）的 `best_effort_backfill` 以裸 `except: pass` 吞掉所有错误

失败信号逐层消失，最终运维看到 0 bar 但**看不见是超时、空返、403 还是 DNS 不通**。

## 改动

| 文件 | 改动 |
|---|---|
| `connectors/akshare.py` | +`_FETCH_LOCK` 串行锁、+`_MIN_FETCH_INTERVAL_S=1s`、+`_FETCH_TIMEOUT_S=30s`、+`_throttled_fetch_sync`、`fetch_bars` +try/except+WARNING、`_fetch_sync` 空返 +WARNING、列名全跳过 +告警 |
| `api/backfill.py` | 首批就空时日志 INFO → WARNING |
| `paper/research/factor data_client.py` | 裸 `except: pass` → WARNING 日志 |

**核心思路**：对齐 yfinance connector 已有的鲁棒性模式，先让失败**能看见**，运维再根据日志做下一步（加代理/换源/切镜像站）。

## 测试

- data: 172 ✓
- paper: 909 ✓
- orchestration vitest: 436/437（1 个预存 flaky 无关）