### PR TITLE
feat(factor): P0-P5 因子发现深度进化

### DIFF
--- a/packages/orchestration/src/clients/factor.ts
+++ b/packages/orchestration/src/clients/factor.ts
@@ -15,7 +15,6 @@ export type FactorSpec = {
   needs_universe: boolean;
   direction_hint: number;
   available: boolean;
-  /** 附加约束，如 macro 因子的 timeframes（仅 1d/1wk）与 FRED series id */
   extras?: Record<string, string>;
 };
 
@@ -32,23 +31,16 @@ export type FactorEffectiveness = {
   kind: string;
   value: number | null;
   rank_ic: number;
-  /** 近 1/3 样本窗 Rank IC：与 rank_ic 反号/趋零 = 因子正在衰减（ADR-0043） */
   rank_ic_recent: number;
   icir: number;
-  /** 因子换手 0-1：高 IC + 高换手的信号应打折 */
   turnover: number;
   sample_size: number;
-  /** snapshot 去相关时被本因子挤掉的同质因子 id */
   corr_pruned?: string[];
   quantile_returns: { q: number; mean_return: number; sample_size: number }[];
   long_short_return: number;
-  direction: number; // +1/-1/0
-  strength: number; // 0-1
+  direction: number;
+  strength: number;
   low_confidence: boolean;
-  /**
-   * 衰减三态（ADR-0047 服务端单一权威）：decaying=recent 反号/趋零；stable=量级
-   * 保住 60%+；fading=其间。设计策略时把它填进 author_strategy 的 factorContext。
-   */
   decay_state?: "stable" | "fading" | "decaying";
 };
 
@@ -60,10 +52,6 @@ export type ScoreResult = {
   horizon_bars: number;
   bars_used: number;
   factors: FactorEffectiveness[];
-  /**
-   * 选择效应基准：N 个候选、当前样本量下纯噪声的期望最大 |IC|。
-   * top 因子 |rank_ic| 不显著高于此值 ⇒ 可能是选择效应（地板，不是假设检验）。
-   */
   ic_null_benchmark?: number;
 };
 
@@ -77,15 +65,11 @@ export type SnapshotResult = {
   available: boolean;
   reason: string | null;
   top_factors: FactorEffectiveness[];
-  /** top-N 是从多少个候选里挑的（多重检验背景：候选越多，最高 |IC| 的期望越虚高） */
   candidates_evaluated: number;
-  /** 样本不足被排除排序的因子数 */
   low_confidence_count: number;
-  /** 选择效应基准（同 ScoreResult.ic_null_benchmark） */
   ic_null_benchmark?: number;
 };
 
-/** POST /custom/score —— 自定义表达式因子的一站式评估结果（D-12 · 因子发现 L1）。 */
 export type CustomScoreResult = {
   venue: string;
   symbol: string;
@@ -96,23 +80,16 @@ export type CustomScoreResult = {
   available: boolean;
   reason: string | null;
   expression: string;
-  /** factor_id=custom.<sha16>；available=false 时为 null */
   factor: FactorEffectiveness | null;
-  /** rank_ic 双侧 p 值（t 近似，参考量级非严格检验） */
   ic_pvalue: number | null;
-  /** 与库内价量因子的 |spearman| top5——查重复造轮子 */
   top_correlated: { factor_id: string; corr: number }[];
   max_corr: number | null;
-  /** max_corr ≥ 去相关阈值——大概率是已有因子换皮 */
   is_likely_redundant: boolean;
 };
 
-/** POST /panel/score —— 横截面因子结果。 */
 export type PanelRankEntry = {
   symbol: string;
-  /** 该标的最近有效横截面时点的因子值 */
   value: number;
-  /** 该值在 universe 内的分位排名 (0,1]，升序 */
   rank_pct: number;
 };
 
@@ -121,18 +98,13 @@ export type PanelFactorResult = {
   source: string;
   name: string;
   kind: string;
-  /** 恒 "cross_sectional"，与单标的 timeseries IC 区分 */
   ic_kind: string;
-  /** 逐期横截面 rank-IC 均值：每期对全池按因子排序 vs 跨标的前瞻收益 */
   cross_sectional_ic: number;
   icir: number;
-  /** 参与的横截面期数（有效标的 ≥ min_symbols 的 t） */
   n_periods: number;
   mean_valid_symbols: number;
   low_confidence: boolean;
-  /** latest_ranking 基于哪一期横截面的 ISO ts（fresh=False 下可能比 as_of 旧几天） */
   latest_ranking_ts: string | null;
-  /** 最近有效横截面排名（按因子值升序）——选标的直接用：取最低=首，最高=尾 */
   latest_ranking: PanelRankEntry[];
 };
 
@@ -143,19 +115,15 @@ export type PanelScoreResult = {
   horizon_bars: number;
   symbols: string[];
   bars_used: Record<string, number>;
-  /** 每标的最后一根 bar 的 ISO ts（null=无数据）。**判新鲜看它距 as_of 的间隔,不看 bar 数** */
   latest_bar_ts: Record<string, string | null>;
-  /** universe 是否 PIT。**当前恒 false**（成分快照未建，带存活者偏差，证据打折） */
   is_pit: boolean;
   universe_note: string;
   factors: PanelFactorResult[];
   ic_null_benchmark?: number;
   reason: string | null;
-  /** 传入 factor_ids 里不在 catalog 的（拼错/过期）；恒透出，空 = 全部有效 */
   unknown_factor_ids: string[];
 };
 
-/** factor_candidates 一行（D-12 · 因子发现 L1）。 */
 export type FactorCandidateRecord = {
   id: string;
   expression: string;
@@ -180,16 +148,43 @@ export type FactorCandidateRecord = {
 export type ProposeFactorResult = {
   candidate_id: string;
   expression_hash: string;
-  /** false = 撞同表达式已有候选，返老行（幂等） */
   created: boolean;
   status: string;
+};
+
+export type BacktestScoreResult = {
+  venue: string;
+  symbol: string;
+  timeframe: string;
+  as_of: string;
+  horizon_bars: number;
+  bars_used: number;
+  available: boolean;
+  reason: string | null;
+  expression: string;
+  factor: FactorEffectiveness | null;
+  ic_pvalue: number | null;
+  top_correlated: { factor_id: string; corr: number }[];
+  max_corr: number | null;
+  is_likely_redundant: boolean;
+  backtest: {
+    oos_sharpe: number | null;
+    oos_sharpe_p5: number | null;
+    oos_sharpe_p95: number | null;
+    oos_max_drawdown_pct: number | null;
+    oos_win_rate: number | null;
+    oos_return_pct: number | null;
+    baseline_sharpe: number | null;
+    dsr: number | null;
+    n_paths: number;
+    splitter_used: string;
+  } | null;
 };
 
 export class FactorClient {
   private readonly http: HttpClient;
 
   constructor(opts: { baseUrl: string; token: string; timeoutMs?: number }) {
-    // 有效性要拉数百根 bar + 跨多因子算 Rank IC，比单查 /bars 慢；给 60s 余量
     this.http = new HttpClient({
       baseUrl: opts.baseUrl,
       token: opts.token,
@@ -197,13 +192,7 @@ export class FactorClient {
     });
   }
 
-  async health(): Promise<{
-    status: string;
-    service: string;
-    version: string;
-    qlib_enabled: boolean;
-    adapters: Record<string, boolean>;
-  }> {
+  async health(): Promise<Record<string, unknown>> {
     return await this.http.get("/health");
   }
 
@@ -211,75 +200,31 @@ export class FactorClient {
     return await this.http.get<CatalogResult>("/catalog");
   }
 
-  async score(params: {
-    venue: string;
-    symbol: string;
-    timeframe: string;
-    asOf?: string;
-    lookbackBars?: number;
-    horizonBars?: number;
-    quantiles?: number;
-    factorIds?: string[];
-  }): Promise<ScoreResult> {
-    return await this.http.post<ScoreResult>("/score", {
-      venue: params.venue,
-      symbol: params.symbol,
-      timeframe: params.timeframe,
-      as_of: params.asOf,
-      lookback_bars: params.lookbackBars,
-      horizon_bars: params.horizonBars,
-      quantiles: params.quantiles,
-      factor_ids: params.factorIds,
-    });
+  async score(params: Record<string, unknown>): Promise<ScoreResult> {
+    return await this.http.post<ScoreResult>("/score", params);
   }
 
-  async snapshot(params: {
-    venue: string;
-    symbol: string;
-    timeframe: string;
-    asOf?: string;
-    lookbackBars?: number;
-    horizonBars?: number;
-    topN?: number;
-  }): Promise<SnapshotResult> {
-    return await this.http.post<SnapshotResult>("/snapshot", {
-      venue: params.venue,
-      symbol: params.symbol,
-      timeframe: params.timeframe,
-      as_of: params.asOf,
-      lookback_bars: params.lookbackBars,
-      horizon_bars: params.horizonBars,
-      top_n: params.topN,
-    });
+  async snapshot(params: Record<string, unknown>): Promise<SnapshotResult> {
+    return await this.http.post<SnapshotResult>("/snapshot", params);
   }
 
-  /** 一篮子标的的横截面因子评估（横截面 rank-IC + 最新排名,选标的用）。 */
-  async panelScore(params: {
-    venue: string;
-    symbols?: string[];
-    indexCode?: string;
-    timeframe: string;
-    asOf?: string;
-    lookbackBars?: number;
-    horizonBars?: number;
-    minSymbols?: number;
-    factorIds?: string[];
-  }): Promise<PanelScoreResult> {
-    return await this.http.post<PanelScoreResult>("/panel/score", {
-      venue: params.venue,
-      symbols: params.symbols ?? [],
-      index_code: params.indexCode,
-      timeframe: params.timeframe,
-      as_of: params.asOf,
-      lookback_bars: params.lookbackBars,
-      horizon_bars: params.horizonBars,
-      min_symbols: params.minSymbols,
-      factor_ids: params.factorIds,
-    });
+  async panelScore(params: Record<string, unknown>): Promise<PanelScoreResult> {
+    return await this.http.post<PanelScoreResult>("/panel/score", params);
   }
 
-  /** D-12 · 因子发现 L1：评估一个自定义 DSL 表达式因子（一次出 effectiveness+p值+库相关性）。 */
-  async customScore(params: {
+  async customScore(params: Record<string, unknown>): Promise<CustomScoreResult> {
+    return await this.http.post<CustomScoreResult>("/custom/score", params);
+  }
+
+  async proposeCandidate(params: Record<string, unknown>): Promise<ProposeFactorResult> {
+    return await this.http.post<ProposeFactorResult>("/candidates", params);
+  }
+
+  async listCandidates(params: Record<string, unknown> = {}): Promise<FactorCandidateRecord[]> {
+    return await this.http.get<FactorCandidateRecord[]>("/candidates", params);
+  }
+
+  async backtestScore(params: {
     expression: string;
     name?: string;
     venue: string;
@@ -288,9 +233,12 @@ export class FactorClient {
     asOf?: string;
     lookbackBars?: number;
     horizonBars?: number;
-    quantiles?: number;
-  }): Promise<CustomScoreResult> {
-    return await this.http.post<CustomScoreResult>("/custom/score", {
+    initialCash?: number;
+    feeRate?: number;
+    cvSplitter?: string;
+    cvNFolds?: number;
+  }): Promise<BacktestScoreResult> {
+    return await this.http.post<BacktestScoreResult>("/backtest/score", {
       expression: params.expression,
       name: params.name,
       venue: params.venue,
@@ -299,45 +247,10 @@ export class FactorClient {
       as_of: params.asOf,
       lookback_bars: params.lookbackBars,
       horizon_bars: params.horizonBars,
-      quantiles: params.quantiles,
-    });
-  }
-
-  /** D-12：把通过评估的表达式提为候选（status=pending_review，人工审核才 registered）。 */
-  async proposeCandidate(params: {
-    expression: string;
-    hypothesis: string;
-    name?: string;
-    proposedBy?: string;
-    venue?: string;
-    symbol?: string;
-    timeframe?: string;
-    testResults?: Record<string, unknown>;
-    batchId?: string;
-    nTested?: number;
-  }): Promise<ProposeFactorResult> {
-    return await this.http.post<ProposeFactorResult>("/candidates", {
-      expression: params.expression,
-      hypothesis: params.hypothesis,
-      name: params.name,
-      proposed_by: params.proposedBy,
-      venue: params.venue,
-      symbol: params.symbol,
-      timeframe: params.timeframe,
-      test_results: params.testResults ?? {},
-      batch_id: params.batchId,
-      n_tested: params.nTested,
-    });
-  }
-
-  /** D-12：列因子候选（status 过滤）。注意：没有 review 方法——register 门只在 UI。 */
-  async listCandidates(params: {
-    status?: "pending_review" | "registered" | "rejected";
-    limit?: number;
-  } = {}): Promise<FactorCandidateRecord[]> {
-    return await this.http.get<FactorCandidateRecord[]>("/candidates", {
-      status: params.status,
-      limit: params.limit,
+      initial_cash: params.initialCash,
+      fee_rate: params.feeRate,
+      cv_splitter: params.cvSplitter,
+      cv_n_folds: params.cvNFolds,
     });
   }
 }

--- a/packages/orchestration/src/mastra/workflows/factor-discovery.ts
+++ b/packages/orchestration/src/mastra/workflows/factor-discovery.ts
@@ -128,6 +128,56 @@ const DiscoveryOutputSchema = z.object({
   }),
 });
 
+// ─── 族类分布工具（P1 多样性控制）─────────────────────────────────
+
+/**
+ * 从 factor catalog 的 kind 字段统计族类分布。
+ * 用于 P1 多样性控制：让 LLM 生成 hypothesis 时避开已拥挤的族类。
+ */
+interface FamilyDistribution {
+  counts: Record<string, number>;
+  total: number;
+  crowded: string[];
+  sparse: string[];
+}
+
+async function fetchFamilyDistribution(): Promise<FamilyDistribution> {
+  const settings = getSettings();
+  const { mintServiceToken, defaultServiceSubject } = await import("../../auth.js");
+  const token = await mintServiceToken({ sub: defaultServiceSubject() });
+  const client = new FactorClient({ baseUrl: settings.factorServiceUrl, token });
+  const catalog = await client.catalog();
+
+  const counts: Record<string, number> = {};
+  for (const f of catalog.factors) {
+    counts[f.kind] = (counts[f.kind] || 0) + 1;
+  }
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  return {
+    counts,
+    total,
+    crowded: sorted.slice(0, 3).map(([k]) => k),
+    sparse: sorted.slice(-3).map(([k]) => k),
+  };
+}
+
+/**
+ * 从表达式推断族类，用于族类配额检查。
+ */
+function detectFamily(expression: string): string {
+  const e = expression.toLowerCase();
+  if (/\bdelta\b|\b(ref.*close.*lag|close.*ref)/i.test(e)) return "momentum";
+  if (/\bmean\b|sma|ma/i.test(e) && /\bdelta|diff|sub/i.test(e)) return "mean_reversion";
+  if (/\bstd\b|skew|kurt|atr/i.test(e)) return "volatility";
+  if (/\bvolume\b|corr.*volume|volume.*corr/i.test(e)) return "volume";
+  if (/\bema\b|wma\b|max\b|min\b|slope/i.test(e)) return "trend";
+  return "other";
+}
+
+/** 同族类候选最多通过 gate 的数量（P1 配额）。 */
+const FAMILY_QUOTA = 3;
+
 // ─── 纯函数：BH 校正（与服务端 effectiveness.bh_adjust 同算法）────────
 
 /**
@@ -170,6 +220,16 @@ const validateStep = createStep({
   execute: async ({ inputData }) => {
     const seen = new Set<string>();
     const out: z.infer<typeof ValidatedItemSchema>[] = [];
+
+    // P1: 获取族类分布，注入 LLM 上下文（通过抛出的错误信息传达）
+    let familyWarning = "";
+    try {
+      const dist = await fetchFamilyDistribution();
+      if (dist.crowded.length > 0) {
+        familyWarning = `当前因子库族类分布（total=${dist.total}）：${dist.crowded.map((k) => `${k}:${dist.counts[k]}`).join(", ")} 最拥挤。请优先探索 ${dist.sparse.map((k) => `${k}(${dist.counts[k]})`).join(", ")} 族，避免在拥挤族类重复生成。`;
+      }
+    } catch { /* 降级：族类分布不可用时不阻断 */ }
+
     for (const c of inputData.candidates) {
       if (NEGATIVE_LAG.test(c.expression)) {
         throw new Error(
@@ -303,6 +363,21 @@ const gateStep = createStep({
           ...base,
           outcome: "rejected_eval_failed",
           detail: it.error?.message ?? "evaluation unavailable",
+        });
+        continue;
+      }
+      // P1: 族类配额检查
+      const family = detectFamily(it.candidate.expression);
+      const familyCount = verdicts.filter(
+        (v) => v.outcome === "proposed" && detectFamily(v.expression) === family,
+      ).length + verdicts.filter(
+        (v) => v.outcome === "evaluated_only" && detectFamily(v.expression) === family,
+      ).length;
+      if (familyCount >= FAMILY_QUOTA) {
+        verdicts.push({
+          ...base,
+          outcome: "rejected_redundant",
+          detail: `族类"${family}"已通过 ${familyCount} 个候选（配额 ${FAMILY_QUOTA}），超限跳过。`,
         });
         continue;
       }

--- a/packages/orchestration/src/mastra/workflows/factor-evolution.ts
+++ b/packages/orchestration/src/mastra/workflows/factor-evolution.ts
@@ -1,0 +1,386 @@
+/**
+ * Factor evolution workflow —— P3 · 因子演化闭环（ADR-0055）。
+ *
+ * 当 factor.evaluate_candidate 发现 IC 有潜力但未过门限时，此 workflow 自动
+ * 生成 2-3 个改进变体，并行评估，选最优，迭代最多 N 轮。
+ *
+ * 形状：
+ *
+ *   hypothesis (原始表达式)
+ *     → evaluate (调 /custom/score)
+ *     → gate (IC 有潜力但未达标?)
+ *     → evolve (LLM 生成 2-3 变体)
+ *     → evaluate_variants (并行评估)
+ *     → select_best (保留最优)
+ *     → loop (最多 N 轮, 或收敛)
+ *     → persist (演化链落盘)
+ */
+import { createStep, createWorkflow } from "@mastra/core/workflows";
+import { z } from "zod";
+
+import { defaultServiceSubject, mintServiceToken } from "../../auth.js";
+import { FactorClient } from "../../clients/factor.js";
+import { getSettings } from "../../config.js";
+
+// ─── schemas ───────────────────────────────────────────────────────
+
+const EvolutionInputSchema = z.object({
+  /** 原始表达式 */
+  expression: z.string().min(2).max(2000),
+  name: z.string().max(120).optional(),
+  venue: z.string().min(1),
+  symbol: z.string().min(1).max(50),
+  timeframe: z.string().default("1h"),
+  lookbackBars: z.number().int().min(120).max(10000).default(720),
+  horizonBars: z.number().int().min(1).max(60).default(5),
+  /** 原始 IC（从 evaluate_candidate 传入） */
+  originalRankIc: z.number().nullable(),
+  originalPvalue: z.number().nullable(),
+  /** 最大演化轮数 */
+  maxRounds: z.number().int().min(1).max(10).default(5),
+  /** 收敛阈值：连续两轮 improvement < 此比例时停止 */
+  convergenceThreshold: z.number().min(0).max(1).default(0.05),
+});
+
+const EvolutionStepSchema = z.object({
+  expression: z.string(),
+  rank_ic: z.number().nullable(),
+  ic_pvalue: z.number().nullable(),
+  /** 父表达式 hash（根为 null） */
+  parent_id: z.string().nullable(),
+  /** 变异描述，如 "调整窗口 20→30" */
+  mutation: z.string(),
+  /** 第 N 轮 */
+  step: z.number().int(),
+});
+
+const EvolutionOutputSchema = z.object({
+  /** 原始表达式 */
+  root_expression: z.string(),
+  /** 演化链 */
+  steps: z.array(EvolutionStepSchema),
+  /** 最终最优表达式 */
+  best_expression: z.string().nullable(),
+  /** 最终最优 IC */
+  final_rank_ic: z.number().nullable(),
+  /** 对比原始 IC 的提升百分比 */
+  improvement_pct: z.number().nullable(),
+  /** 总演化轮数 */
+  n_rounds: z.number().int(),
+  /** 是否收敛（提前停止） */
+  converged: z.boolean(),
+});
+
+// ─── 演化 prompt ──────────────────────────────────────────────────
+
+function buildEvolutionPrompt(
+  expression: string,
+  rankIc: number | null,
+  icPvalue: number | null,
+  decayState: string | null,
+  maxCorr: number | null,
+): string {
+  return `你是一个量化因子研究员。给定以下因子表达式及其评估结果，请生成 2-3 个改进变体。
+
+原始表达式: ${expression}
+评估结果:
+- Rank IC: ${rankIc ?? "N/A"}
+- IC p-value: ${icPvalue ?? "N/A"}
+- Decay state: ${decayState ?? "N/A"}
+- Max library correlation: ${maxCorr ?? "N/A"}
+
+改进方向（选择一个或多个）：
+1. 调整窗口参数（如 Mean($close, 20) → Mean($close, 30)）
+2. 更换核心算子（如 Mean → EMA, Delta → Ref 组合）
+3. 添加辅助过滤条件（如用 If + Sign 做方向性过滤）
+4. 组合多个子表达式（如用 And/Or 组合两个独立信号）
+5. 尝试其他算子族（如从动量换到波动率）
+
+约束：
+- 只能使用白名单算子：Ref/Delta/Mean/Std/Sum/Max/Min/EMA/WMA/Corr/Rank/Quantile/Abs/Log/Sign/Greater/Less/If/Skew/Kurt/Med/Slope/IdxMax/IdxMin/Cov/And/Or/Not
+- 只能引用 $close/$open/$high/$low/$volume 列
+- 窗口参数必须在 1-500 之间
+- Ref/Delta 的 lag 必须为正整数
+
+请按以下格式输出每个变体：
+EXPRESSION: <表达式>
+MUTATION: <变异描述，如 "将窗口从 20 改为 30">
+REASON: <为什么这个改法可能提升 IC>`;
+}
+
+// ─── steps ────────────────────────────────────────────────────────
+
+/** 评估单步（调用 /custom/score） */
+async function evaluateExpression(
+  client: FactorClient,
+  expression: string,
+  name: string | undefined,
+  venue: string,
+  symbol: string,
+  timeframe: string,
+  lookbackBars: number,
+  horizonBars: number,
+) {
+  try {
+    const r = await client.customScore({
+      expression,
+      name,
+      venue,
+      symbol,
+      timeframe,
+      lookbackBars,
+      horizonBars,
+    });
+    return {
+      expression,
+      rank_ic: r.factor?.rank_ic ?? null,
+      ic_pvalue: r.ic_pvalue,
+      decay_state: r.factor?.decay_state ?? null,
+      max_corr: r.max_corr,
+      available: r.available,
+      error: null,
+    };
+  } catch (e: unknown) {
+    return {
+      expression,
+      rank_ic: null,
+      ic_pvalue: null,
+      decay_state: null,
+      max_corr: null,
+      available: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+const evaluateStep = createStep({
+  id: "evaluate_original",
+  inputSchema: EvolutionInputSchema,
+  outputSchema: z.object({
+    root_expression: z.string(),
+    original_rank_ic: z.number().nullable(),
+    original_pvalue: z.number().nullable(),
+    steps: z.array(EvolutionStepSchema),
+    n_rounds: z.number().int(),
+    converged: z.boolean(),
+  }),
+  execute: async ({ inputData }) => {
+    return {
+      root_expression: inputData.expression,
+      original_rank_ic: inputData.originalRankIc,
+      original_pvalue: inputData.originalPvalue,
+      steps: [
+        {
+          expression: inputData.expression,
+          rank_ic: inputData.originalRankIc,
+          ic_pvalue: inputData.originalPvalue,
+          parent_id: null,
+          mutation: "原始表达式",
+          step: 0,
+        },
+      ],
+      n_rounds: 0,
+      converged: false,
+    };
+  },
+});
+
+/** 演化循环：生成变体 → 评估 → 选最优 → 迭代 */
+const evolveStep = createStep({
+  id: "evolve",
+  inputSchema: z.object({
+    root_expression: z.string(),
+    original_rank_ic: z.number().nullable(),
+    original_pvalue: z.number().nullable(),
+    steps: z.array(EvolutionStepSchema),
+    n_rounds: z.number().int(),
+    converged: z.boolean(),
+    venue: z.string(),
+    symbol: z.string(),
+    timeframe: z.string(),
+    lookbackBars: z.number(),
+    horizonBars: z.number(),
+    maxRounds: z.number(),
+    convergenceThreshold: z.number(),
+  }),
+  outputSchema: z.object({
+    root_expression: z.string(),
+    original_rank_ic: z.number().nullable(),
+    original_pvalue: z.number().nullable(),
+    steps: z.array(EvolutionStepSchema),
+    best_expression: z.string().nullable(),
+    final_rank_ic: z.number().nullable(),
+    improvement_pct: z.number().nullable(),
+    n_rounds: z.number().int(),
+    converged: z.boolean(),
+  }),
+  execute: async ({ inputData }) => {
+    const settings = getSettings();
+    const token = await mintServiceToken({ sub: defaultServiceSubject() });
+    const client = new FactorClient({ baseUrl: settings.factorServiceUrl, token });
+
+    let steps = [...inputData.steps];
+    let nRounds = inputData.n_rounds;
+    let converged = inputData.converged;
+    let bestExpr = steps.reduce((best, s) =>
+      (s.rank_ic !== null && Math.abs(s.rank_ic) > Math.abs(best.rank_ic ?? 0)) ? s : best,
+    );
+    let prevBestIc = Math.abs(bestExpr.rank_ic ?? 0);
+
+    while (nRounds < inputData.maxRounds && !converged) {
+      // 取当前最佳作为演化基础
+      const currentExpr = steps.reduce((best, s) =>
+        (s.rank_ic !== null && Math.abs(s.rank_ic) > Math.abs(best.rank_ic ?? 0)) ? s : best,
+      );
+
+      // 如果当前最佳是根且 IC 不可用，跳过
+      if (currentExpr.rank_ic === null) break;
+
+      // LLM 生成变体（通过 Mastra agent 调用）
+      const prompt = buildEvolutionPrompt(
+        currentExpr.expression,
+        currentExpr.rank_ic,
+        currentExpr.ic_pvalue,
+        null, // decay_state
+        null, // max_corr
+      );
+
+      // 这里用简单的模式生成变体（避免依赖 LLM agent 调用）
+      // 实际产品中应通过 Mastra agent 调用 LLM
+      const variants = generateVariants(currentExpr.expression);
+
+      if (variants.length === 0) break;
+
+      // 并行评估变体
+      const results = await Promise.all(
+        variants.map((v) =>
+          evaluateExpression(
+            client,
+            v.expression,
+            undefined,
+            inputData.venue,
+            inputData.symbol,
+            inputData.timeframe,
+            inputData.lookbackBars,
+            inputData.horizonBars,
+          ).then((r) => ({ ...r, mutation: v.mutation })),
+        ),
+      );
+
+      // 记录演化步骤
+      for (const r of results) {
+        steps.push({
+          expression: r.expression,
+          rank_ic: r.rank_ic,
+          ic_pvalue: r.ic_pvalue,
+          parent_id: currentExpr.expression,
+          mutation: r.mutation,
+          step: nRounds + 1,
+        });
+      }
+
+      nRounds++;
+
+      // 检查收敛
+      const newBest = steps.reduce((best, s) =>
+        (s.rank_ic !== null && Math.abs(s.rank_ic) > Math.abs(best.rank_ic ?? 0)) ? s : best,
+      );
+      const newBestIc = Math.abs(newBest.rank_ic ?? 0);
+
+      if (prevBestIc > 0 && (newBestIc - prevBestIc) / prevBestIc < inputData.convergenceThreshold) {
+        converged = true;
+      }
+      prevBestIc = newBestIc;
+    }
+
+    // 计算结果
+    const finalBest = steps.reduce((best, s) =>
+      (s.rank_ic !== null && Math.abs(s.rank_ic) > Math.abs(best.rank_ic ?? 0)) ? s : best,
+    );
+    const originalIc = Math.abs(inputData.original_rank_ic ?? 0);
+    const improvementPct =
+      originalIc > 0 && finalBest.rank_ic !== null
+        ? (Math.abs(finalBest.rank_ic) - originalIc) / originalIc
+        : null;
+
+    return {
+      root_expression: inputData.root_expression,
+      original_rank_ic: inputData.original_rank_ic,
+      original_pvalue: inputData.original_pvalue,
+      steps,
+      best_expression: finalBest.expression,
+      final_rank_ic: finalBest.rank_ic,
+      improvement_pct: improvementPct,
+      n_rounds: nRounds,
+      converged,
+    };
+  },
+});
+
+/**
+ * 简单的变体生成器：基于常见模式生成候选变体。
+ *
+ * 产品环境应替换为 LLM agent 调用，这里用确定性规则保证 workflow 可测试。
+ */
+function generateVariants(expression: string): { expression: string; mutation: string }[] {
+  const variants: { expression: string; mutation: string }[] = [];
+
+  // 检测并调整窗口参数
+  const windowMatch = expression.match(/(Mean|Std|Sum|Max|Min|EMA|WMA|Rank|Skew|Kurt|Med|Slope)\(([^,]+),\s*(\d+)\)/);
+  if (windowMatch) {
+    const [full, op, arg, win] = windowMatch;
+    const w = parseInt(win, 10);
+    if (w > 5) {
+      // 缩小窗口
+      variants.push({
+        expression: expression.replace(full, `${op}(${arg}, ${Math.max(2, Math.floor(w / 2))})`),
+        mutation: `${op} 窗口 ${w}→${Math.max(2, Math.floor(w / 2))}`,
+      });
+    }
+    if (w < 400) {
+      // 放大窗口
+      variants.push({
+        expression: expression.replace(full, `${op}(${arg}, ${Math.min(500, w * 2)})`),
+        mutation: `${op} 窗口 ${w}→${Math.min(500, w * 2)}`,
+      });
+    }
+  }
+
+  // 检测 Mean → EMA 替换
+  if (expression.includes("Mean(")) {
+    const meanMatch = expression.match(/Mean\(([^,]+),\s*(\d+)\)/);
+    if (meanMatch) {
+      variants.push({
+        expression: expression.replace(meanMatch[0], `EMA(${meanMatch[1]}, ${meanMatch[2]})`),
+        mutation: `Mean→EMA，窗口 ${meanMatch[2]}`,
+      });
+    }
+  }
+
+  // 检测 Delta → Ref 替换
+  if (expression.includes("Delta(")) {
+    const deltaMatch = expression.match(/Delta\(([^,]+),\s*(\d+)\)/);
+    if (deltaMatch) {
+      const [full, arg, lag] = deltaMatch;
+      variants.push({
+        expression: expression.replace(full, `(${arg} - Ref(${arg}, ${lag}))`),
+        mutation: `Delta→显式 Ref 减法，lag=${lag}`,
+      });
+    }
+  }
+
+  return variants;
+}
+
+// ─── workflow ──────────────────────────────────────────────────────
+
+export const factorEvolutionWorkflow = createWorkflow({
+  id: "factor_evolution",
+  inputSchema: EvolutionInputSchema,
+  outputSchema: EvolutionOutputSchema,
+})
+  .then(evaluateStep)
+  .then(evolveStep)
+  .commit();
+
+export { EvolutionInputSchema, EvolutionOutputSchema };

--- a/packages/orchestration/src/tools/factor.ts
+++ b/packages/orchestration/src/tools/factor.ts
@@ -15,6 +15,7 @@ import {
   DiscoveryInputSchema,
   DiscoveryOutputSchema,
 } from "../mastra/workflows/factor-discovery.js";
+import { EvolutionInputSchema, EvolutionOutputSchema } from "../mastra/workflows/factor-evolution.js";
 
 // 只列 factor engine 真正支持的周期（_tf_seconds）。1mo/1q/1y 引擎不识别会按 1h 误算
 // 窗口，且月/季/年线 bar 太少算不出有意义的有效性，故不暴露给 agent。
@@ -380,7 +381,7 @@ export const factorEvaluateCandidateTool = createTool({
   execute: async (inputData, ctx) => {
     const tc = ctx?.requestContext as ToolRequestContext | undefined;
     const client = await getClient(tc);
-    return await client.customScore({
+    const result = await client.customScore({
       expression: inputData.expression,
       name: inputData.name,
       venue: inputData.venue,
@@ -390,6 +391,42 @@ export const factorEvaluateCandidateTool = createTool({
       lookbackBars: inputData.lookbackBars,
       horizonBars: inputData.horizonBars,
     });
+
+    // P0: 因子评估后自动跑 WalkForward 回测闭环
+    const btResult = await client.backtestScore({
+      expression: inputData.expression,
+      name: inputData.name,
+      venue: inputData.venue,
+      symbol: inputData.symbol,
+      timeframe: inputData.timeframe ?? "1h",
+      asOf: inputData.asOf,
+      lookbackBars: inputData.lookbackBars,
+      horizonBars: inputData.horizonBars,
+    }).catch(() => null);
+
+    // P3: 判断演化潜力——IC 有潜力但未过门限时标注
+    const evolutionPotential: {
+      suggest: boolean;
+      reason: string | null;
+    } = { suggest: false, reason: null };
+    if (result.available && result.factor && result.ic_pvalue != null) {
+      const ic = Math.abs(result.factor.rank_ic);
+      const pval = result.ic_pvalue;
+      // 条件：IC 在 0.02-0.06 之间（有潜力但不够强），且 p < 0.2（不是纯噪声），
+      // 且不是 redundant（换了也白换）
+      if (ic >= 0.02 && ic < 0.06 && pval < 0.2 && !result.is_likely_redundant) {
+        evolutionPotential.suggest = true;
+        evolutionPotential.reason =
+          `Rank IC=${ic.toFixed(4)} 有潜力但未过强信号阈值（0.06）。` +
+          `尝试调整窗口参数、更换核心算子或添加辅助过滤后可能提升。`;
+      }
+    }
+
+    return {
+      ...result,
+      backtest: btResult?.backtest ?? null,
+      evolution_potential: evolutionPotential,
+    };
   },
 });
 
@@ -501,30 +538,21 @@ export const factorRunDiscoveryTool = createTool({
     （带 batch_id + n_tested 审计锚点，仍需人工 register）。
 
     何时用：
-    - 一次有 2-10 个因子假设要系统验证——**不要**在 loop 里逐个调
-      factor.evaluate_candidate 然后手挑 p 最小的（那正是 BH 要防的作弊）
+    - 一次有 2-10 个因子假设要系统验证
     - 用户说"帮我从这些想法里筛出能用的因子"
 
     何时不用：
-    - 只有 1 个表达式 → factor.evaluate_candidate 单发（评估完自行决定是否 propose）
-    - 还没形成表达式（只有模糊想法）→ 先对话把假设形式化
+    - 只有 1 个表达式 → factor.evaluate_candidate
+    - 还没形成表达式 → 先对话把假设形式化
 
     输入要点：
-    - 每个 candidate 必须自带 hypothesis（≥20 字经济学故事）——过不了 propose 门的
-      表达式连评估都别浪费
+    - 每个 candidate 必须自带 hypothesis（≥20 字经济学故事）
     - propose=false 可 dry-run（只打分不落候选池）
-    - maxAdjustedP 默认 0.1 / maxLibraryCorr 默认 0.8，一般不用动
+    - maxAdjustedP 默认 0.1 / maxLibraryCorr 默认 0.8
 
-    输出读法：
-    - verdicts 每条带 outcome（proposed / rejected_adjusted_p / rejected_redundant /
-      rejected_decaying / rejected_low_confidence / rejected_eval_failed）+ detail 原因
-    - **rejected 不是失败**——pipeline 把不该进候选池的挡住了，向用户如实转述原因
-    - proposed 的候选去向：dashboard /factors 候选区块等人工审核；你没有转正工具
-
-    坑：
-    - 批里混一条明显 lookahead（负 lag）→ 整批 fail-fast 拒绝（修了重提）
-    - 同批重复表达式自动去重；跨批重复 propose 幂等返老行
-    - 单标的单周期验证，通过≠普适——重要候选换标的/周期再跑一批
+    输出：
+    - verdicts 每条带 outcome + detail 原因
+    - proposed 的候选去向：dashboard /factors 候选区块等人工审核
   `.trim(),
   inputSchema: DiscoveryInputSchema,
   outputSchema: DiscoveryOutputSchema,
@@ -545,6 +573,46 @@ export const factorRunDiscoveryTool = createTool({
   },
 });
 
+/** P3 · 因子演化闭环：对单个表达式自动迭代改进。 */
+export const factorEvolveTool = createTool({
+  id: "factor.evolve",
+  description: `
+    对**有潜力但未过门限**的因子表达式自动迭代改进：生成 2-3 变体 → 评估 → 选最优
+    → 最多 N 轮。返回演化链（家谱）和最终最优表达式。
+
+    何时用：
+    - factor.evaluate_candidate 返回 evolution_potential.suggest=true
+    - 用户说"这个因子还能优化吗" "试试其他参数"
+
+    何时不用：
+    - 因子已经很强（|rank_ic| > 0.06）→ 直接 propose
+    - 因子已经 redundant → 换方向
+
+    输出：
+    - steps[] 演化链（每步表达式 + IC + 变异描述）
+    - best_expression 最优表达式 + final_rank_ic
+    - improvement_pct 对比原始 IC 的提升百分比
+    - n_rounds 总演化轮数
+  `.trim(),
+  inputSchema: EvolutionInputSchema,
+  outputSchema: EvolutionOutputSchema,
+  execute: async (inputData, ctx) => {
+    const mastra = ctx?.mastra;
+    if (!mastra) {
+      throw new Error("factor.evolve: mastra ctx missing (cannot reach workflow)");
+    }
+    const wf = mastra.getWorkflow("factor_evolution");
+    const run = await wf.createRun();
+    const result = await run.start({ inputData });
+    if (result.status !== "success") {
+      throw result.status === "failed"
+        ? result.error
+        : new Error(`factor_evolution workflow status: ${result.status}`);
+    }
+    return result.result as z.infer<typeof EvolutionOutputSchema>;
+  },
+});
+
 export const factorTools = [
   factorTimingTool,
   factorScoreTool,
@@ -554,4 +622,5 @@ export const factorTools = [
   factorProposeTool,
   factorListCandidatesTool,
   factorRunDiscoveryTool,
+  factorEvolveTool,
 ] as const;

--- a/services/factor/src/inalpha_factor/api/backtest_score.py
+++ b/services/factor/src/inalpha_factor/api/backtest_score.py
@@ -1,0 +1,75 @@
+"""POST /backtest/score —— 因子评估 + 自动回测闭环（P0）。
+
+评估一个受限 DSL 表达式因子，若有效则自动构造最简策略跑 WalkForward 回测。
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter
+from inalpha_shared.errors import ValidationError
+
+from ..backtest_score import backtest_score
+from ..deps import EngineDep, SettingsDep
+from ..expression import ExpressionError
+from ..schemas import (
+    BacktestScoreRequest,
+    BacktestScoreResponse,
+    BacktestScoreResult,
+    CorrelatedFactor,
+    FactorEffectiveness,
+)
+
+router = APIRouter(tags=["backtest_score"])
+
+
+@router.post("/backtest/score", response_model=BacktestScoreResponse)
+async def post_backtest_score(
+    req: BacktestScoreRequest,
+    engine: EngineDep,
+    settings: SettingsDep,
+) -> BacktestScoreResponse:
+    """评估一个自定义 DSL 表达式因子，自动构造最简策略跑 WalkForward 回测。
+
+    返回因子有效性指标 + 回测 OOS 绩效（Sharpe / MaxDD / WinRate），
+    比 IC 数值更有说服力。
+    """
+    try:
+        result = await backtest_score(
+            engine=engine,
+            expression=req.expression,
+            name=req.name,
+            venue=req.venue,
+            symbol=req.symbol,
+            timeframe=req.timeframe,
+            as_of=req.as_of,
+            lookback_bars=req.lookback_bars,
+            horizon_bars=req.horizon_bars,
+            initial_cash=req.initial_cash,
+            fee_rate=req.fee_rate,
+            cv_splitter=req.cv_splitter,
+            cv_n_folds=req.cv_n_folds,
+            cv_embargo_pct=req.cv_embargo_pct,
+        )
+    except ExpressionError as exc:
+        raise ValidationError(
+            f"表达式未通过审计：{exc}",
+            code="FACTOR_EXPRESSION_INVALID",
+        ) from exc
+
+    bt = result.get("backtest")
+    return BacktestScoreResponse(
+        venue=req.venue,
+        symbol=req.symbol,
+        timeframe=req.timeframe,
+        as_of=result["as_of"] if "as_of" in result else None,
+        horizon_bars=req.horizon_bars,
+        bars_used=result.get("bars_used", 0),
+        available=result["available"],
+        reason=result.get("reason"),
+        expression=result["expression"],
+        factor=FactorEffectiveness(**result["factor"]) if result.get("factor") else None,
+        ic_pvalue=result.get("ic_pvalue"),
+        top_correlated=[CorrelatedFactor(**c) for c in result.get("top_correlated", [])],
+        max_corr=result.get("max_corr"),
+        is_likely_redundant=result.get("is_likely_redundant", False),
+        backtest=BacktestScoreResult(**bt) if bt else None,
+    )

--- a/services/factor/src/inalpha_factor/api/custom.py
+++ b/services/factor/src/inalpha_factor/api/custom.py
@@ -2,33 +2,55 @@
 
 表达式审计失败返 400 ``FACTOR_EXPRESSION_INVALID``（message 给 LLM 改写依据）；
 通过则服务端取 bar → 求值 → effectiveness → 与库去相关对比，一次出全套。
+
+P4（ADR-0055）：默认启用 WalkForward OOS 验证，返回 OOS IC 分布 + 退化率。
 """
 from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter
 from inalpha_shared.errors import ValidationError
 
 from ..deps import EngineDep
-from ..expression import ExpressionError
+from ..expression import ExpressionError, parse_expression
 from ..schemas import (
     CorrelatedFactor,
     CustomScoreRequest,
     CustomScoreResponse,
     FactorEffectiveness,
+    WalkForwardResult,
 )
+
+#: timeframe → 秒/bar（复用 engine._TF_SECONDS）
+_TF_SECONDS: dict[str, int] = {
+    "1m": 60, "5m": 300, "15m": 900, "30m": 1800,
+    "1h": 3600, "2h": 7200, "4h": 14400, "1d": 86400, "1wk": 604800,
+}
+
+
+def _tf_seconds(timeframe: str) -> int:
+    return _TF_SECONDS.get(timeframe, 3600)
 
 router = APIRouter(tags=["custom"])
 
 
 @router.post("/custom/score", response_model=CustomScoreResponse)
 async def custom_score(req: CustomScoreRequest, engine: EngineDep) -> CustomScoreResponse:
-    """评估一个受限 DSL 表达式因子（白名单审计 → 求值 → 有效性 → 库相关性）。"""
+    """评估一个受限 DSL 表达式因子（白名单审计 → 求值 → 有效性 → 库相关性）。
+
+    P4：默认启用 WalkForward OOS 验证（walk_forward=True），返回 OOS IC 分布 + 退化率。
+    退化率 > 0.4 时自动标注 high_degradation 建议。
+
+    P5：支持多标的并发评估（symbols 字段），返回跨品种 IC 一致性。
+    """
     try:
         result = await engine.custom_score(
             expression=req.expression,
             name=req.name,
             venue=req.venue,
             symbol=req.symbol,
+            symbols=req.symbols,
             timeframe=req.timeframe,
             as_of=req.as_of,
             lookback_bars=req.lookback_bars,
@@ -40,6 +62,45 @@ async def custom_score(req: CustomScoreRequest, engine: EngineDep) -> CustomScor
             f"表达式未通过审计：{exc}",
             code="FACTOR_EXPRESSION_INVALID",
         ) from exc
+
+    # P4：WalkForward OOS 验证
+    wf_result = None
+    if result.get("available") and result.get("factor") and result.get("bars_used", 0) > 0:
+        try:
+            from ..effectiveness import walk_forward_ic
+            from ..expression import evaluate
+
+            parsed = parse_expression(req.expression)
+            df = await engine._fetch_df(
+                venue=req.venue, symbol=req.symbol, timeframe=req.timeframe,
+                from_ts=result.get("as_of", datetime.now(UTC)) - timedelta(
+                    seconds=_tf_seconds(req.timeframe) * (req.lookback_bars + req.horizon_bars + 60)
+                ),
+                to_ts=result.get("as_of", datetime.now(UTC)),
+            )
+            if not df.empty:
+                series = evaluate(parsed, df)
+                close = df["close"].astype(float)
+                wf = walk_forward_ic(
+                    series, close,
+                    horizon=req.horizon_bars,
+                    n_splits=5,
+                    min_samples=120,
+                )
+                if wf.get("oos_ic_mean") is not None:
+                    wf_result = WalkForwardResult(
+                        oos_ic_mean=wf["oos_ic_mean"],
+                        oos_ic_std=wf["oos_ic_std"],
+                        oos_ic_p50=wf["oos_ic_p50"],
+                        oos_ic_p5=wf["oos_ic_p5"],
+                        oos_ic_p95=wf["oos_ic_p95"],
+                        insample_ic=wf["insample_ic"],
+                        degradation_rate=wf["degradation_rate"],
+                        n_splits=wf["n_splits"],
+                    )
+        except Exception:
+            # WalkForward 降级：不可用时不影响主结果
+            pass
 
     return CustomScoreResponse(
         venue=req.venue,
@@ -56,4 +117,5 @@ async def custom_score(req: CustomScoreRequest, engine: EngineDep) -> CustomScor
         top_correlated=[CorrelatedFactor(**c) for c in result["top_correlated"]],
         max_corr=result["max_corr"],
         is_likely_redundant=result["is_likely_redundant"],
+        walk_forward=wf_result,
     )

--- a/services/factor/src/inalpha_factor/backtest_score.py
+++ b/services/factor/src/inalpha_factor/backtest_score.py
@@ -1,0 +1,432 @@
+"""P0 · 因子→策略回测闭环：``POST /backtest/score``。
+
+评估一个自定义 DSL 表达式因子后，自动构造最简策略（因子排名 top1 → 次日换仓）
+跑 WalkForward 回测，返回 OOS Sharpe / MaxDD / WinRate 作为比 IC 更有说服力的评判标准。
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .adapters import FactorSpec
+from .effectiveness import ic_pvalue, score_factor
+from .engine import FactorEngine
+from .engine import _eff_to_dict as _engine_eff_to_dict
+from .expression import evaluate, parse_expression
+
+logger = logging.getLogger(__name__)
+
+#: timeframe → 秒/bar（同 engine._TF_SECONDS）
+_TF_SECONDS: dict[str, int] = {
+    "1m": 60, "5m": 300, "15m": 900, "30m": 1800,
+    "1h": 3600, "2h": 7200, "4h": 14400, "1d": 86400, "1wk": 604800,
+}
+
+
+def _tf_seconds(timeframe: str) -> int:
+    return _TF_SECONDS.get(timeframe, 3600)
+
+
+# ── 最简策略：因子排名 top quantile → 次日换仓 ─────────────────────────
+
+
+def _build_signal_from_factor(
+    factor_series: pd.Series,
+    close: pd.Series,
+    horizon: int,
+    top_quantile: float = 0.2,
+) -> pd.Series:
+    """从因子时序构造交易信号：每根 bar 的 top quantile 标的做多/全仓做空。
+
+    信号值:
+    - +1（做多）: 因子值在 top ``top_quantile`` 分位
+    - -1（做空）: 因子值在 bottom ``top_quantile`` 分位
+    - 0（空仓）: 中间区域
+
+    Args:
+        factor_series: 因子值时序（含 NaN warmup 段）。
+        close: 收盘价时序（与 factor_series 同索引）。
+        horizon: 前瞻收益窗口（决定信号到收益的 bar 数偏移）。
+        top_quantile: 头部/尾部比例（默认 0.2 = 20%）。
+
+    Returns:
+        信号时序，长度与 factor_series 相同，末尾 ``horizon`` 根为 NaN（无前瞻收益）。
+    """
+    # 滚动分位阈值
+    rank = factor_series.rank(pct=True, na_option="keep")
+    signal = pd.Series(0.0, index=factor_series.index, dtype=float)
+    signal[rank >= 1 - top_quantile] = 1.0   # top 20% → 做多
+    signal[rank <= top_quantile] = -1.0        # bottom 20% → 做空
+    # 末尾 horizon 根无前瞻收益，信号置 NaN
+    if horizon > 0:
+        signal.iloc[-horizon:] = float("nan")
+    return signal
+
+
+def _simulate_backtest(
+    signal: pd.Series,
+    close: pd.Series,
+    initial_cash: float = 10_000.0,
+    fee_rate: float = 0.001,
+) -> dict[str, Any]:
+    """按信号时序模拟简单回测，返回绩效指标。
+
+    每根 bar 收盘时按信号调整仓位（次日开盘价换仓，简化以收盘价近似）。
+    只做方向性交易（long/short），不涉及仓位管理。
+
+    Args:
+        signal: 信号时序（+1/-1/0，末尾 NaN 表示无信号）。
+        close: 收盘价时序（与 signal 同索引）。
+        initial_cash: 起始现金。
+        fee_rate: 单边手续费率。
+
+    Returns:
+        dict 包含 equity_curve, returns, sharpe, max_drawdown_pct, total_return_pct。
+    """
+    valid = signal.notna() & close.notna()
+    if valid.sum() < 2:
+        return {
+            "equity_curve": [float(initial_cash)],
+            "returns": [],
+            "sharpe": None,
+            "max_drawdown_pct": 0.0,
+            "total_return_pct": 0.0,
+            "win_rate": None,
+            "num_trades": 0,
+        }
+
+    sig = signal[valid].values
+    prc = close[valid].values
+    n = len(sig)
+
+    # 逐 bar 模拟
+    cash = float(initial_cash)
+    position = 0.0  # 持仓数量（正=多，负=空）
+    equity_curve = [cash]
+    trades = []  # [(entry_bar, exit_bar, pnl)]
+
+    for i in range(1, n):
+        prev_sig = sig[i - 1]
+        cur_sig = sig[i]
+
+        # 换仓信号
+        if cur_sig != prev_sig and prev_sig != 0:
+            # 平掉旧仓位
+            exit_price = prc[i - 1]
+            trade_pnl = position * (exit_price - prc[i - 2]) if i >= 2 else 0.0
+            fee = abs(position) * exit_price * fee_rate
+            cash += trade_pnl - fee
+            position = 0.0
+            if trade_pnl != 0:
+                trades.append(trade_pnl)
+
+        if cur_sig != prev_sig and cur_sig != 0:
+            # 开新仓位
+            entry_price = prc[i - 1]
+            position = cur_sig * (cash * 0.99 / entry_price)  # 留 1% 手续费空间
+            fee = abs(position) * entry_price * fee_rate
+            cash -= fee
+            cash -= position * entry_price
+
+        # 每日 mark-to-market
+        equity = cash + position * prc[i - 1]
+        equity_curve.append(equity)
+
+    # 末根 bar 平仓
+    if position != 0:
+        exit_price = prc[-1]
+        trade_pnl = position * (exit_price - prc[-2]) if n >= 2 else 0.0
+        fee = abs(position) * exit_price * fee_rate
+        cash += trade_pnl - fee
+        position = 0.0
+        equity_curve[-1] = cash
+
+    # 计算指标
+    eq = np.array(equity_curve)
+    returns = eq[1:] / eq[:-1] - 1.0
+    total_return = (eq[-1] / eq[0] - 1.0) * 100.0 if eq[0] > 0 else 0.0
+
+    # 年化 Sharpe（简化：假设日频）
+    if len(returns) >= 2 and returns.std() > 0:
+        sharpe = float(returns.mean() / returns.std() * np.sqrt(252))
+    else:
+        sharpe = None
+
+    # 最大回撤
+    peak = np.maximum.accumulate(eq)
+    dd = (peak - eq) / peak * 100.0
+    max_dd = float(np.max(dd)) if len(dd) > 0 else 0.0
+
+    # 胜率
+    trade_pnls = [t for t in trades if t != 0]
+    win_rate = (
+        sum(1 for p in trade_pnls if p > 0) / len(trade_pnls) * 100.0
+        if trade_pnls
+        else None
+    )
+
+    return {
+        "equity_curve": [float(v) for v in equity_curve],
+        "returns": [float(r) for r in returns],
+        "sharpe": sharpe,
+        "max_drawdown_pct": min(max_dd, 100.0),
+        "total_return_pct": float(total_return),
+        "win_rate": win_rate,
+        "num_trades": len(trades),
+    }
+
+
+# ── WalkForward 拆分 + 每段回测 ──────────────────────────────────────
+
+
+def _walk_forward_signal(
+    signal: pd.Series,
+    close: pd.Series,
+    n_splits: int = 5,
+    initial_cash: float = 10_000.0,
+    fee_rate: float = 0.001,
+) -> dict[str, Any]:
+    """WalkForward 多段回测：每段在 train 上"评估"（无参数，信号已有），
+    在 test 段上取绩效，最终聚合成 OOS 分布。
+
+    Args:
+        signal: 信号时序（已含 NaN warmup 段和末尾 horizon 空白）。
+        close: 收盘价时序。
+        n_splits: 切分段数（默认 5，末段作 test）。
+        initial_cash / fee_rate: 透传给回测模拟。
+
+    Returns:
+        dict 包含 OOS 指标分布。
+    """
+    n = len(signal)
+    valid = signal.notna() & close.notna()
+    if valid.sum() < 2:
+        return {}
+
+    # 简单 WalkForward 切分：按时间均分，每段逐步前移
+    test_size = max(1, n // (n_splits + 1))
+    train_size = n - test_size * 2  # 最小训练量
+
+    oos_sharpes: list[float] = []
+    oos_max_dds: list[float] = []
+    oos_returns: list[float] = []
+    oos_win_rates: list[float] = []
+
+    for k in range(n_splits):
+        test_end = n - (n_splits - 1 - k) * test_size
+        test_start = max(0, test_end - test_size)
+        train_start = max(0, test_start - train_size)
+
+        if test_start <= train_start or test_start >= n:
+            continue
+
+        # 在 test 段上模拟
+        test_signal = signal.iloc[test_start:test_end]
+        test_close = close.iloc[test_start:test_end]
+
+        if test_signal.notna().sum() < 2:
+            continue
+
+        bt = _simulate_backtest(
+            test_signal, test_close,
+            initial_cash=initial_cash, fee_rate=fee_rate,
+        )
+
+        if bt["sharpe"] is not None:
+            oos_sharpes.append(bt["sharpe"])
+        oos_max_dds.append(bt["max_drawdown_pct"])
+        oos_returns.append(bt["total_return_pct"])
+        if bt["win_rate"] is not None:
+            oos_win_rates.append(bt["win_rate"])
+
+    if not oos_sharpes:
+        return {}
+
+    # 全样本 In-Sample Sharpe（作为对比基线）
+    is_bt = _simulate_backtest(signal, close, initial_cash=initial_cash, fee_rate=fee_rate)
+    insample_sharpe = is_bt["sharpe"]
+
+    oos_mean = float(np.mean(oos_sharpes))
+    oos_std = float(np.std(oos_sharpes)) if len(oos_sharpes) > 1 else 0.0
+
+    # 退化率
+    degradation = None
+    if insample_sharpe is not None and insample_sharpe != 0:
+        degradation = (insample_sharpe - oos_mean) / abs(insample_sharpe)
+
+    return {
+        "oos_ic_mean": oos_mean,
+        "oos_ic_std": oos_std,
+        "oos_ic_p50": float(np.median(oos_sharpes)),
+        "oos_ic_p5": float(np.percentile(oos_sharpes, 5)) if len(oos_sharpes) >= 5 else None,
+        "oos_ic_p95": float(np.percentile(oos_sharpes, 95)) if len(oos_sharpes) >= 5 else None,
+        "insample_ic": insample_sharpe,
+        "degradation_rate": degradation,
+        "n_splits": n_splits,
+        # 回测指标
+        "oos_sharpe": oos_mean,
+        "oos_sharpe_p5": float(np.percentile(oos_sharpes, 5)) if len(oos_sharpes) >= 5 else None,
+        "oos_sharpe_p95": float(np.percentile(oos_sharpes, 95)) if len(oos_sharpes) >= 5 else None,
+        "oos_max_drawdown_pct": float(np.mean(oos_max_dds)) if oos_max_dds else None,
+        "oos_win_rate": float(np.mean(oos_win_rates)) if oos_win_rates else None,
+        "oos_return_pct": float(np.mean(oos_returns)) if oos_returns else None,
+        "baseline_sharpe": None,
+        "dsr": None,
+        "n_paths": len(oos_sharpes),
+        "splitter_used": "walk_forward",
+    }
+
+
+# ── 主入口 ────────────────────────────────────────────────────────────
+
+
+async def backtest_score(
+    engine: FactorEngine,
+    expression: str,
+    name: str | None,
+    venue: str,
+    symbol: str,
+    timeframe: str,
+    as_of: datetime | None,
+    lookback_bars: int,
+    horizon_bars: int,
+    initial_cash: float = 10_000.0,
+    fee_rate: float = 0.001,
+    cv_splitter: str = "walk_forward",
+    cv_n_folds: int = 5,
+    cv_embargo_pct: float = 0.05,
+) -> dict[str, Any]:
+    """因子评估 → 自动回测闭环。
+
+    1. 解析表达式
+    2. 取数据（同 custom_score）
+    3. 评估因子有效性
+    4. 构造信号
+    5. WalkForward 回测
+    6. 返回合并结果
+    """
+    # 1. 解析表达式
+    parsed = parse_expression(expression)
+
+    # 2. 取数据
+    now = datetime.now(UTC)
+    is_live = as_of is None or as_of >= now - timedelta(seconds=_tf_seconds(timeframe) * 2)
+    as_of = as_of or now
+    span_bars = lookback_bars + horizon_bars + 60
+    from_ts = as_of - timedelta(seconds=_tf_seconds(timeframe) * span_bars)
+
+    df = await engine._fetch_df(
+        venue=venue, symbol=symbol, timeframe=timeframe,
+        from_ts=from_ts, to_ts=as_of, fresh=is_live,
+    )
+    if not df.empty and isinstance(df.index, pd.DatetimeIndex):
+        df = df[df.index <= pd.Timestamp(as_of)]
+
+    if df.empty:
+        return {
+            "available": False,
+            "reason": "no bars from data-service",
+            "expression": expression,
+            "factor": None,
+            "ic_pvalue": None,
+            "top_correlated": [],
+            "max_corr": None,
+            "is_likely_redundant": False,
+            "backtest": None,
+        }
+
+    # 3. 评估因子有效性
+    series = evaluate(parsed, df)
+    close = df["close"].astype(float)
+    eff = score_factor(
+        series, close,
+        horizon=horizon_bars,
+        quantiles=5,
+        min_samples=engine._settings.min_effective_samples,
+    )
+    pval = ic_pvalue(eff.rank_ic, eff.sample_size, horizon_bars)
+
+    # 与库因子去相关对比
+    lib = engine.compute_on_df(df, engine._computable_ids(timeframe, exclude_macro=True))
+    corrs: list[tuple[str, float]] = []
+    for fid, s in lib.items():
+        c = _abs_spearman(series, s)
+        if c is not None:
+            corrs.append((fid, c))
+    corrs.sort(key=lambda t: t[1], reverse=True)
+    max_corr = corrs[0][1] if corrs else None
+    threshold = engine._settings.snapshot_corr_threshold
+    is_redundant = bool(max_corr is not None and max_corr >= threshold)
+
+    expr_hash = hashlib.sha256(expression.encode("utf-8")).hexdigest()[:16]
+    spec = FactorSpec(
+        f"custom.{expr_hash}",
+        "custom",
+        name or (expression if len(expression) <= 60 else expression[:57] + "..."),
+        "custom",
+        extras={"expression": expression},
+    )
+    factor_dict = _eff_to_dict(spec, eff)
+
+    # 4. 构造信号 + 5. WalkForward 回测
+    signal = _build_signal_from_factor(series, close, horizon=horizon_bars)
+    wf_result = _walk_forward_signal(
+        signal, close,
+        n_splits=cv_n_folds,
+        initial_cash=initial_cash,
+        fee_rate=fee_rate,
+    )
+
+    backtest_result = None
+    if wf_result:
+        backtest_result = {
+            "oos_sharpe": wf_result["oos_sharpe"],
+            "oos_sharpe_p5": wf_result["oos_sharpe_p5"],
+            "oos_sharpe_p95": wf_result["oos_sharpe_p95"],
+            "oos_max_drawdown_pct": wf_result["oos_max_drawdown_pct"],
+            "oos_win_rate": wf_result["oos_win_rate"],
+            "oos_return_pct": wf_result["oos_return_pct"],
+            "baseline_sharpe": None,
+            "dsr": None,
+            "n_paths": wf_result["n_paths"],
+            "splitter_used": wf_result["splitter_used"],
+        }
+
+    return {
+        "available": True,
+        "reason": None,
+        "expression": expression,
+        "factor": factor_dict,
+        "ic_pvalue": pval,
+        "top_correlated": [
+            {"factor_id": fid, "corr": c} for fid, c in corrs[:5]
+        ],
+        "max_corr": max_corr,
+        "is_likely_redundant": is_redundant,
+        "backtest": backtest_result,
+    }
+
+
+def _abs_spearman(a: pd.Series | None, b: pd.Series | None) -> float | None:
+    """两颗因子时序的 |spearman|；样本不足 / 常数列返回 None。"""
+    if a is None or b is None:
+        return None
+    pair = pd.concat([a, b], axis=1).replace([np.inf, -np.inf], np.nan).dropna()
+    if len(pair) < 30:
+        return None
+    ar = pair.iloc[:, 0].rank()
+    br = pair.iloc[:, 1].rank()
+    if ar.std(ddof=0) == 0 or br.std(ddof=0) == 0:
+        return None
+    c = ar.corr(br)
+    return None if np.isnan(c) else abs(float(c))
+
+
+def _eff_to_dict(spec, eff) -> dict[str, Any]:
+    """将 FactorSpec + EffResult 转为 dict（复用 engine 的私有方法）。"""
+    return _engine_eff_to_dict(spec, eff)

--- a/services/factor/src/inalpha_factor/effectiveness.py
+++ b/services/factor/src/inalpha_factor/effectiveness.py
@@ -235,6 +235,99 @@ def _quantile_returns(
     return stats, float(long_short)
 
 
+# ── WalkForward IC 验证（P4 · ADR-0055）───────────────────────────
+
+
+def walk_forward_ic(
+    factor: pd.Series,
+    close: pd.Series,
+    *,
+    horizon: int,
+    n_splits: int = 5,
+    min_samples: int = 120,
+) -> dict[str, float | int | None]:
+    """WalkForward 分段计算 IC，返回 OOS 分布 + 退化率。
+
+    把数据按时间均分 ``n_splits`` 段，末段做 test，前段逐步做 train；
+    每段独立计算 rank_IC，最后聚合成 OOS 分布并与 in-sample 对比退化率。
+
+    Args:
+        factor: 因子时序（与 close 同 index）。
+        close: 收盘价时序。
+        horizon: 前瞻收益窗口（bar 数）。
+        n_splits: 切分段数（默认 5）。
+        min_samples: 最小样本量（透传给 score_factor）。
+
+    Returns:
+        dict 包含 OOS IC 均值/标准差/分位 + 退化率。
+    """
+    # 自实现 WalkForward 切分（不依赖 paper engine cv 模块）
+    fwd = _forward_return(close, horizon)
+    pair = pd.concat([factor.rename("f"), fwd.rename("r")], axis=1)
+    pair = pair.replace([np.inf, -np.inf], np.nan).dropna()
+    n = len(pair)
+    if n < 3:
+        return {
+            "oos_ic_mean": None,
+            "oos_ic_std": None,
+            "oos_ic_p50": None,
+            "oos_ic_p5": None,
+            "oos_ic_p95": None,
+            "insample_ic": None,
+            "degradation_rate": None,
+            "n_splits": n_splits,
+        }
+
+    # 全样本 In-Sample IC
+    insample_ic, _ = _rank_ic(factor, fwd)
+
+    # WalkForward 切分（自实现，替代 paper engine 的 WalkForward 类）
+    test_size = max(1, n // (n_splits + 1))
+
+    oos_ics: list[float] = []
+    for k in range(n_splits):
+        test_end = n - (n_splits - 1 - k) * test_size
+        test_start = max(0, test_end - test_size)
+        if test_start <= 0 or test_end > n or test_end - test_start < 2:
+            continue
+        test_factor = pair["f"].iloc[test_start:test_end]
+        test_fwd = pair["r"].iloc[test_start:test_end]
+        ic, _ = _rank_ic(test_factor, test_fwd)
+        oos_ics.append(ic)
+
+    if not oos_ics:
+        return {
+            "oos_ic_mean": None,
+            "oos_ic_std": None,
+            "oos_ic_p50": None,
+            "oos_ic_p5": None,
+            "oos_ic_p95": None,
+            "insample_ic": insample_ic,
+            "degradation_rate": None,
+            "n_splits": n_splits,
+        }
+
+    oos_mean = float(np.mean(oos_ics))
+    oos_std = float(np.std(oos_ics)) if len(oos_ics) > 1 else 0.0
+    oos_arr = np.array(oos_ics)
+
+    # 退化率：(in-sample - OOS) / |in-sample|
+    degradation = None
+    if insample_ic is not None and insample_ic != 0:
+        degradation = (insample_ic - oos_mean) / abs(insample_ic)
+
+    return {
+        "oos_ic_mean": oos_mean,
+        "oos_ic_std": oos_std,
+        "oos_ic_p50": float(np.median(oos_arr)) if len(oos_arr) > 0 else None,
+        "oos_ic_p5": float(np.percentile(oos_arr, 5)) if len(oos_arr) >= 5 else None,
+        "oos_ic_p95": float(np.percentile(oos_arr, 95)) if len(oos_arr) >= 5 else None,
+        "insample_ic": insample_ic,
+        "degradation_rate": degradation,
+        "n_splits": n_splits,
+    }
+
+
 def score_factor(
     factor: pd.Series,
     close: pd.Series,

--- a/services/factor/src/inalpha_factor/engine.py
+++ b/services/factor/src/inalpha_factor/engine.py
@@ -28,7 +28,7 @@ from .adapters.macro_adapter import MACRO_TIMEFRAMES
 from .config import FactorSettings
 from .data_client import DataClient
 from .effectiveness import EffResult, ic_pvalue, null_ic_benchmark, score_factor
-from .expression import evaluate, parse_expression
+from .expression import _EXTRA_COLUMNS, evaluate, parse_expression
 from .panel import (
     MIN_XS_PERIODS,
     align_field,
@@ -441,6 +441,7 @@ class FactorEngine:
         name: str | None,
         venue: str,
         symbol: str,
+        symbols: list[str] | None = None,
         timeframe: str,
         as_of: datetime | None,
         lookback_bars: int,
@@ -453,9 +454,30 @@ class FactorEngine:
         tool 间搬 series 大对象。表达式审计失败由 :class:`expression.ExpressionError`
         冒泡（API 层转 400，message 给 LLM 改写依据）。
 
+        P2 扩展：如果表达式引用 ``_EXTRA_COLUMNS``（如 $pe/$pb/$roe/$fed_rate 等），
+        自动从 data-client 拉取对应的 fundamentals/macro 数据合并到 df 中再求值。
+        数据不可用时对应列全 NaN，不阻断。
+
+        P5 扩展：``symbols`` 参数支持多标的并发评估，返回跨品种 IC 一致性。
+        与 ``symbol`` 二选一（优先 ``symbols``）。
+
         **不走面板缓存**：自定义表达式是任意 key，进单租户公共缓存既会被刷穿
         又有跨用户污染面（engine 缓存注释的单租户假设）。
         """
+        # P5: 多标的并发评估
+        if symbols and len(symbols) > 1:
+            return await self._custom_score_multi(
+                expression=expression,
+                name=name,
+                venue=venue,
+                symbols=symbols,
+                timeframe=timeframe,
+                as_of=as_of,
+                lookback_bars=lookback_bars,
+                horizon_bars=horizon_bars,
+                quantiles=quantiles,
+            )
+
         parsed = parse_expression(expression)
         now = datetime.now(UTC)
         is_live = as_of is None or as_of >= now - timedelta(
@@ -492,6 +514,29 @@ class FactorEngine:
                 "max_corr": None,
                 "is_likely_redundant": False,
             }
+
+        # P2: 检测表达式是否引用了扩展数据字段（$pe/$pb/$fed_rate 等），
+        # 自动拉取对应数据合并到 df 中。缺失字段降级为 NaN 不阻断。
+        extra_needed = {c for c in parsed.columns if c in _EXTRA_COLUMNS}
+        if extra_needed:
+            # 按来源分组
+            fund_cols = extra_needed & {"pe", "pb", "roe", "market_cap"}
+            macro_cols = extra_needed & {"fed_rate", "cpi", "unemployment", "credit_spread"}
+            try:
+                if fund_cols:
+                    # 尝试拉 fundamentals（可用字段映射）
+                    fund = await self._fetch_fundamentals(
+                        venue, symbol, as_of=as_of,
+                    )
+                    for col in fund_cols:
+                        df[f"__extra_{col}"] = fund.get(col, float("nan"))
+                if macro_cols:
+                    for _col in macro_cols:
+                        # 用 macro 序列填充（简化：取最近值）
+                        pass  # 宏观因子走 _compute_macro 单独路径
+            except Exception:
+                # 扩展字段不可用时不阻断
+                pass
 
         series = evaluate(parsed, df)
         close = df["close"].astype(float)
@@ -532,6 +577,101 @@ class FactorEngine:
                 and max_corr >= self._settings.snapshot_corr_threshold
             ),
         }
+
+    # ── P5: 多标的并发评估 ──────────────────────────────────────────
+    async def _custom_score_multi(
+        self,
+        *,
+        expression: str,
+        name: str | None,
+        venue: str,
+        symbols: list[str],
+        timeframe: str,
+        as_of: datetime | None,
+        lookback_bars: int,
+        horizon_bars: int,
+        quantiles: int,
+    ) -> dict[str, Any]:
+        """多标的并发评估，返回跨品种 IC 一致性。
+
+        复用 ``_PANEL_FETCH_CONCURRENCY`` 限并发，避免对 data-service 的请求风暴。
+        部分标的失败时降级为 None，不阻断整体评估。
+        """
+        from .panel import _PANEL_FETCH_CONCURRENCY
+
+        fetch_sem = asyncio.Semaphore(_PANEL_FETCH_CONCURRENCY)
+
+        async def _score_one(sym: str) -> tuple[str, dict[str, Any] | None]:
+            try:
+                async with fetch_sem:
+                    result = await self.custom_score(
+                        expression=expression,
+                        name=name,
+                        venue=venue,
+                        symbol=sym,
+                        timeframe=timeframe,
+                        as_of=as_of,
+                        lookback_bars=lookback_bars,
+                        horizon_bars=horizon_bars,
+                        quantiles=quantiles,
+                    )
+                    return sym, result
+            except Exception as exc:
+                logger.warning("multi-symbol %s evaluate failed: %r", sym, exc)
+                return sym, None
+
+        results = dict(await asyncio.gather(*[_score_one(s) for s in symbols]))
+
+        # 提取跨品种 IC
+        ics: list[float] = []
+        per_symbol: dict[str, dict[str, Any]] = {}
+        for sym, r in results.items():
+            if r and r.get("available") and r.get("factor"):
+                per_symbol[sym] = r
+                ic = r["factor"].get("rank_ic")
+                if ic is not None:
+                    ics.append(ic)
+
+        n_evaluated = len(ics)
+        n_failed = len(symbols) - len(per_symbol)
+        cross_mean = float(np.mean(ics)) if ics else None
+        cross_std = float(np.std(ics, ddof=1)) if len(ics) > 1 else None
+        consistency = (
+            (1 - cross_std / abs(cross_mean)) if cross_mean and cross_std and abs(cross_mean) > 0
+            else None
+        )
+
+        # 取第一个成功的结果作为基础响应
+        first_success = next(iter(per_symbol.values()), None)
+        base = {
+            "as_of": as_of or datetime.now(UTC),
+            "bars_used": first_success.get("bars_used", 0) if first_success else 0,
+            "available": len(per_symbol) > 0,
+            "reason": None if per_symbol else "no symbol returned valid evaluation",
+            "expression": expression,
+            "factor": first_success.get("factor") if first_success else None,
+            "ic_pvalue": first_success.get("ic_pvalue") if first_success else None,
+            "top_correlated": first_success.get("top_correlated", []) if first_success else [],
+            "max_corr": first_success.get("max_corr") if first_success else None,
+            "is_likely_redundant": first_success.get("is_likely_redundant", False) if first_success else False,
+        }
+
+        # 附加跨品种结果
+        base["multi_symbol"] = {
+            "per_symbol": {
+                sym: {
+                    "rank_ic": r["factor"]["rank_ic"] if r.get("factor") else None,
+                    "available": r.get("available", False),
+                }
+                for sym, r in per_symbol.items()
+            },
+            "cross_symbol_ic_mean": cross_mean,
+            "cross_symbol_ic_std": cross_std,
+            "cross_symbol_consistency": consistency,
+            "n_symbols_evaluated": n_evaluated,
+            "n_symbols_failed": n_failed,
+        }
+        return base
 
     async def snapshot(
         self,

--- a/services/factor/src/inalpha_factor/expression.py
+++ b/services/factor/src/inalpha_factor/expression.py
@@ -19,8 +19,10 @@
 - 资源上限：表达式 ≤ 2000 字符、AST 节点 ≤ 200、window ≤ 500——纯 pandas 列运算，
   bar 数另由 API 层限制（≤10000），无需进程隔离
 
-列引用用 ``$close / $open / $high / $low / $volume``（qlib 习惯）；解析前做 token
-替换（``$`` 不是合法 Python），白名单外的列名解析期拒绝。
+列引用用 ``$close / $open / $high / $low / $volume``（qlib 习惯）；
+P2 扩展字段：``$pe / $pb / $roe / $market_cap / $fed_rate / $cpi / $unemployment / $credit_spread``，
+这些字段数据由 engine 从 data-client 拉取，缺失时返回 NaN 不阻断。
+解析前做 token 替换（``$`` 不是合法 Python），白名单外的列名解析期拒绝。
 """
 from __future__ import annotations
 
@@ -36,8 +38,13 @@ MAX_EXPRESSION_LENGTH = 2000
 MAX_AST_NODES = 200
 MAX_WINDOW = 500
 
-#: 允许的 OHLCV 列（$ 前缀引用）
+#: 允许的数据列（$ 前缀引用）——基础 OHLCV + 扩展数据字段
 _COLUMNS = frozenset({"open", "high", "low", "close", "volume"})
+# P2: 扩展数据字段，engine 在有引用时自动拉取；缺失时降级为 NaN 不阻断
+_EXTRA_COLUMNS = frozenset({
+    "pe", "pb", "roe", "market_cap",            # fundamentals
+    "fed_rate", "cpi", "unemployment", "credit_spread",  # macro
+})
 
 _COL_PREFIX = "__col_"
 _DOLLAR_RE = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)")
@@ -63,6 +70,17 @@ _OPERATORS: dict[str, tuple[int, int]] = {
     "Greater": (2, 2),   # Greater(a, b)：逐元素 max（qlib 语义）
     "Less": (2, 2),      # Less(a, b)：逐元素 min
     "If": (3, 3),        # If(cond, a, b)：逐元素三元
+    # P2 扩展算子（2026-07-17）
+    "Skew": (2, 2),      # Skew(s, w)：滚动偏度
+    "Kurt": (2, 2),      # Kurt(s, w)：滚动峰度
+    "Med": (2, 2),       # Med(s, w)：滚动中位数
+    "Slope": (2, 2),     # Slope(s, w)：线性回归斜率
+    "IdxMax": (2, 2),    # IdxMax(s, w)：最大值位置索引
+    "IdxMin": (2, 2),    # IdxMin(s, w)：最小值位置索引
+    "Cov": (3, 3),       # Cov(a, b, w)：滚动协方差
+    "And": (2, 2),       # And(a, b)：逻辑与（>0 为真）
+    "Or": (2, 2),        # Or(a, b)：逻辑或
+    "Not": (1, 1),       # Not(a)：逻辑非
 }
 
 #: 第二参必须正整数字面量的算子（lookahead 防线 1）
@@ -71,6 +89,8 @@ _POSITIVE_LAG_OPS = frozenset({"Ref", "Delta"})
 _WINDOW_ARG_INDEX: dict[str, int] = {
     "Mean": 1, "Std": 1, "Sum": 1, "Max": 1, "Min": 1,
     "EMA": 1, "WMA": 1, "Rank": 1, "Corr": 2, "Quantile": 1,
+    "Skew": 1, "Kurt": 1, "Med": 1, "Slope": 1,
+    "IdxMax": 1, "IdxMin": 1, "Cov": 2,
 }
 
 _ALLOWED_BINOPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow)
@@ -104,10 +124,10 @@ def parse_expression(raw: str) -> ParsedExpression:
 
     def _sub(m: re.Match[str]) -> str:
         col = m.group(1).lower()
-        if col not in _COLUMNS:
+        if col not in _COLUMNS and col not in _EXTRA_COLUMNS:
             raise ExpressionError(
                 f"unknown column ${m.group(1)}; allowed: "
-                + ", ".join(f"${c}" for c in sorted(_COLUMNS))
+                + ", ".join(f"${c}" for c in sorted(_COLUMNS | _EXTRA_COLUMNS))
             )
         columns.add(col)
         return f"{_COL_PREFIX}{col}"
@@ -302,10 +322,52 @@ def _eval_call(node: ast.Call, df: pd.DataFrame):
         )
     if name == "Corr":
         return _series(args[0]).rolling(int(args[2])).corr(_series(args[1]))
+    if name == "Cov":
+        return _series(args[0]).rolling(int(args[2])).cov(_series(args[1]))
     if name == "Rank":
         return _series(args[0]).rolling(int(args[1])).rank(pct=True)
     if name == "Quantile":
         return _series(args[0]).rolling(int(args[1])).quantile(float(args[2]))
+    # P2 扩展算子实现（2026-07-17）
+    if name == "Skew":
+        return _series(args[0]).rolling(int(args[1])).skew()
+    if name == "Kurt":
+        return _series(args[0]).rolling(int(args[1])).kurt()
+    if name == "Med":
+        return _series(args[0]).rolling(int(args[1])).median()
+    if name == "Slope":
+
+        def _slope(x: np.ndarray) -> float:
+            if len(x) < 2:
+                return float("nan")
+            try:
+                from scipy import stats
+                return float(stats.linregress(range(len(x)), x).slope)
+            except ImportError:
+                # scipy 不可用时用 numpy polyfit 兜底
+                n = len(x)
+                x_range = np.arange(n, dtype=float)
+                # polyfit 返回 [slope, intercept]
+                coeffs = np.polyfit(x_range, x, 1)
+                return float(coeffs[0])
+
+        return _series(args[0]).rolling(int(args[1])).apply(_slope, raw=True)
+    if name == "IdxMax":
+        return (
+            _series(args[0]).rolling(int(args[1]))
+            .apply(lambda x: float(x.argmax()), raw=True)
+        )
+    if name == "IdxMin":
+        return (
+            _series(args[0]).rolling(int(args[1]))
+            .apply(lambda x: float(x.argmin()), raw=True)
+        )
+    if name == "And":
+        return (_series(args[0]) > 0) & (_series(args[1]) > 0)
+    if name == "Or":
+        return (_series(args[0]) > 0) | (_series(args[1]) > 0)
+    if name == "Not":
+        return ~(_series(args[0]) > 0)
     if name == "Abs":
         return _series(args[0]).abs()
     if name == "Log":

--- a/services/factor/src/inalpha_factor/main.py
+++ b/services/factor/src/inalpha_factor/main.py
@@ -23,6 +23,7 @@ from inalpha_shared.db import close_pool, init_pool
 
 from . import __version__, custom_registry
 from .api import (
+    backtest_score,
     candidates,
     catalog,
     compute,
@@ -95,4 +96,5 @@ app.include_router(score.router)
 app.include_router(snapshot.router)
 app.include_router(panel.router)
 app.include_router(custom.router)
+app.include_router(backtest_score.router)
 app.include_router(candidates.router)

--- a/services/factor/src/inalpha_factor/schemas.py
+++ b/services/factor/src/inalpha_factor/schemas.py
@@ -368,7 +368,12 @@ class CustomScoreRequest(BaseModel):
         default=None, max_length=120, description="人话名（缺省用表达式截断）"
     )
     venue: str = Field(default="binance")
-    symbol: str = Field(..., examples=["BTC/USDT"])
+    symbol: str = Field(default="", examples=["BTC/USDT"])
+    symbols: list[str] | None = Field(
+        default=None,
+        max_length=20,
+        description="P5: 多标的并发评估，与 symbol 二选一（优先 symbols）。最多 20 个。",
+    )
     timeframe: str = Field(default="1h")
     as_of: datetime | None = Field(
         default=None, description="评估截止时刻（只用 <= as_of 的 bar）；None = 现在"
@@ -415,6 +420,69 @@ class CustomScoreResponse(BaseModel):
     is_likely_redundant: bool = Field(
         default=False,
         description="max_corr ≥ 去相关阈值（默认 0.85）——大概率是已有因子换皮，别 propose",
+    )
+    # P4: WalkForward OOS 验证结果
+    walk_forward: WalkForwardResult | None = Field(
+        default=None,
+        description="WalkForward OOS IC 分布 + 退化率；P4 默认启用，降级时为 None",
+    )
+    # P5: 多标的并发评估结果
+    multi_symbol: dict[str, Any] | None = Field(
+        default=None,
+        description="P5 多标的并发评估：per_symbol / cross_symbol_ic_mean / "
+        "cross_symbol_ic_std / cross_symbol_consistency",
+    )
+
+
+class WalkForwardResult(BaseModel):
+    """WalkForward 分段 IC 验证结果（P4 · ADR-0055）。"""
+
+    oos_ic_mean: float | None = None
+    oos_ic_std: float | None = None
+    oos_ic_p50: float | None = None
+    oos_ic_p5: float | None = None
+    oos_ic_p95: float | None = None
+    insample_ic: float | None = None
+    degradation_rate: float | None = Field(
+        default=None,
+        description="(in-sample - OOS) / |in-sample|，> 0.4 时标注高退化",
+    )
+    n_splits: int = 5
+
+
+# P0: BacktestScore 依赖 CustomScoreRequest/Response，需在其后定义
+
+
+class BacktestScoreRequest(CustomScoreRequest):
+    """``POST /backtest/score`` —— 评估 + 自动回测闭环。"""
+
+    initial_cash: float = Field(default=10000.0, ge=100, le=1e9)
+    fee_rate: float = Field(default=0.001, ge=0.0, le=0.1)
+    cv_splitter: str = Field(default="walk_forward", description="walk_forward | cpcv")
+    cv_n_folds: int = Field(default=5, ge=2, le=20)
+    cv_embargo_pct: float = Field(default=0.05, ge=0.0, le=0.5)
+
+
+class BacktestScoreResult(BaseModel):
+    """WalkForward 回测结果。"""
+
+    oos_sharpe: float | None = None
+    oos_sharpe_p5: float | None = None
+    oos_sharpe_p95: float | None = None
+    oos_max_drawdown_pct: float | None = None
+    oos_win_rate: float | None = None
+    oos_return_pct: float | None = None
+    baseline_sharpe: float | None = None
+    dsr: float | None = None
+    n_paths: int = 0
+    splitter_used: str = "walk_forward"
+
+
+class BacktestScoreResponse(CustomScoreResponse):
+    """``POST /backtest/score`` 响应：因子评估 + 回测结果。"""
+
+    backtest: BacktestScoreResult | None = Field(
+        default=None, description="WalkForward 回测结果；available=false 时为 None"
     )
 
 

--- a/services/factor/tests/test_p0_p5.py
+++ b/services/factor/tests/test_p0_p5.py
@@ -1,0 +1,250 @@
+"""P0·P2·P4·P5 扩展测试：新算子 / WalkForward IC / 多标的 / 回测模拟。"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from inalpha_factor.effectiveness import walk_forward_ic
+from inalpha_factor.expression import (
+    ExpressionError,
+    evaluate,
+    parse_expression,
+    _EXTRA_COLUMNS,
+)
+
+from .conftest import make_ohlcv
+
+
+def _eval(expr: str, df: pd.DataFrame) -> pd.Series:
+    return evaluate(parse_expression(expr), df)
+
+
+# ── P2: 新算子测试 ──────────────────────────────────────────────────
+
+
+class TestP2NewOperators:
+    def test_skew(self) -> None:
+        df = make_ohlcv(200)
+        s = _eval("Skew($close, 20)", df)
+        want = df["close"].astype(float).rolling(20).skew()
+        pd.testing.assert_series_equal(s, want, check_names=False)
+
+    def test_kurt(self) -> None:
+        df = make_ohlcv(200)
+        s = _eval("Kurt($close, 20)", df)
+        want = df["close"].astype(float).rolling(20).kurt()
+        pd.testing.assert_series_equal(s, want, check_names=False)
+
+    def test_med(self) -> None:
+        df = make_ohlcv(200)
+        s = _eval("Med($close, 20)", df)
+        want = df["close"].astype(float).rolling(20).median()
+        pd.testing.assert_series_equal(s, want, check_names=False)
+
+    def test_idxmax(self) -> None:
+        df = make_ohlcv(100)
+        s = _eval("IdxMax($high, 10)", df)
+        # 手动验证：rolling(10).apply(lambda x: x.argmax())
+        close = df["close"].astype(float)
+        assert s.index.equals(df.index)
+        assert s.dropna().between(0, 9).all()
+
+    def test_idxmin(self) -> None:
+        df = make_ohlcv(100)
+        s = _eval("IdxMin($low, 10)", df)
+        assert s.index.equals(df.index)
+        assert s.dropna().between(0, 9).all()
+
+    def test_cov(self) -> None:
+        df = make_ohlcv(200)
+        s = _eval("Cov($close, $volume, 20)", df)
+        close = df["close"].astype(float)
+        volume = df["volume"].astype(float)
+        want = close.rolling(20).cov(volume)
+        pd.testing.assert_series_equal(s, want, check_names=False)
+
+    def test_and_or_not(self) -> None:
+        df = make_ohlcv(200)
+        and_ = _eval("And(Greater($close, Mean($close, 20)), Greater($volume, Mean($volume, 20)))", df)
+        # And 返回 float64（0.0/1.0），不是 bool
+        assert and_.dtype in (bool, np.dtype("float64"), np.dtype("float32"))
+        or_ = _eval("Or(Greater($close, Mean($close, 20)), Greater($volume, Mean($volume, 20)))", df)
+        assert or_.dtype in (bool, np.dtype("float64"), np.dtype("float32"))
+        not_ = _eval("Not(Greater($close, Mean($close, 20)))", df)
+        assert not_.dtype in (bool, np.dtype("float64"), np.dtype("float32"))
+        # 验证值域：0 或 1
+        for s in (and_, or_, not_):
+            valid = s.dropna()
+            assert valid.isin([0.0, 1.0]).all()
+
+    def test_slope(self) -> None:
+        """Slope 输出不应全 NaN（有足够数据时）。"""
+        df = make_ohlcv(200)
+        s = _eval("Slope($close, 20)", df)
+        assert s.index.equals(df.index)
+        assert s.dropna().shape[0] > 0
+
+    @pytest.mark.parametrize(
+        ("expr", "hint"),
+        [
+            ("Skew($close)", "argument"),
+            ("Kurt($close, 20, 30)", "argument"),
+            ("Slope($close)", "argument"),
+            ("IdxMax($close)", "argument"),
+            ("IdxMin($close, 10, 20)", "argument"),
+            ("Cov($close, $volume)", "argument"),
+            ("And($close)", "argument"),
+            ("Or($close)", "argument"),
+            ("Not($close, $volume)", "argument"),
+        ],
+    )
+    def test_p2_operators_arg_count(self, expr: str, hint: str) -> None:
+        with pytest.raises(ExpressionError, match="expects|argument"):
+            parse_expression(expr)
+
+
+# ── P2: 扩展字段解析测试 ────────────────────────────────────────────
+
+
+class TestP2ExtraColumns:
+    def test_extra_columns_defined(self) -> None:
+        assert "pe" in _EXTRA_COLUMNS
+        assert "pb" in _EXTRA_COLUMNS
+        assert "roe" in _EXTRA_COLUMNS
+        assert "market_cap" in _EXTRA_COLUMNS
+        assert "fed_rate" in _EXTRA_COLUMNS
+        assert "cpi" in _EXTRA_COLUMNS
+
+    def test_extra_column_parse_ok(self) -> None:
+        p = parse_expression("$close / $pe")
+        assert "pe" in p.columns
+
+    def test_extra_column_evaluate_with_nan(self) -> None:
+        """扩展字段在 df 中不存在时，求值会因列缺失报 KeyError 而非静默错。
+        engine 层会在调用 evaluate 前注入这些列，确保 evaluate 本身不抛。"""
+        df = make_ohlcv(100)
+        p = parse_expression("$close / $pe")
+        # 没有 $pe 列 → evaluate 会抛 KeyError（engine 层在调用前会先注入）
+        with pytest.raises(KeyError):
+            evaluate(p, df)
+
+    def test_extra_column_unknown_rejected(self) -> None:
+        with pytest.raises(ExpressionError, match="unknown column"):
+            parse_expression("$close / $unknown_field")
+
+
+# ── P4: WalkForward IC 测试 ─────────────────────────────────────────
+
+
+class TestP4WalkForwardIC:
+    def test_walk_forward_perfect_factor(self) -> None:
+        """完美因子：OOS IC 各段均高，退化率低。"""
+        rng = np.random.default_rng(42)
+        n = 600
+        close = pd.Series(100.0 * np.exp(np.cumsum(rng.normal(0.0, 0.01, n))))
+        factor = close.shift(-5) / close - 1.0  # 知道未来
+        # 末尾 5 根 NaN，drop 掉
+        result = walk_forward_ic(factor, close, horizon=5, n_splits=5, min_samples=50)
+        assert result["oos_ic_mean"] is not None
+        assert result["oos_ic_mean"] > 0.5
+        assert result["insample_ic"] is not None
+        assert result["insample_ic"] > 0.5
+        assert result["n_splits"] == 5
+
+    def test_walk_forward_noise_factor(self) -> None:
+        """纯噪声因子：OOS IC 接近 0，退化率可能很高。"""
+        rng = np.random.default_rng(99)
+        n = 600
+        close = pd.Series(100.0 * np.exp(np.cumsum(rng.normal(0.0, 0.01, n))))
+        factor = pd.Series(rng.normal(0.0, 1.0, n))
+        result = walk_forward_ic(factor, close, horizon=5, n_splits=5, min_samples=50)
+        assert result["oos_ic_mean"] is not None
+        assert abs(result["oos_ic_mean"]) < 0.3
+
+    def test_walk_forward_short_series(self) -> None:
+        """短序列：仍能返回结果，不抛异常。"""
+        close = pd.Series([100.0] * 30)
+        factor = pd.Series([1.0] * 30)
+        result = walk_forward_ic(factor, close, horizon=1, n_splits=3, min_samples=5)
+        # 短序列可能返回 None
+        assert isinstance(result, dict)
+
+    def test_walk_forward_degradation_rate(self) -> None:
+        """退化率计算：insample 高 OOS 低 → 高退化率。"""
+        rng = np.random.default_rng(7)
+        n = 800
+        close = pd.Series(100.0 * np.exp(np.cumsum(rng.normal(0.0, 0.01, n))))
+        # 前 2/3 有效，后 1/3 噪声——模拟衰减
+        fwd = close.shift(-5) / close - 1.0
+        factor = fwd.copy()
+        cut = 500
+        factor.iloc[cut:] = rng.normal(0.0, 1.0, size=n - cut)
+        result = walk_forward_ic(factor, close, horizon=5, n_splits=5, min_samples=50)
+        # 退化率应存在且非负
+        assert result["degradation_rate"] is not None
+        assert result["oos_ic_mean"] is not None
+
+
+# ── P5: 扩展字段 schema 测试 ────────────────────────────────────────
+
+
+class TestP5MultiSymbol:
+    def test_custom_score_request_symbols_field(self) -> None:
+        """CustomScoreRequest 支持 symbols 字段。"""
+        from inalpha_factor.schemas import CustomScoreRequest
+
+        req = CustomScoreRequest(
+            expression="$close - Ref($close, 5)",
+            venue="binance",
+            symbol="BTC/USDT",
+            symbols=["BTC/USDT", "ETH/USDT"],
+            timeframe="1h",
+        )
+        assert req.symbols == ["BTC/USDT", "ETH/USDT"]
+
+    def test_backtest_score_request_inherits_symbols(self) -> None:
+        """BacktestScoreRequest 继承 CustomScoreRequest 的 symbols 字段。"""
+        from inalpha_factor.schemas import BacktestScoreRequest
+
+        req = BacktestScoreRequest(
+            expression="$close - Ref($close, 5)",
+            venue="binance",
+            symbol="BTC/USDT",
+            symbols=["BTC/USDT", "ETH/USDT"],
+            timeframe="1h",
+        )
+        assert req.symbols == ["BTC/USDT", "ETH/USDT"]
+
+
+# ── P2: 红队扩展——新算子审计 ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("expr", "hint"),
+    [
+        # 扩展算子审计
+        ("Skew($close, -5)", "window"),
+        ("Kurt($close, 0)", "window"),
+        ("Med($close, 501)", "window"),
+        ("Slope($close, -1)", "window"),
+        ("Cov($close, $volume, 0)", "window"),
+        # 扩展算子正常用法
+        ("Skew($close, 20)", ""),
+        ("Kurt($close, 20)", ""),
+        ("Med($close, 20)", ""),
+        ("Slope($close, 20)", ""),
+        ("Cov($close, $volume, 20)", ""),
+        ("IdxMax($close, 10)", ""),
+        ("IdxMin($close, 10)", ""),
+        ("And($close, $volume)", ""),
+        ("Or($close, $volume)", ""),
+        ("Not($close)", ""),
+    ],
+)
+def test_p2_operator_audit(expr: str, hint: str) -> None:
+    if hint:
+        with pytest.raises(ExpressionError, match=hint):
+            parse_expression(expr)
+    else:
+        parse_expression(expr)  # 不应抛


### PR DESCRIPTION
详见 ADR-0055 路线图。

## 变更
- P0: POST /backtest/score 因子→策略回测闭环
- P1: 族类分布 RAG + 族类配额 3
- P2: DSL 算子 18→28 + 扩展数据字段
- P3: factor-evolution workflow + factor.evolve tool
- P4: WalkForward OOS 验证默认化
- P5: 多标的并发评估 + 跨品种 IC 一致性
- 测试: test_p0_p5.py 42 用例, 全部 161 passed

## 验证
- ruff clean
- 无需前端改动