### PR TITLE
fix(data): 完成 Baostock venue 拆分与兼容迁移

### DIFF
--- a/infra/migrations/versions/0035_bars_akshare_to_baostock.py
+++ b/infra/migrations/versions/0035_bars_akshare_to_baostock.py
@@ -1,0 +1,52 @@
+"""将旧 A 股 bars venue 从 ``akshare`` 迁移到 ``baostock``。
+
+迁移使用 upsert 后删除旧行，避免目标 venue 已有同键数据时违反主键约束。
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0035"
+down_revision: str | None = "0034"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO bars (ts, venue, symbol, timeframe, open, high, low, close, volume)
+        SELECT ts, 'baostock', symbol, timeframe, open, high, low, close, volume
+        FROM bars
+        WHERE venue = 'akshare' AND symbol ~ '^(sh|sz)\\.'
+        ON CONFLICT (ts, venue, symbol, timeframe) DO UPDATE
+        SET open = EXCLUDED.open,
+            high = EXCLUDED.high,
+            low = EXCLUDED.low,
+            close = EXCLUDED.close,
+            volume = EXCLUDED.volume
+        """
+    )
+    op.execute(
+        "DELETE FROM bars WHERE venue = 'akshare' AND symbol ~ '^(sh|sz)\\.'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO bars (ts, venue, symbol, timeframe, open, high, low, close, volume)
+        SELECT ts, 'akshare', symbol, timeframe, open, high, low, close, volume
+        FROM bars
+        WHERE venue = 'baostock' AND symbol ~ '^(sh|sz)\\.'
+        ON CONFLICT (ts, venue, symbol, timeframe) DO UPDATE
+        SET open = EXCLUDED.open,
+            high = EXCLUDED.high,
+            low = EXCLUDED.low,
+            close = EXCLUDED.close,
+            volume = EXCLUDED.volume
+        """
+    )
+    op.execute(
+        "DELETE FROM bars WHERE venue = 'baostock' AND symbol ~ '^(sh|sz)\\.'"
+    )

--- a/packages/orchestration/src/tools/factor.ts
+++ b/packages/orchestration/src/tools/factor.ts
@@ -29,7 +29,7 @@ const SymbolSchema = z
   .max(50)
   .regex(
     /^[\^A-Za-z0-9._/\-:]+$/,
-    "symbol 不能为空 / 含空格；crypto 'BTC/USDT' / 股票 'AAPL' / 指数 '^N225' / akshare 'sh.600519'",
+    "symbol 不能为空 / 含空格；crypto 'BTC/USDT' / 股票 'AAPL' / 指数 '^N225' / baostock 'sh.600519'",
   );
 
 type ToolRequestContext = { authToken?: string; get?: (key: string) => unknown };
@@ -199,7 +199,7 @@ export const factorPanelScoreTool = createTool({
       因子：value / momentum / volatility / 任意 catalog 因子）
     - 想知道某因子在这组标的上**横截面**有没有选股力（每期排序 vs 跨标的后市收益）
     - "成分股里按因子轮动"类策略的选标的步——传 indexCode（如 000300）让它取 **PIT 成分**
-      当 universe（去存活者偏差，venue 配 akshare），而非自己列 symbols
+      当 universe（去存活者偏差，venue 配 baostock），而非自己列 symbols
 
     何时不用：
     - 只有一个标的、判方向/时机 → factor.timing（横截面要 ≥2 个标的）
@@ -241,7 +241,7 @@ export const factorPanelScoreTool = createTool({
       .optional()
       .describe(
         "指数代码（如 000300），由 data 解析 asOf 那刻的 **PIT 成分**当 universe（is_pit=true，" +
-        "去存活者偏差，venue 配 akshare）。与 symbols 二选一,优先 indexCode。取不到 PIT 快照→空+降级",
+        "去存活者偏差，venue 配 baostock）。与 symbols 二选一,优先 indexCode。取不到 PIT 快照→空+降级",
       ),
     timeframe: TimeframeSchema.default("1d"),
     asOf: z

--- a/services/data/src/inalpha_data/api/backfill.py
+++ b/services/data/src/inalpha_data/api/backfill.py
@@ -21,6 +21,7 @@ from ..connectors.fred import TIMEFRAME_SECONDS as FRED_TIMEFRAME_SECONDS
 from ..connectors.yfinance_conn import TIMEFRAME_SECONDS as YFINANCE_TIMEFRAME_SECONDS
 from ..schemas import BackfillRequest, BackfillResponse
 from ..storage.bars import insert_bars, latest_bar_ts
+from ..venues import canonicalize_venue, is_legacy_a_share_venue
 
 router = APIRouter(tags=["backfill"])
 _logger = get_logger(__name__)
@@ -79,9 +80,8 @@ async def backfill_bars(
 
     # ─── venue 路由 ──────────────────────────────────────────────
     # **向后兼容**：venue="akshare" 且 symbol 带 sh./sz. 前缀 → 自动路由到 baostock
-    _baostock_prefixes = ("sh.", "sz.")
-    effective_venue = req.venue
-    if req.venue == "akshare" and any(req.symbol.startswith(p) for p in _baostock_prefixes):
+    effective_venue = canonicalize_venue(req.venue, req.symbol)
+    if is_legacy_a_share_venue(req.venue, req.symbol):
         _logger.warning(
             "venue_akshare_deprecated",
             symbol=req.symbol,
@@ -111,7 +111,7 @@ async def backfill_bars(
     # baostock 分钟 K 每条调用一次 API，长跨度会快速消耗 5 万日配额
     # 仅对 baostock venue 生效（binance/alpaca/yfinance 不受此限制）
     effective_from_ts = req.from_ts
-    if req.venue == "baostock" and req.timeframe in _MINUTE_LOOKBACK_LIMITS:
+    if effective_venue == "baostock" and req.timeframe in _MINUTE_LOOKBACK_LIMITS:
         max_lookback_days = _MINUTE_LOOKBACK_LIMITS[req.timeframe]
         span_days = (req.to_ts - req.from_ts).total_seconds() / 86400
 

--- a/services/data/src/inalpha_data/api/backfill.py
+++ b/services/data/src/inalpha_data/api/backfill.py
@@ -1,7 +1,8 @@
 """``POST /backfill/bars`` —— 从外部市场拉历史 K 线落库。
 
-D-9 起多 venue：按 ``req.venue`` 从注册表取 connector（binance / alpaca / akshare）。
+D-9 起多 venue：按 ``req.venue`` 从注册表取 connector（binance / alpaca / baostock）。
 """
+
 from __future__ import annotations
 
 from datetime import timedelta
@@ -34,19 +35,19 @@ _MAX_BARS_PER_REQUEST = 50_000
 # 分钟级查询限制（baostock 配额优化）
 # baostock 分钟 K 每条调用一次 API，长跨度会快速消耗 5 万日配额
 _MINUTE_LOOKBACK_LIMITS = {
-    "5m": 7,    # 7 天 = 336 条
+    "5m": 7,  # 7 天 = 336 条
     "15m": 14,  # 14 天 = 672 条
     "30m": 30,  # 30 天 = 720 条
-    "1h": 60,   # 60 天 = 720 条
+    "1h": 60,  # 60 天 = 720 条
 }
 
 
 # venue → 该 venue 支持的 timeframe → 秒数
-# baostock（akshare venue）支持日级 + 分钟级（5/15/30/60 分钟）
+# baostock（baostock venue）支持日级 + 分钟级（5/15/30/60 分钟）
 _VENUE_TIMEFRAME_SECONDS: dict[str, dict[str, int]] = {
     "binance": BINANCE_TIMEFRAME_SECONDS,
     "alpaca": ALPACA_TIMEFRAME_SECONDS,
-    "akshare": {
+    "baostock": {
         "1d": 86400,
         "1wk": 604800,
         "1mo": 2_592_000,
@@ -69,7 +70,7 @@ async def backfill_bars(
 ) -> BackfillResponse:
     """从外部 venue 拉指定时段的 K 线，幂等写入 TimescaleDB。
 
-    支持 venue：``binance`` / ``alpaca`` / ``akshare``。
+    支持 venue：``binance`` / ``alpaca`` / ``baostock``。
 
     **硬限**：``(to_ts - from_ts) / timeframe`` 估算 bar 数 > 50k 直接拒。
     """
@@ -77,15 +78,26 @@ async def backfill_bars(
         raise ValidationError("from_ts must be <= to_ts")
 
     # ─── venue 路由 ──────────────────────────────────────────────
+    # **向后兼容**：venue="akshare" 且 symbol 带 sh./sz. 前缀 → 自动路由到 baostock
+    _baostock_prefixes = ("sh.", "sz.")
+    effective_venue = req.venue
+    if req.venue == "akshare" and any(req.symbol.startswith(p) for p in _baostock_prefixes):
+        _logger.warning(
+            "venue_akshare_deprecated",
+            symbol=req.symbol,
+            reason="venue 'akshare' is deprecated for A-share; use 'baostock' instead",
+        )
+        effective_venue = "baostock"
+
     try:
-        connector: Connector = get_connector_for_venue(req.venue)
+        connector: Connector = get_connector_for_venue(effective_venue)
     except KeyError:
         raise ValidationError(
             f"unsupported venue {req.venue!r}",
             details={"supported": list_registered_venues()},
         ) from None
 
-    tf_table = _VENUE_TIMEFRAME_SECONDS.get(req.venue)
+    tf_table = _VENUE_TIMEFRAME_SECONDS.get(effective_venue)
     if tf_table is None or req.timeframe not in tf_table:
         raise ValidationError(
             f"venue {req.venue!r} does not support timeframe {req.timeframe!r}",
@@ -97,9 +109,9 @@ async def backfill_bars(
 
     # ─── 分钟级强制限制（baostock 配额优化）──────────────────────
     # baostock 分钟 K 每条调用一次 API，长跨度会快速消耗 5 万日配额
-    # 仅对 akshare venue 生效（binance/alpaca/yfinance 不受此限制）
+    # 仅对 baostock venue 生效（binance/alpaca/yfinance 不受此限制）
     effective_from_ts = req.from_ts
-    if req.venue == "akshare" and req.timeframe in _MINUTE_LOOKBACK_LIMITS:
+    if req.venue == "baostock" and req.timeframe in _MINUTE_LOOKBACK_LIMITS:
         max_lookback_days = _MINUTE_LOOKBACK_LIMITS[req.timeframe]
         span_days = (req.to_ts - req.from_ts).total_seconds() / 86400
 
@@ -141,7 +153,7 @@ async def backfill_bars(
     # 但不早于请求的 from_ts；空缓存则从 from_ts 全量。
     # 注：仅按 max(ts) 续拉，中间空洞（非连续缓存，罕见）不会回补；需要时显式重拉窗口。
     cached_latest = await latest_bar_ts(
-        db, req.venue, req.symbol, req.timeframe, upto=req.to_ts
+        db, effective_venue, req.symbol, req.timeframe, upto=req.to_ts
     )
     if cached_latest is not None and cached_latest > effective_from_ts:
         cursor = cached_latest
@@ -199,7 +211,7 @@ async def backfill_bars(
         if not bars:
             break
 
-        n = await insert_bars(db, req.venue, req.symbol, req.timeframe, bars)
+        n = await insert_bars(db, effective_venue, req.symbol, req.timeframe, bars)
         fetched_total += len(bars)
         inserted_total += n
 

--- a/services/data/src/inalpha_data/api/bars.py
+++ b/services/data/src/inalpha_data/api/bars.py
@@ -1,9 +1,11 @@
 """``GET /bars`` —— 从 TimescaleDB 查 K 线。"""
+
 from __future__ import annotations
 
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
+from inalpha_shared import get_logger
 from inalpha_shared.auth import User, get_current_user
 from inalpha_shared.db import DBConn
 from inalpha_shared.errors import ValidationError
@@ -12,6 +14,7 @@ from ..schemas import BarResponse, BarsQuery
 from ..storage.bars import query_bars
 
 router = APIRouter(tags=["bars"])
+_logger = get_logger(__name__)
 
 
 @router.get("/bars", response_model=list[BarResponse])
@@ -25,14 +28,28 @@ async def list_bars(
     时间范围闭区间，最多返回 ``limit`` 根（默认 10k，上限 50k）。
     """
     if query.from_ts > query.to_ts:
-        raise ValidationError("from_ts must be <= to_ts", details={
-            "from_ts": query.from_ts.isoformat(),
-            "to_ts": query.to_ts.isoformat(),
-        })
+        raise ValidationError(
+            "from_ts must be <= to_ts",
+            details={
+                "from_ts": query.from_ts.isoformat(),
+                "to_ts": query.to_ts.isoformat(),
+            },
+        )
+
+    # 向后兼容：venue="akshare" + sh./sz. 前缀 → 自动用 baostock 查 DB
+    _baostock_prefixes = ("sh.", "sz.")
+    effective_venue = query.venue
+    if query.venue == "akshare" and any(query.symbol.startswith(p) for p in _baostock_prefixes):
+        _logger.warning(
+            "venue_akshare_deprecated",
+            symbol=query.symbol,
+            reason="venue 'akshare' is deprecated for A-share; use 'baostock' instead",
+        )
+        effective_venue = "baostock"
 
     rows = await query_bars(
         db,
-        venue=query.venue,
+        venue=effective_venue,
         symbol=query.symbol,
         timeframe=query.timeframe,
         from_ts=query.from_ts,

--- a/services/data/src/inalpha_data/api/bars.py
+++ b/services/data/src/inalpha_data/api/bars.py
@@ -12,6 +12,7 @@ from inalpha_shared.errors import ValidationError
 
 from ..schemas import BarResponse, BarsQuery
 from ..storage.bars import query_bars
+from ..venues import canonicalize_venue, is_legacy_a_share_venue
 
 router = APIRouter(tags=["bars"])
 _logger = get_logger(__name__)
@@ -37,9 +38,8 @@ async def list_bars(
         )
 
     # 向后兼容：venue="akshare" + sh./sz. 前缀 → 自动用 baostock 查 DB
-    _baostock_prefixes = ("sh.", "sz.")
-    effective_venue = query.venue
-    if query.venue == "akshare" and any(query.symbol.startswith(p) for p in _baostock_prefixes):
+    effective_venue = canonicalize_venue(query.venue, query.symbol)
+    if is_legacy_a_share_venue(query.venue, query.symbol):
         _logger.warning(
             "venue_akshare_deprecated",
             symbol=query.symbol,

--- a/services/data/src/inalpha_data/api/fundamentals.py
+++ b/services/data/src/inalpha_data/api/fundamentals.py
@@ -1,7 +1,8 @@
 """``GET /fundamentals`` —— 拉财报基本面数据（D-10，给 research analyst 用）。
 
-支持 venue=akshare（A股/港股）和 venue=yfinance（全球兜底）。
+支持 venue=baostock（A股）和 venue=yfinance（全球兜底）。
 """
+
 from __future__ import annotations
 
 from typing import Annotated
@@ -20,19 +21,19 @@ router = APIRouter(tags=["fundamentals"])
 @router.get("/fundamentals", response_model=FinancialsResponse)
 async def get_fundamentals(
     _user: Annotated[User, Depends(get_current_user)],
-    venue: Annotated[str, Query(description="数据源：akshare 或 yfinance")],
+    venue: Annotated[str, Query(description="数据源：baostock 或 yfinance")],
     symbol: Annotated[str, Query(description="ticker 标识（如 sh.600519 / AAPL）")],
     as_of: Annotated[
         str | None,
         Query(
             description="point-in-time 截断（ISO 8601，ADR-0053 阶段 A）：只返回该时点已"
-            "披露的财报，防回测看到未来财报。仅 akshare 生效；yfinance v1 不做 PIT。",
+            "披露的财报，防回测看到未来财报。仅 baostock 生效；yfinance v1 不做 PIT。",
         ),
     ] = None,
 ) -> FinancialsResponse:
     """拉指定 ticker 的财报基本面数据（``as_of`` 给定则做 PIT 截断）。
 
-    venue 支持 akshare / yfinance；其它 venue 返 422。
+    venue 支持 baostock / yfinance；其它 venue 返 422。
     """
     if venue == "yfinance":
         try:
@@ -47,8 +48,8 @@ async def get_fundamentals(
             )
         return FinancialsResponse(**data)
 
-    if venue == "akshare":
-        conn = get_connector_for_venue("akshare")
+    if venue == "baostock":
+        conn = get_connector_for_venue("baostock")
         if not hasattr(conn, "fetch_financials"):
             raise ValidationError(
                 f"fundamentals fetch not available for venue {venue!r}",
@@ -61,6 +62,5 @@ async def get_fundamentals(
     raise ValidationError(
         f"fundamentals venue {venue!r} not supported",
         code="FUNDAMENTALS_VENUE_NOT_SUPPORTED",
-        details={"venue": venue, "supported": ["akshare", "yfinance"]},
+        details={"venue": venue, "supported": ["baostock", "yfinance"]},
     )
-

--- a/services/data/src/inalpha_data/api/fundamentals.py
+++ b/services/data/src/inalpha_data/api/fundamentals.py
@@ -14,6 +14,7 @@ from inalpha_shared.errors import ValidationError
 from ..connectors import yfinance_conn
 from ..connectors._base import get_connector_for_venue
 from ..schemas import FinancialsResponse
+from ..venues import canonicalize_venue
 
 router = APIRouter(tags=["fundamentals"])
 
@@ -35,7 +36,8 @@ async def get_fundamentals(
 
     venue 支持 baostock / yfinance；其它 venue 返 422。
     """
-    if venue == "yfinance":
+    effective_venue = canonicalize_venue(venue, symbol)
+    if effective_venue == "yfinance":
         try:
             conn = yfinance_conn.get_connector()
             data = await conn.fetch_financials(symbol, as_of=as_of)
@@ -48,7 +50,7 @@ async def get_fundamentals(
             )
         return FinancialsResponse(**data)
 
-    if venue == "baostock":
+    if effective_venue == "baostock":
         conn = get_connector_for_venue("baostock")
         if not hasattr(conn, "fetch_financials"):
             raise ValidationError(

--- a/services/data/src/inalpha_data/api/news.py
+++ b/services/data/src/inalpha_data/api/news.py
@@ -14,6 +14,7 @@ from inalpha_shared.errors import ValidationError
 from ..connectors import yfinance_conn
 from ..connectors._base import get_connector_for_venue
 from ..schemas import NewsItem, NewsQuery, NewsResponse
+from ..venues import canonicalize_venue
 
 router = APIRouter(tags=["news"])
 
@@ -27,13 +28,14 @@ async def get_news(
 
     venue 支持 yfinance / baostock（其它返 422）；不支持 ticker 返空 list 而非错。
     """
-    if query.venue == "yfinance":
+    effective_venue = canonicalize_venue(query.venue, query.symbol)
+    if effective_venue == "yfinance":
         try:
             conn = yfinance_conn.get_connector()
             raw = await conn.fetch_news(query.symbol, limit=query.limit)
         except Exception:
             raw = []
-    elif query.venue == "baostock":
+    elif effective_venue == "baostock":
         conn = get_connector_for_venue("baostock")
         if not hasattr(conn, "fetch_news"):
             raise ValidationError(

--- a/services/data/src/inalpha_data/api/news.py
+++ b/services/data/src/inalpha_data/api/news.py
@@ -1,7 +1,8 @@
 """``GET /news`` —— 拉新闻头条（D-9，零 key，给 research analyst 喂真数据用）。
 
-当前支持 venue=yfinance（全球）和 venue=akshare（A股）。
+当前支持 venue=yfinance（全球）和 venue=baostock（A股）。
 """
+
 from __future__ import annotations
 
 from typing import Annotated
@@ -24,7 +25,7 @@ async def get_news(
 ) -> NewsResponse:
     """拉指定 ticker 的最新新闻。
 
-    venue 支持 yfinance / akshare（其它返 422）；不支持 ticker 返空 list 而非错。
+    venue 支持 yfinance / baostock（其它返 422）；不支持 ticker 返空 list 而非错。
     """
     if query.venue == "yfinance":
         try:
@@ -32,8 +33,8 @@ async def get_news(
             raw = await conn.fetch_news(query.symbol, limit=query.limit)
         except Exception:
             raw = []
-    elif query.venue == "akshare":
-        conn = get_connector_for_venue("akshare")
+    elif query.venue == "baostock":
+        conn = get_connector_for_venue("baostock")
         if not hasattr(conn, "fetch_news"):
             raise ValidationError(
                 f"news fetch not available for venue {query.venue!r}",
@@ -45,7 +46,7 @@ async def get_news(
         raise ValidationError(
             f"news venue {query.venue!r} not supported",
             code="NEWS_VENUE_NOT_SUPPORTED",
-            details={"venue": query.venue, "supported": ["yfinance", "akshare"]},
+            details={"venue": query.venue, "supported": ["yfinance", "baostock"]},
         )
 
     items = [NewsItem(**r) for r in raw]

--- a/services/data/src/inalpha_data/api/ticker.py
+++ b/services/data/src/inalpha_data/api/ticker.py
@@ -39,6 +39,7 @@ from ..connectors import (
 )
 from ..schemas import TickerQuery, TickerResponse
 from ..storage.bars import query_bars
+from ..venues import canonicalize_venue
 
 router = APIRouter(tags=["ticker"])
 
@@ -80,10 +81,11 @@ async def get_ticker(
       网络抖动失败时**不**自动 fallback 到 DB（让 caller 看到原因），由 caller 决定重试。
     """
     now = datetime.now(UTC)
+    effective_venue = canonicalize_venue(query.venue, query.symbol)
 
     if query.fresh:
         try:
-            connector = get_connector_for_venue(query.venue)
+            connector = get_connector_for_venue(effective_venue)
         except KeyError:
             raise ValidationError(
                 f"unsupported venue {query.venue!r}",
@@ -125,7 +127,7 @@ async def get_ticker(
     for timeframe, source_tag in (("1m", "db_1m"), ("1h", "db_1h")):
         rows = await query_bars(
             db,
-            venue=query.venue,
+            venue=effective_venue,
             symbol=query.symbol,
             timeframe=timeframe,
             from_ts=lookback_start,

--- a/services/data/src/inalpha_data/connectors/baostock.py
+++ b/services/data/src/inalpha_data/connectors/baostock.py
@@ -1,30 +1,19 @@
-"""akshare connector —— A股走 baostock（证券宝）+ 港股走 akshare 东财源。
+"""baostock connector —— A 股全栈数据源（证券宝，免费零 key）。
 
-baostock（证券宝）做 A 股全栈数据源：
+2026-07 起，原 akshare venue 的 A 股能力全部迁移至此独立 venue。
 
-- **K 线**：日/周/月线，OHLCV 齐全（含真实成交量）
-- **财报**：利润表 + 负债表 + 成长指标 + 现金流比率 + 分红记录
+baostock（证券宝）功能覆盖：
+
+- **K 线**：日/周/月/分钟（5m/15m/30m/1h），OHLCV 齐全（含真实成交量）
+- **财报**：利润表 + 负债表 + 成长指标 + 现金流 + 运营能力 + 杜邦分析 + 分红记录
 - **交易日历**：A 股交易/非交易日查询
 - **指数成分**：沪深300 / 上证50 / 中证500 当前成分股
 - **全部免费零 key**，无需注册
 
-**2026-07 更新**：
+**symbol 格式约定**（venue=``"baostock"``）：
 
-- A股（sh/sz）：东财 push2his 失效 → 全部能力切 baostock
-  - K 线：日/周/月 + volume
-  - 财报：利润/负债/成长/现金流/分红（baostock pubDate 做 PIT）
-  - 交易日历：query_trade_dates
-  - 指数成分：沪深300/上证50/中证500
-- 港股（hk）：东财 ``stock_hk_hist`` 保留作 fallback（push2his 同失效），
-  orchestrator 默认路由到 yfinance
-- 日股 / 英股 / 德股：``stock_jp_hist`` / ``stock_uk_hist`` / ``stock_de_hist``
-  在 akshare ≥1.18.63 中已删除；orchestrator 路由到 yfinance
-
-**symbol 格式约定**（venue=``"akshare"``）：
-
-- A股沪市：``"sh.600519"``  → baostock ``"sh.600519"``
-- A股深市：``"sz.000001"``  → baostock ``"sz.000001"``
-- 港股   ：``"hk.00700"``  → akshare ``stock_hk_hist``（东财源，当前不可用）
+- A 股沪市：``"sh.600519"``
+- A 股深市：``"sz.000001"``
 
 **timeframe 支持**：
 
@@ -32,6 +21,7 @@ baostock（证券宝）做 A 股全栈数据源：
 - ``"5m"`` / ``"15m"`` / ``"30m"`` / ``"1h"`` → baostock ``frequency="5"/"15"/"30"/"60"``
 - 不支持 1 分钟（baostock 限制）
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -46,7 +36,7 @@ from ._base import register_connector, unregister_connector
 
 _logger = get_logger(__name__)
 
-VENUE = "akshare"
+VENUE = "baostock"
 
 #: fundamentals 进程内缓存 TTL（秒）。A股一次 fundamentals 要打 1 次财报摘要 + 3 次
 #: Baidu 估值(串行 ~4-5s),research 多 analyst fan-out 会重复问同一标的;60s 缓存挡掉
@@ -101,9 +91,12 @@ def _ensure_bs_login() -> None:
             # 另一个线程刚登完，直接返回
             return
         import baostock as bs
+
         lg = bs.login()
         if lg.error_code != "0":
-            _logger.warning("baostock_login_failed", error_code=lg.error_code, error_msg=lg.error_msg)
+            _logger.warning(
+                "baostock_login_failed", error_code=lg.error_code, error_msg=lg.error_msg
+            )
         else:
             _bs_logged_in = True
 
@@ -117,11 +110,13 @@ def _bs_session_logout() -> None:
         if not _bs_logged_in:
             return
         import baostock as bs
+
         bs.logout()
         _bs_logged_in = False
 
+
 #: 允许的市场前缀
-_ALLOWED_PREFIXES = frozenset({"sh", "sz", "hk", "jp", "uk", "de"})
+_ALLOWED_PREFIXES = frozenset({"sh", "sz"})
 
 
 def _parse_symbol(symbol: str) -> tuple[str, str]:
@@ -139,22 +134,19 @@ def _parse_symbol(symbol: str) -> tuple[str, str]:
             symbol = f"{suffix.lower()}.{code}"
     if "." not in symbol:
         raise ValueError(
-            f"akshare symbol must be '<prefix>.<code>'，prefix in (sh/sz/hk/jp/uk/de)，"
-            f"got {symbol!r}"
+            f"baostock symbol must be '<prefix>.<code>'，prefix in (sh/sz)，got {symbol!r}"
         )
     prefix, code = symbol.split(".", 1)
     prefix = prefix.lower()
     if prefix not in _ALLOWED_PREFIXES:
-        raise ValueError(
-            f"akshare unknown prefix {prefix!r}，allow: {sorted(_ALLOWED_PREFIXES)}"
-        )
+        raise ValueError(f"baostock unknown prefix {prefix!r}，allow: {sorted(_ALLOWED_PREFIXES)}")
     if not code:
-        raise ValueError(f"akshare code is empty: {symbol!r}")
+        raise ValueError(f"baostock code is empty: {symbol!r}")
     return prefix, code
 
 
-class AkshareConnector:
-    """akshare 包装 —— 同步库走 ``asyncio.to_thread``。"""
+class BaostockConnector:
+    """baostock 包装 —— 同步库走 ``asyncio.to_thread``。"""
 
     def __init__(self) -> None:
         # akshare 无 client 对象,import 即用。fundamentals 进程内 TTL 缓存,**PIT-aware**:
@@ -167,9 +159,7 @@ class AkshareConnector:
     def _fin_cache_key(symbol: str, as_of: datetime | None) -> tuple[str, str | None]:
         return (symbol, as_of.date().isoformat() if as_of is not None else None)
 
-    def _fin_cache_get(
-        self, symbol: str, as_of: datetime | None = None
-    ) -> dict[str, Any] | None:
+    def _fin_cache_get(self, symbol: str, as_of: datetime | None = None) -> dict[str, Any] | None:
         key = self._fin_cache_key(symbol, as_of)
         hit = self._fin_cache.get(key)
         if hit is None:
@@ -200,7 +190,7 @@ class AkshareConnector:
         """从 akshare 拉 OHLCV。
 
         Args:
-            symbol: ``"sh.600519"`` / ``"sz.000001"`` / ``"hk.00700"``
+            symbol: ``"sh.600519"`` / ``"sz.000001"``
             timeframe: 支持 ``"1d"`` / ``"1wk"`` / ``"1mo"`` 及分钟级 ``"5m"`` / ``"15m"`` / ``"30m"`` / ``"1h"``
             since: UTC datetime；akshare 接 ``YYYYMMDD`` 字符串
             limit: 不直接生效（akshare 不接 limit，整段拉回；上层切片）
@@ -210,18 +200,17 @@ class AkshareConnector:
         """
         if timeframe not in _PERIOD_MAP:
             raise NotImplementedError(
-                f"akshare connector only supports {sorted(_PERIOD_MAP)}; "
-                f"got {timeframe!r}"
+                f"baostock connector only supports {sorted(_PERIOD_MAP)}; got {timeframe!r}"
             )
 
         prefix, code = _parse_symbol(symbol)
         period = _PERIOD_MAP[timeframe]
         start_str = since.strftime("%Y%m%d")
-        # end 给 today 让 akshare 一口气拉全
+        # end 给 today 让 baostock 一口气拉全
         end_str = datetime.now(UTC).strftime("%Y%m%d")
 
         _logger.debug(
-            "akshare_fetch_bars",
+            "baostock_fetch_bars",
             symbol=symbol,
             timeframe=timeframe,
             since=since.isoformat(),
@@ -239,7 +228,7 @@ class AkshareConnector:
             )
         except Exception as exc:
             _logger.warning(
-                "akshare_fetch_bars_failed",
+                "baostock_fetch_bars_failed",
                 symbol=symbol,
                 timeframe=timeframe,
                 start_str=start_str,
@@ -267,7 +256,7 @@ class AkshareConnector:
         if not out and rows:
             # 上游返了行但全部被列名解析跳过 → 列名漂移告警
             _logger.warning(
-                "akshare_fetch_bars_all_rows_skipped",
+                "baostock_fetch_bars_all_rows_skipped",
                 symbol=symbol,
                 timeframe=timeframe,
                 row_count=len(rows),
@@ -316,9 +305,7 @@ class AkshareConnector:
             finally:
                 _last_fetch_mono = time.monotonic()
 
-    async def fetch_financials(
-        self, symbol: str, as_of: str | None = None
-    ) -> dict[str, Any]:
+    async def fetch_financials(self, symbol: str, as_of: str | None = None) -> dict[str, Any]:
         """拉 A股 / 港股 财报基本面数据。
 
         A-share: baostock 利润表 + 负债表 + 成长指标 + 现金流 + 分红
@@ -342,7 +329,7 @@ class AkshareConnector:
                 "venue": VENUE,
                 "symbol": symbol,
                 "available": False,
-                "reason": f"financials not supported for akshare prefix {prefix!r}",
+                "reason": f"financials not supported for baostock prefix {prefix!r}",
             }
 
         as_of_dt: datetime | None = None
@@ -381,7 +368,7 @@ class AkshareConnector:
                 publish_lag_days=FINANCIALS_PUBLISH_LAG_DAYS,
             )
         except Exception as exc:
-            _logger.warning("akshare_financials_fetch_failed", symbol=symbol, error=str(exc))
+            _logger.warning("baostock_financials_fetch_failed", symbol=symbol, error=str(exc))
             return {
                 "venue": VENUE,
                 "symbol": symbol,
@@ -393,7 +380,7 @@ class AkshareConnector:
             reason = (
                 f"no financials published as of {as_of}"
                 if as_of_dt is not None
-                else "akshare returned empty financial data"
+                else "baostock returned empty financial data"
             )
             return {
                 "venue": VENUE,
@@ -471,8 +458,7 @@ class AkshareConnector:
             prefix in ("sh", "sz")
             and not _is_historical
             and not all(
-                indicators.get(k) is not None
-                for k in ("market_cap", "pe_ratio", "pb_ratio")
+                indicators.get(k) is not None for k in ("market_cap", "pe_ratio", "pb_ratio")
             )
         ):
             try:
@@ -481,7 +467,7 @@ class AkshareConnector:
                     if indicators.get(k) is None:
                         indicators[k] = v
             except Exception as exc:
-                _logger.warning("akshare_valuation_fetch_failed", symbol=symbol, error=str(exc))
+                _logger.warning("baostock_valuation_fetch_failed", symbol=symbol, error=str(exc))
 
         # as_of 回填：PIT 查询回显请求的 as_of（数据有效时点）；非 PIT 回填取数时刻
         as_of_echo = (
@@ -514,20 +500,19 @@ class AkshareConnector:
         """
         prefix, code = _parse_symbol(symbol)
         if prefix not in ("sh", "sz"):
-            _logger.debug("akshare_fetch_news_unsupported_prefix", symbol=symbol, prefix=prefix)
+            _logger.debug("baostock_fetch_news_unsupported_prefix", symbol=symbol, prefix=prefix)
             return []
 
-        _logger.debug("akshare_fetch_news", symbol=symbol, prefix=prefix, code=code, limit=limit)
+        _logger.debug("baostock_fetch_news", symbol=symbol, prefix=prefix, code=code, limit=limit)
 
         try:
             raw = await asyncio.to_thread(_fetch_news_sync, symbol=code)
         except Exception as exc:
-            _logger.warning("akshare_news_fetch_failed", symbol=symbol, error=str(exc))
+            _logger.warning("baostock_news_fetch_failed", symbol=symbol, error=str(exc))
             return []
 
         if not raw or not isinstance(raw, list):
             return []
-
 
         out: list[dict[str, Any]] = []
         for item in raw[:limit]:
@@ -543,25 +528,31 @@ class AkshareConnector:
                 try:
                     if isinstance(ts_raw, (int, float)):
                         from datetime import datetime as dt_dt_dt
+
                         published_at = dt_dt_dt.fromtimestamp(int(ts_raw), tz=UTC).isoformat()
                     else:
                         from datetime import datetime as dt_dt_dt
-                        published_at = dt_dt_dt.strptime(str(ts_raw)[:19], "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC).isoformat()
+
+                        published_at = (
+                            dt_dt_dt.strptime(str(ts_raw)[:19], "%Y-%m-%d %H:%M:%S")
+                            .replace(tzinfo=UTC)
+                            .isoformat()
+                        )
                 except (ValueError, OSError):
                     published_at = None
 
-            out.append({
-                "title": title,
-                "publisher": item.get("source") or item.get("来源") or "",
-                "link": item.get("url") or item.get("链接") or "",
-                "published_at": published_at,
-                "summary": (item.get("content") or item.get("内容") or "")[:500],
-            })
+            out.append(
+                {
+                    "title": title,
+                    "publisher": item.get("source") or item.get("来源") or "",
+                    "link": item.get("url") or item.get("链接") or "",
+                    "published_at": published_at,
+                    "summary": (item.get("content") or item.get("内容") or "")[:500],
+                }
+            )
         return out
 
-    async def fetch_trade_calendar(
-        self, start_date: str, end_date: str
-    ) -> list[dict[str, Any]]:
+    async def fetch_trade_calendar(self, start_date: str, end_date: str) -> list[dict[str, Any]]:
         """查询 A 股交易日历（baostock ``query_trade_dates``）。
 
         Args:
@@ -605,7 +596,7 @@ class AkshareConnector:
             rows = await asyncio.to_thread(_fetch_constituents_sync, index_code=index_code)
         except Exception as exc:
             _logger.warning(
-                "akshare_constituents_fetch_failed", index_code=index_code, error=str(exc)
+                "baostock_constituents_fetch_failed", index_code=index_code, error=str(exc)
             )
             return []
         return rows
@@ -650,11 +641,11 @@ def _fetch_financials_sync(
         # 港股东财源当前不可用，打日志后静默返回空（orchestrator 路由到 yfinance）
         raw = ak.stock_hk_financial_abstract(symbol=code)
         if raw is None:
-            _logger.warning("akshare_hk_financials_none", prefix=prefix, code=code)
+            _logger.warning("baostock_hk_financials_none", prefix=prefix, code=code)
             return {}
         # akshare 返回 DataFrame，非 dict
         if hasattr(raw, "empty") and raw.empty:
-            _logger.warning("akshare_hk_financials_empty", prefix=prefix, code=code)
+            _logger.warning("baostock_hk_financials_empty", prefix=prefix, code=code)
             return {}
         return _flatten_financial_abstract(raw, as_of=as_of, publish_lag_days=publish_lag_days)
 
@@ -677,9 +668,7 @@ def _fetch_financials_baostock_sync(
     return _query_baostock_financials(symbol, as_of)
 
 
-def _query_baostock_financials(
-    symbol: str, as_of: datetime | None
-) -> dict[str, Any]:
+def _query_baostock_financials(symbol: str, as_of: datetime | None) -> dict[str, Any]:
     """查询 baostock 四大报表 + 分红，返回拍平的指标 dict。"""
     import math as _math
 
@@ -887,10 +876,10 @@ def _query_baostock_financials(
         indicators["equity_multiplier"] = _f(balance.get("assetToEquity"))  # 权益乘数
     if growth:
         indicators["profit_yoy"] = _f(growth.get("YOYPNI"))
-        indicators["revenue_yoy"] = _f(growth.get("YOYNI"))       # 归属净利润同比
-        indicators["equity_yoy"] = _f(growth.get("YOYEquity"))    # 净资产同比
-        indicators["asset_yoy"] = _f(growth.get("YOYAsset"))      # 总资产同比
-        indicators["eps_yoy"] = _f(growth.get("YOYEPSBasic"))     # EPS 同比
+        indicators["revenue_yoy"] = _f(growth.get("YOYNI"))  # 归属净利润同比
+        indicators["equity_yoy"] = _f(growth.get("YOYEquity"))  # 净资产同比
+        indicators["asset_yoy"] = _f(growth.get("YOYAsset"))  # 总资产同比
+        indicators["eps_yoy"] = _f(growth.get("YOYEPSBasic"))  # EPS 同比
     if cash_flow:
         indicators["ocf_to_revenue"] = _f(cash_flow.get("CFOToOR"))
         indicators["ocf_to_profit"] = _f(cash_flow.get("CFOToNP"))
@@ -1046,7 +1035,11 @@ def _fetch_baostock_sync(
 
     # 分钟级需要 time 字段
     is_intraday = frequency.isdigit()
-    fields = "date,time,open,high,low,close,volume,amount" if is_intraday else "date,open,high,low,close,volume,amount"
+    fields = (
+        "date,time,open,high,low,close,volume,amount"
+        if is_intraday
+        else "date,open,high,low,close,volume,amount"
+    )
 
     rs = bs.query_history_k_data_plus(
         symbol,
@@ -1078,27 +1071,31 @@ def _fetch_baostock_sync(
         # 日级:   [date, open, high, low, close, volume, amount]
         if is_intraday and len(row_data) >= 8:
             date_str, time_str, open_s, high_s, low_s, close_s, vol_s, amt_s = row_data[:8]
-            rows.append({
-                "date": date_str,
-                "time": time_str,
-                "open": open_s,
-                "high": high_s,
-                "low": low_s,
-                "close": close_s,
-                "volume": vol_s,
-                "amount": amt_s,
-            })
+            rows.append(
+                {
+                    "date": date_str,
+                    "time": time_str,
+                    "open": open_s,
+                    "high": high_s,
+                    "low": low_s,
+                    "close": close_s,
+                    "volume": vol_s,
+                    "amount": amt_s,
+                }
+            )
         else:
             date_str, open_s, high_s, low_s, close_s, vol_s, amt_s = row_data[:7]
-            rows.append({
-                "date": date_str,
-                "open": open_s,
-                "high": high_s,
-                "low": low_s,
-                "close": close_s,
-                "volume": vol_s,
-                "amount": amt_s,
-            })
+            rows.append(
+                {
+                    "date": date_str,
+                    "open": open_s,
+                    "high": high_s,
+                    "low": low_s,
+                    "close": close_s,
+                    "volume": vol_s,
+                    "amount": amt_s,
+                }
+            )
 
     return rows
 
@@ -1165,7 +1162,7 @@ def _fetch_sync(
         df = ak.stock_hk_hist(adjust="", **common)
         if df is None or len(df) == 0:
             _logger.warning(
-                "akshare_fetch_empty",
+                "baostock_fetch_empty",
                 prefix=prefix,
                 code=code,
                 period=period,
@@ -1240,11 +1237,13 @@ def _fetch_constituents_sync(*, index_code: str) -> list[dict[str, Any]]:
                     if rd and rd[0]:
                         row = dict(zip(rs.fields, rd, strict=True))
                         raw_code = str(row.get("code", "")).strip()
-                        out.append({
-                            "code": _cn_symbol(raw_code),
-                            "name": str(row.get("code_name", "")).strip() or None,
-                            "weight": None,  # baostock 无权重
-                        })
+                        out.append(
+                            {
+                                "code": _cn_symbol(raw_code),
+                                "name": str(row.get("code_name", "")).strip() or None,
+                                "weight": None,  # baostock 无权重
+                            }
+                        )
                 if out:
                     return out
         except Exception as exc:
@@ -1284,11 +1283,13 @@ def _fetch_constituents_sync(*, index_code: str) -> list[dict[str, Any]]:
         code_str = str(raw).strip().zfill(6)
         if not code_str.isdigit() or len(code_str) != 6:
             continue
-        out.append({
-            "code": _cn_symbol(code_str),
-            "name": str(row.get(name_col)).strip() if name_col else None,
-            "weight": _to_float(row.get(weight_col)) if weight_col else None,
-        })
+        out.append(
+            {
+                "code": _cn_symbol(code_str),
+                "name": str(row.get(name_col)).strip() if name_col else None,
+                "weight": _to_float(row.get(weight_col)) if weight_col else None,
+            }
+        )
     return out
 
 
@@ -1321,9 +1322,13 @@ def _parse_date(v: Any) -> datetime:
     if len(s) == 14 and s.isdigit():
         # 20260709093500000 → 2026-07-09 09:35:00
         return datetime(
-            int(s[:4]), int(s[4:6]), int(s[6:8]),
-            int(s[8:10]), int(s[10:12]), int(s[12:14]),
-            tzinfo=UTC
+            int(s[:4]),
+            int(s[4:6]),
+            int(s[6:8]),
+            int(s[8:10]),
+            int(s[10:12]),
+            int(s[12:14]),
+            tzinfo=UTC,
         )
     # 日级：YYYY-MM-DD 或 YYYYMMDD
     return datetime.fromisoformat(s).replace(tzinfo=UTC)
@@ -1331,15 +1336,15 @@ def _parse_date(v: Any) -> datetime:
 
 # ---------- module-level singleton ----------
 
-_connector: AkshareConnector | None = None
+_connector: BaostockConnector | None = None
 
 
-def init_connector() -> AkshareConnector:
-    """启动时调一次。akshare 无 API key 需要。"""
+def init_connector() -> BaostockConnector:
+    """启动时调一次。baostock 无 API key 需要。"""
     global _connector
     if _connector is not None:
-        raise RuntimeError("Akshare connector already initialized")
-    _connector = AkshareConnector()
+        raise RuntimeError("Baostock connector already initialized")
+    _connector = BaostockConnector()
     register_connector(VENUE, _connector)
     return _connector
 
@@ -1354,7 +1359,7 @@ async def close_connector() -> None:
     _bs_session_logout()
 
 
-def get_connector() -> AkshareConnector:
+def get_connector() -> BaostockConnector:
     if _connector is None:
-        raise RuntimeError("Akshare connector not initialized; call init_connector() first")
+        raise RuntimeError("Baostock connector not initialized; call init_connector() first")
     return _connector

--- a/services/data/src/inalpha_data/main.py
+++ b/services/data/src/inalpha_data/main.py
@@ -2,6 +2,7 @@
 
 启动：``uvicorn inalpha_data.main:app --port 8001``
 """
+
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
@@ -33,8 +34,8 @@ from .api import (
     web_search,
 )
 from .config import get_data_settings
-from .connectors import akshare as akshare_conn
 from .connectors import alpaca as alpaca_conn
+from .connectors import baostock as baostock_conn
 from .connectors import binance as binance_conn
 from .connectors import cn_market as cn_market_conn
 from .connectors import fred as fred_conn
@@ -64,7 +65,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         api_key=_settings.alpaca_api_key,
         api_secret=_settings.alpaca_api_secret,
     )
-    akshare_conn.init_connector()
+    baostock_conn.init_connector()
     yfinance_conn.init_connector()
     fred_conn.init_connector(api_key=_settings.fred_api_key)
     web_search_conn.init_connector()
@@ -87,7 +88,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         await yfinance_conn.close_connector()
         await cn_market_conn.close_connector()
         await web_search_conn.close_connector()
-        await akshare_conn.close_connector()
+        await baostock_conn.close_connector()
         await alpaca_conn.close_connector()
         await binance_conn.close_connector()
         await close_pool()

--- a/services/data/src/inalpha_data/scheduler.py
+++ b/services/data/src/inalpha_data/scheduler.py
@@ -1,17 +1,18 @@
 """指数成分每日快照调度 —— ADR-0053 阶段 C 向前累积的运营臂。
 
-akshare 只回**当前**成分，免费历史成分拿不到 → 唯一 PIT 路径是从启用日起每日把
+baostock 只回**当前**成分，免费历史成分拿不到 → 唯一 PIT 路径是从启用日起每日把
 "当前成分"以 ``as_of_date=今天`` 落 ``constituent_snapshot``。本模块在 data 服务
 lifespan 里起一个后台循环，按 ``CONSTITUENT_SNAPSHOT_INDICES`` 周期性补当天快照。
 
 设计要点：
 
-- **幂等**：每轮先查"今天是否已有快照"，有则跳过——省 akshare 调用 + 防封，且重启
+- **幂等**：每轮先查"今天是否已有快照"，有则跳过——省 baostock 调用 + 防封，且重启
   频繁（uvicorn --reload）也不会重复打源站。
 - **catch-up**：启动即跑一轮，补上停机期间缺的当天快照（不回填历史，accumulate forward）。
 - **per-index 隔离**：单个指数拉取失败只 warning 跳过，不拖垮整轮/其他指数。
 - 手动 ``POST /constituents/snapshot`` 与本调度共用 :func:`record_snapshot`，行为一致。
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -22,7 +23,7 @@ from inalpha_shared.db import get_conn
 from inalpha_shared.errors import InalphaError
 from psycopg import AsyncConnection
 
-from .connectors.akshare import get_connector as get_akshare_connector
+from .connectors.baostock import get_connector as get_baostock_connector
 from .storage import constituents as store
 
 _logger = get_logger(__name__)
@@ -38,26 +39,25 @@ class ConstituentsUnavailableError(InalphaError):
 async def record_snapshot(
     db: AsyncConnection, *, index_code: str, as_of_date: date | None = None
 ) -> tuple[str, int]:
-    """拉 ``index_code`` 当前成分（akshare）落库 ``as_of_date``，返回 ``(日期, 条数)``。
+    """拉 ``index_code`` 当前成分（baostock）落库 ``as_of_date``，返回 ``(日期, 条数)``。
 
-    akshare 只回当前成分，故这是 PIT 史的**唯一来源**；源站失败 → 抛
+    baostock 只回当前成分，故这是 PIT 史的**唯一来源**；源站失败 → 抛
     :class:`ConstituentsUnavailableError`，不静默写空（§3.1）。调用方负责开事务。
 
     ``as_of_date`` 由调用方传入则用之（调度器跨午夜场景：``_tick`` 在入口锁定当天，避免
-    akshare HTTP 跨过午夜后这里重算成 D+1、让 D 永久空洞）；省略=用"现在"（HTTP 端点）。
+    baostock HTTP 跨过午夜后这里重算成 D+1、让 D 永久空洞）；省略=用"现在"（HTTP 端点）。
     """
     try:
-        conn = get_akshare_connector()
-    except RuntimeError as exc:  # akshare connector 未注册（启动未 init）
+        conn = get_baostock_connector()
+    except RuntimeError as exc:  # baostock connector 未注册（启动未 init）
         raise ConstituentsUnavailableError(
-            f"akshare connector unavailable: {exc}", code="CONSTITUENTS_UNAVAILABLE"
+            f"baostock connector unavailable: {exc}", code="CONSTITUENTS_UNAVAILABLE"
         ) from exc
 
     members = await conn.fetch_index_constituents(index_code)
     if not members:
         raise ConstituentsUnavailableError(
-            f"no constituents fetched for index {index_code!r} "
-            "(akshare 拉取失败 / 不支持该指数)",
+            f"no constituents fetched for index {index_code!r} (baostock 拉取失败 / 不支持该指数)",
             details={"index_code": index_code},
         )
 
@@ -97,9 +97,7 @@ class ConstituentSnapshotScheduler:
             return
         if self._task is not None:
             return
-        self._task = asyncio.create_task(
-            self._loop(), name="constituent-snapshot-scheduler"
-        )
+        self._task = asyncio.create_task(self._loop(), name="constituent-snapshot-scheduler")
         _logger.info(
             "constituent_scheduler_started",
             indices=self._index_codes,

--- a/services/data/src/inalpha_data/schemas.py
+++ b/services/data/src/inalpha_data/schemas.py
@@ -1,4 +1,5 @@
 """请求 / 响应 schema —— 给 FastAPI 路由用，自动生成 OpenAPI。"""
+
 from __future__ import annotations
 
 from datetime import UTC, datetime
@@ -91,12 +92,12 @@ class NewsQuery(BaseModel):
 
     venue: str = Field(
         default="yfinance",
-        description="新闻数据源 venue。支持 yfinance（全球零 key）和 akshare（A股）。",
+        description="新闻数据源 venue。支持 yfinance（全球零 key）和 baostock（A股）。",
     )
     symbol: str = Field(
         ...,
         examples=["AAPL", "^GSPC", "005930.KS", "sh.600519"],
-        description="ticker 标识：yfinance 用 Yahoo ticker，akshare 用 sh./sz. 前缀。",
+        description="ticker 标识：yfinance 用 Yahoo ticker，baostock 用 sh./sz. 前缀。",
     )
     limit: int = Field(default=10, ge=1, le=30, description="最多返回多少条")
 
@@ -128,7 +129,7 @@ class TickerQuery(BaseModel):
         default=False,
         description=(
             "true 时绕过 DB 缓存，直接调外部市场实时 ticker。"
-            "支持 venue：binance / yfinance / alpaca；akshare / fred 不支持，"
+            "支持 venue：binance / yfinance / alpaca；baostock / fred 不支持，"
             "会返 422 FRESH_NOT_SUPPORTED_FOR_VENUE 并提示切 fresh=false。"
             "适合 scheduler 周期性拉真·最新价的场景。"
         ),
@@ -162,9 +163,7 @@ class PerpFundingQuery(BaseModel):
     """``GET /perp/funding`` query 参数。"""
 
     venue: str = Field(default="binance", description="crypto 交易所（仅 crypto perp 支持）")
-    symbol: str = Field(
-        ..., description="USDT-M 永续标的（ccxt 记法）", examples=["BTC/USDT:USDT"]
-    )
+    symbol: str = Field(..., description="USDT-M 永续标的（ccxt 记法）", examples=["BTC/USDT:USDT"])
 
 
 class PerpFundingResponse(BaseModel):
@@ -376,7 +375,7 @@ class WebFetchResponse(BaseModel):
 
 class SymbolSearchResult(BaseModel):
     symbol: str
-    """已按 venue 约定格式化：akshare → ``sh.600519``；yfinance → ``AAPL`` / ``0700.HK``。"""
+    """已按 venue 约定格式化：baostock → ``sh.600519``；yfinance → ``AAPL`` / ``0700.HK``。"""
     name: str = ""
     exchange: str = ""
     venue: str

--- a/services/data/src/inalpha_data/venues.py
+++ b/services/data/src/inalpha_data/venues.py
@@ -1,0 +1,25 @@
+"""数据服务 venue 规范化。
+
+``akshare`` 曾同时承载多个市场。A 股行情现已迁移到 ``baostock``；过渡期仍接受
+旧客户端发送的 ``akshare`` + ``sh./sz.``，但所有存储和 connector 路由统一使用新 venue。
+"""
+from __future__ import annotations
+
+LEGACY_A_SHARE_VENUE = "akshare"
+A_SHARE_VENUE = "baostock"
+_A_SHARE_PREFIXES = ("sh.", "sz.")
+
+
+def canonicalize_venue(venue: str, symbol: str) -> str:
+    """返回用于 connector 与持久化的 canonical venue。"""
+    normalized = venue.strip().lower()
+    if normalized == LEGACY_A_SHARE_VENUE and symbol.strip().lower().startswith(_A_SHARE_PREFIXES):
+        return A_SHARE_VENUE
+    return normalized
+
+
+def is_legacy_a_share_venue(venue: str, symbol: str) -> bool:
+    """旧 A 股 venue 是否被映射到 ``baostock``。"""
+    return venue.strip().lower() == LEGACY_A_SHARE_VENUE and canonicalize_venue(
+        venue, symbol
+    ) == A_SHARE_VENUE

--- a/services/data/tests/test_backfill_router.py
+++ b/services/data/tests/test_backfill_router.py
@@ -5,10 +5,10 @@ D-9 ``data.backfill_bars`` 工具层解锁后，TS schema 不再卡 venue ——
 
 - 5 venue 各自路由到正确 connector，写库行数正确
 - venue 不在注册表 → 422 + ``details.supported`` 含已注册列表
-- venue 支持但 timeframe 不支持（如 akshare 传 1m）→ 422 +
+- venue 支持但 timeframe 不支持（如 baostock 传 1m）→ 422 +
   ``details.supported_timeframes`` 列出该 venue 允许的 timeframe
 
-**不**走真实 yfinance / akshare / alpaca / fred 网络 —— 这些是 connector 层职责（已在
+**不**走真实 yfinance / baostock / alpaca / fred 网络 —— 这些是 connector 层职责（已在
 ``test_connectors.py`` 覆盖）；本文件只验 router/registry 装配是否正确。
 """
 from __future__ import annotations
@@ -56,14 +56,14 @@ class _FakeConnector:
 async def app_with_all_venues_mocked() -> AsyncIterator[Any]:
     """启 app + 把 5 venue 的 registry 全部替换成 _FakeConnector。
 
-    复用 conftest.app_with_overrides 的 lifespan 模式，但额外覆盖 alpaca / akshare /
+    复用 conftest.app_with_overrides 的 lifespan 模式，但额外覆盖 alpaca / baostock /
     yfinance / fred —— conftest 默认只 mock 了 binance + test-venue。
     """
     from inalpha_data.connectors import _base as _connectors_base
     from inalpha_data.main import app
 
     async with app.router.lifespan_context(app):
-        for venue in ("binance", "alpaca", "akshare", "yfinance", "fred"):
+        for venue in ("binance", "alpaca", "baostock", "yfinance", "fred"):
             _connectors_base._REGISTRY[venue] = _FakeConnector()
         yield app
 
@@ -83,7 +83,7 @@ def all_venues_client(app_with_all_venues_mocked: Any) -> TestClient:
     [
         ("binance", "BTC/USDT", "1h"),
         ("alpaca", "AAPL", "1h"),
-        ("akshare", "sh.600519", "1d"),
+        ("baostock", "sh.600519", "1d"),
         ("yfinance", "TSLA", "1d"),
         ("fred", "DFF", "1d"),
     ],
@@ -149,15 +149,14 @@ def test_backfill_unknown_venue_returns_supported_list(
     supported = body["details"]["supported"]
     assert isinstance(supported, list)
     # 5 venue 全在
-    for v in ("binance", "alpaca", "akshare", "yfinance", "fred"):
+    for v in ("binance", "alpaca", "baostock", "yfinance", "fred"):
         assert v in supported
 
 
 @pytest.mark.parametrize(
     "venue, bad_timeframe",
     [
-        ("akshare", "1m"),  # akshare 仅日级
-        ("akshare", "1h"),  # akshare 仅日级
+        ("baostock", "1m"),  # baostock 不支持 1 分钟
         ("fred", "1m"),  # fred 仅日级及以上
         ("fred", "1h"),
     ],
@@ -191,6 +190,25 @@ def test_backfill_rejects_timeframe_unsupported_by_venue(
     assert isinstance(supported_tfs, list)
     assert bad_timeframe not in supported_tfs
     assert "1d" in supported_tfs  # 两个 venue 至少都支持 1d
+
+
+def test_legacy_akshare_alias_applies_baostock_minute_cap(
+    all_venues_client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    """旧 A 股 venue 别名必须与 baostock 走同一配额保护。"""
+    r = all_venues_client.post(
+        "/backfill/bars",
+        headers=auth_headers,
+        json={
+            "venue": "akshare",
+            "symbol": f"sh.600519-{uuid4().hex[:8]}",
+            "timeframe": "5m",
+            "from_ts": "2026-01-01T00:00:00Z",
+            "to_ts": "2026-04-01T00:00:00Z",
+        },
+    )
+    assert r.status_code == 200, r.json()
+    assert r.json()["from_ts"] == "2026-03-25T00:00:00Z"
 
 
 # ─── 增量 backfill：已缓存则从 max(ts) 续拉，不从 from_ts 全量重拉 ──────────

--- a/services/data/tests/test_connectors.py
+++ b/services/data/tests/test_connectors.py
@@ -1,4 +1,4 @@
-"""multi-venue connector 路由 + akshare symbol 解析单测（不打网络）。"""
+"""multi-venue connector 路由 + baostock symbol 解析单测（不打网络）。"""
 from __future__ import annotations
 
 import asyncio
@@ -15,7 +15,7 @@ from inalpha_data.connectors import (
     register_connector,
     unregister_connector,
 )
-from inalpha_data.connectors.akshare import _parse_symbol
+from inalpha_data.connectors.baostock import _parse_symbol
 
 # ────────────────────────────────────────────────────────────────────
 # Registry
@@ -83,7 +83,7 @@ def test_unregister_is_idempotent() -> None:
 
 
 # ────────────────────────────────────────────────────────────────────
-# akshare symbol 解析
+# baostock symbol 解析
 # ────────────────────────────────────────────────────────────────────
 
 
@@ -99,25 +99,16 @@ def test_parse_symbol_sz_a_share() -> None:
     assert code == "000001"
 
 
-def test_parse_symbol_hk_stock() -> None:
-    prefix, code = _parse_symbol("hk.00700")
-    assert prefix == "hk"
-    assert code == "00700"
+def test_parse_symbol_non_a_share_prefix_raises() -> None:
+    with pytest.raises(ValueError, match="unknown prefix 'hk'"):
+        _parse_symbol("hk.00700")
 
 
-@pytest.mark.parametrize(
-    "raw,want_prefix,want_code",
-    [
-        ("jp.6758", "jp", "6758"),
-        ("uk.BARC", "uk", "BARC"),
-        ("de.SAP", "de", "SAP"),
-    ],
-)
-def test_parse_symbol_global_prefixes(raw: str, want_prefix: str, want_code: str) -> None:
-    """G1: akshare 扩 jp/uk/de 三个新前缀，覆盖日股 / 英股 / 德股。"""
-    prefix, code = _parse_symbol(raw)
-    assert prefix == want_prefix
-    assert code == want_code
+@pytest.mark.parametrize("raw", ["jp.6758", "uk.BARC", "de.SAP"])
+def test_parse_symbol_global_prefixes_raise(raw: str) -> None:
+    """全球市场由 yfinance venue 承载，baostock 只接受沪深 A 股。"""
+    with pytest.raises(ValueError, match="unknown prefix"):
+        _parse_symbol(raw)
 
 
 def test_parse_symbol_case_insensitive_prefix() -> None:

--- a/services/data/tests/test_constituents.py
+++ b/services/data/tests/test_constituents.py
@@ -7,8 +7,8 @@ from uuid import uuid4
 import pandas as pd
 import pytest
 
-from inalpha_data.connectors import akshare as ak_conn
-from inalpha_data.connectors.akshare import _cn_symbol
+from inalpha_data.connectors import baostock as bs_conn
+from inalpha_data.connectors.baostock import _cn_symbol
 
 # ── connector：符号归一 + 列模糊匹配（无网络/无 DB）────────────────────
 
@@ -24,9 +24,11 @@ def test_cn_symbol_prefix() -> None:
 
 
 def test_fetch_constituents_sync_fuzzy_columns(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    """akshare 中证列名（成分券代码/名称/权重）模糊抽取 + 归一为 Inalpha 符号。"""
+    """akshare fallback 列名模糊抽取 + 归一为 Inalpha 符号。"""
     import akshare
+    import baostock
 
+    monkeypatch.setattr(baostock, "query_hs300_stocks", lambda: None)
     df = pd.DataFrame(
         {
             "日期": ["2026-06-26", "2026-06-26"],
@@ -38,7 +40,7 @@ def test_fetch_constituents_sync_fuzzy_columns(monkeypatch) -> None:  # type: ig
     monkeypatch.setattr(
         akshare, "index_stock_cons_weight_csindex", lambda symbol: df, raising=False
     )
-    out = ak_conn._fetch_constituents_sync(index_code="000300")
+    out = bs_conn._fetch_constituents_sync(index_code="000300")
     by_code = {o["code"]: o for o in out}
     assert set(by_code) == {"sh.600519", "sz.000001"}
     assert by_code["sh.600519"]["name"] == "贵州茅台"
@@ -54,6 +56,9 @@ def test_fetch_constituents_sync_picks_constituent_not_index_columns(
     本身（300 行全 = 000300/沪深300）。_find 改 key 优先后精确「成分券代码」先命中。
     """
     import akshare
+    import baostock
+
+    monkeypatch.setattr(baostock, "query_hs300_stocks", lambda: None)
 
     df = pd.DataFrame(
         {
@@ -68,7 +73,7 @@ def test_fetch_constituents_sync_picks_constituent_not_index_columns(
     monkeypatch.setattr(
         akshare, "index_stock_cons_weight_csindex", lambda symbol: df, raising=False
     )
-    out = ak_conn._fetch_constituents_sync(index_code="000300")
+    out = bs_conn._fetch_constituents_sync(index_code="000300")
     by_code = {o["code"]: o for o in out}
     assert set(by_code) == {"sh.600519", "sz.000001"}  # 成分，非 sz.000300
     assert by_code["sh.600519"]["name"] == "贵州茅台"  # 成分名，非「沪深300」
@@ -78,6 +83,9 @@ def test_fetch_constituents_sync_picks_constituent_not_index_columns(
 def test_fetch_constituents_sync_empty(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """weight 接口空 → 回退 cons 接口；都空 → []（优雅降级）。"""
     import akshare
+    import baostock
+
+    monkeypatch.setattr(baostock, "query_hs300_stocks", lambda: None)
 
     empty = pd.DataFrame()
     monkeypatch.setattr(
@@ -86,7 +94,7 @@ def test_fetch_constituents_sync_empty(monkeypatch) -> None:  # type: ignore[no-
     monkeypatch.setattr(
         akshare, "index_stock_cons_csindex", lambda symbol: empty, raising=False
     )
-    assert ak_conn._fetch_constituents_sync(index_code="000300") == []
+    assert bs_conn._fetch_constituents_sync(index_code="000300") == []
 
 
 # ── 存储：time-travel + 幂等（真实 DB，5433 inalpha）──────────────────

--- a/services/data/tests/test_financials_pit.py
+++ b/services/data/tests/test_financials_pit.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
 
-from inalpha_data.connectors.akshare import (
+from inalpha_data.connectors.baostock import (
     FINANCIALS_PUBLISH_LAG_DAYS,
     _flatten_financial_abstract,
     _period_publishable,
@@ -96,7 +96,7 @@ async def test_yfinance_as_of_marks_pit_not_supported(monkeypatch) -> None:
 
 async def test_financials_cache_is_pit_aware(monkeypatch) -> None:
     """#102 CR：PIT 缓存按 (symbol, as_of 天) 分格——同一天复用、不同天各打一次。"""
-    from inalpha_data.connectors import akshare as ak
+    from inalpha_data.connectors import baostock as bs
 
     calls = {"n": 0}
 
@@ -104,15 +104,15 @@ async def test_financials_cache_is_pit_aware(monkeypatch) -> None:
         calls["n"] += 1
         return {"净资产收益率(ROE)": 18.0}
 
-    monkeypatch.setattr(ak, "_fetch_financials_sync", fake_sync)
-    conn = ak.AkshareConnector()  # hk → 跳过 sh/sz 的 Baidu 估值网络调用
+    monkeypatch.setattr(bs, "_fetch_financials_sync", fake_sync)
+    conn = bs.BaostockConnector()
 
-    a1 = await conn.fetch_financials("hk.00700", as_of="2020-06-30T00:00:00Z")
-    a2 = await conn.fetch_financials("hk.00700", as_of="2020-06-30T23:00:00Z")  # 同一天
+    a1 = await conn.fetch_financials("sh.600519", as_of="2020-06-30T00:00:00Z")
+    a2 = await conn.fetch_financials("sh.600519", as_of="2020-06-30T23:00:00Z")
     assert a1["available"] is True and a2["available"] is True
     assert calls["n"] == 1  # 同 (symbol, 天) → 第二次命中缓存,不再打 akshare
 
-    await conn.fetch_financials("hk.00700", as_of="2020-09-30T00:00:00Z")  # 另一天
+    await conn.fetch_financials("sh.600519", as_of="2020-09-30T00:00:00Z")
     assert calls["n"] == 2  # 不同天 → 另一格,再打一次
 
 
@@ -120,10 +120,10 @@ async def test_ashare_valuation_skipped_for_historical_as_of(monkeypatch) -> Non
     """#102 CR M2：历史 as_of 跳过 Baidu 实时估值（防时序混用）；今天/None 照取。"""
     from datetime import UTC, datetime
 
-    from inalpha_data.connectors import akshare as ak
+    from inalpha_data.connectors import baostock as bs
 
     monkeypatch.setattr(
-        ak, "_fetch_financials_sync", lambda **kw: {"净资产收益率(ROE)": 18.0}
+        bs, "_fetch_financials_sync", lambda **kw: {"净资产收益率(ROE)": 18.0}
     )
     val_calls = {"n": 0}
 
@@ -131,8 +131,8 @@ async def test_ashare_valuation_skipped_for_historical_as_of(monkeypatch) -> Non
         val_calls["n"] += 1
         return {"market_cap": 1.0e12, "pe_ratio": 30.0, "pb_ratio": 5.0}
 
-    monkeypatch.setattr(ak, "_fetch_valuation_sync", fake_val)
-    conn = ak.AkshareConnector()
+    monkeypatch.setattr(bs, "_fetch_valuation_sync", fake_val)
+    conn = bs.BaostockConnector()
 
     # 历史 as_of（去年）→ 跳过实时估值,估值字段留空
     hist = await conn.fetch_financials("sh.600519", as_of="2020-01-01T00:00:00Z")
@@ -149,7 +149,7 @@ async def test_ashare_valuation_skipped_for_historical_as_of(monkeypatch) -> Non
 
 async def test_cache_key_normalizes_tz_to_utc(monkeypatch) -> None:
     """#102 CR：as_of 归一到 UTC——+08:00 与其 UTC 等价串落同一缓存格（同 UTC 日）。"""
-    from inalpha_data.connectors import akshare as ak
+    from inalpha_data.connectors import baostock as bs
 
     calls = {"n": 0}
 
@@ -157,12 +157,12 @@ async def test_cache_key_normalizes_tz_to_utc(monkeypatch) -> None:
         calls["n"] += 1
         return {"净资产收益率(ROE)": 18.0}
 
-    monkeypatch.setattr(ak, "_fetch_financials_sync", fake_sync)
-    conn = ak.AkshareConnector()
+    monkeypatch.setattr(bs, "_fetch_financials_sync", fake_sync)
+    conn = bs.BaostockConnector()
 
     # 两者都 = UTC 2020-06-29；未归一时 +08:00 的本地日期是 06-30 会落到另一格
-    await conn.fetch_financials("hk.00700", as_of="2020-06-30T07:00:00+08:00")
-    await conn.fetch_financials("hk.00700", as_of="2020-06-29T23:00:00Z")
+    await conn.fetch_financials("sh.600519", as_of="2020-06-30T07:00:00+08:00")
+    await conn.fetch_financials("sh.600519", as_of="2020-06-29T23:00:00Z")
     assert calls["n"] == 1  # 同 UTC 日 → 同缓存格,只打一次
 
 
@@ -170,27 +170,27 @@ def test_fundamentals_endpoint_threads_as_of(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:
     """GET /fundamentals?as_of=... 把 as_of 透传到 connector。"""
-    from inalpha_data.connectors import akshare as ak
+    from inalpha_data.connectors import baostock as bs
 
     captured: dict[str, str | None] = {}
-    original = ak._connector.fetch_financials
+    original = bs._connector.fetch_financials
 
     async def mock_fin(symbol, as_of=None):
         captured["as_of"] = as_of
         return {
-            "venue": "akshare",
+            "venue": "baostock",
             "symbol": symbol,
             "available": False,
             "reason": f"no financials published as of {as_of}",
         }
 
-    ak._connector.fetch_financials = mock_fin
+    bs._connector.fetch_financials = mock_fin
     try:
         r = client.get(
             "/fundamentals",
             headers=auth_headers,
             params={
-                "venue": "akshare",
+                "venue": "baostock",
                 "symbol": "sh.600519",
                 "as_of": "2026-01-01T00:00:00Z",
             },
@@ -199,4 +199,4 @@ def test_fundamentals_endpoint_threads_as_of(
         assert captured["as_of"] == "2026-01-01T00:00:00Z"
         assert r.json()["available"] is False
     finally:
-        ak._connector.fetch_financials = original
+        bs._connector.fetch_financials = original

--- a/services/data/tests/test_fundamentals.py
+++ b/services/data/tests/test_fundamentals.py
@@ -9,21 +9,21 @@ pytestmark = pytest.mark.anyio
 
 def test_fundamentals_requires_auth(client: TestClient) -> None:
     """GET /fundamentals without token returns 401."""
-    r = client.get("/fundamentals", params={"venue": "akshare", "symbol": "sh.600519"})
+    r = client.get("/fundamentals", params={"venue": "baostock", "symbol": "sh.600519"})
     assert r.status_code == 401
 
 
-def test_fundamentals_akshare_venue(
+def test_fundamentals_baostock_venue(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:
-    """Mocked akshare connector returns financial data."""
-    from inalpha_data.connectors import akshare as ak
+    """Mocked baostock connector returns financial data."""
+    from inalpha_data.connectors import baostock as bs
 
-    original = ak._connector.fetch_financials
+    original = bs._connector.fetch_financials
 
     async def mock_fin(symbol, as_of=None):
         return {
-            "venue": "akshare",
+            "venue": "baostock",
             "symbol": symbol,
             "available": True,
             "as_of": "2026-05-29T00:00:00Z",
@@ -36,12 +36,12 @@ def test_fundamentals_akshare_venue(
             "raw": {"总市值": "2300000000000"},
         }
 
-    ak._connector.fetch_financials = mock_fin
+    bs._connector.fetch_financials = mock_fin
     try:
         r = client.get(
             "/fundamentals",
             headers=auth_headers,
-            params={"venue": "akshare", "symbol": "sh.600519"},
+            params={"venue": "baostock", "symbol": "sh.600519"},
         )
         assert r.status_code == 200
         body = r.json()
@@ -49,7 +49,31 @@ def test_fundamentals_akshare_venue(
         assert body["indicators"]["pe_ratio"] == 32.5
         assert body["indicators"]["roe"] == 0.283
     finally:
-        ak._connector.fetch_financials = original
+        bs._connector.fetch_financials = original
+
+
+def test_fundamentals_legacy_akshare_alias(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    """旧 A 股 venue 在迁移窗口内仍路由到 baostock。"""
+    from inalpha_data.connectors import baostock as bs
+
+    original = bs._connector.fetch_financials
+
+    async def mock_fin(symbol, as_of=None):
+        return {"venue": "baostock", "symbol": symbol, "available": False, "reason": "no data"}
+
+    bs._connector.fetch_financials = mock_fin
+    try:
+        r = client.get(
+            "/fundamentals",
+            headers=auth_headers,
+            params={"venue": "akshare", "symbol": "sh.600519"},
+        )
+        assert r.status_code == 200
+        assert r.json()["venue"] == "baostock"
+    finally:
+        bs._connector.fetch_financials = original
 
 
 def test_fundamentals_yfinance_venue(
@@ -102,27 +126,27 @@ def test_fundamentals_unavailable_data(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:
     """Connector returns available=False → endpoint returns 200 with available=False."""
-    from inalpha_data.connectors import akshare as ak
+    from inalpha_data.connectors import baostock as bs
 
-    original = ak._connector.fetch_financials
+    original = bs._connector.fetch_financials
 
     async def mock_fin(symbol, as_of=None):
         return {
-            "venue": "akshare",
+            "venue": "baostock",
             "symbol": symbol,
             "available": False,
             "reason": "no data",
         }
 
-    ak._connector.fetch_financials = mock_fin
+    bs._connector.fetch_financials = mock_fin
     try:
         r = client.get(
             "/fundamentals",
             headers=auth_headers,
-            params={"venue": "akshare", "symbol": "jp.6758"},
+            params={"venue": "baostock", "symbol": "sh.600519"},
         )
         assert r.status_code == 200
         body = r.json()
         assert body["available"] is False
     finally:
-        ak._connector.fetch_financials = original
+        bs._connector.fetch_financials = original

--- a/services/data/tests/test_news.py
+++ b/services/data/tests/test_news.py
@@ -1,4 +1,4 @@
-"""Tests for GET /news endpoint — extended to support akshare venue (D-10)."""
+"""Tests for GET /news endpoint — extended to support baostock venue."""
 from __future__ import annotations
 
 import pytest
@@ -47,13 +47,13 @@ def test_news_yfinance_venue(
         yf._connector.fetch_news = original
 
 
-def test_news_akshare_venue(
+def test_news_baostock_venue(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:
-    """GET /news with venue=akshare returns A-share news (D-10 new)."""
-    from inalpha_data.connectors import akshare as ak
+    """GET /news with venue=baostock returns A-share news."""
+    from inalpha_data.connectors import baostock as bs
 
-    original = ak._connector.fetch_news
+    original = bs._connector.fetch_news
 
     async def mock_news(symbol, limit=20):
         return [
@@ -66,19 +66,19 @@ def test_news_akshare_venue(
             }
         ]
 
-    ak._connector.fetch_news = mock_news
+    bs._connector.fetch_news = mock_news
     try:
         r = client.get(
             "/news",
             headers=auth_headers,
-            params={"venue": "akshare", "symbol": "sh.600519"},
+            params={"venue": "baostock", "symbol": "sh.600519"},
         )
         assert r.status_code == 200
         body = r.json()
         assert len(body["items"]) == 1
         assert "茅台" in body["items"][0]["title"]
     finally:
-        ak._connector.fetch_news = original
+        bs._connector.fetch_news = original
 
 
 def test_news_unsupported_venue(

--- a/services/data/tests/test_scheduler.py
+++ b/services/data/tests/test_scheduler.py
@@ -124,7 +124,7 @@ async def test_record_snapshot_honors_passed_as_of_date(
         captured["as_of_date"] = as_of_date
         return len(constituents)
 
-    monkeypatch.setattr(sched, "get_akshare_connector", lambda: _FakeAk())
+    monkeypatch.setattr(sched, "get_baostock_connector", lambda: _FakeAk())
     monkeypatch.setattr(sched.store, "upsert_snapshot", fake_upsert)
 
     pinned = date(2026, 1, 31)

--- a/services/factor/src/inalpha_factor/schemas.py
+++ b/services/factor/src/inalpha_factor/schemas.py
@@ -254,7 +254,7 @@ class PanelScoreRequest(BaseModel):
         default=None,
         description="指数代码（如 000300），由 data /constituents 解析 as_of 那刻的 **PIT 成分**"
         "当 universe（is_pit=true，去存活者偏差）。取不到 PIT 快照 → 显式降级返空,**不**回退"
-        "当前成分。venue 应配 akshare（成分是 A股符号）。与 symbols 二选一,优先 index_code。",
+        "当前成分。venue 应配 baostock（成分是 A股符号）。与 symbols 二选一,优先 index_code。",
         examples=["000300"],
     )
     timeframe: str = Field(default="1d")

--- a/services/paper/src/inalpha_paper/execution/risk_rules/exchange_resolver.py
+++ b/services/paper/src/inalpha_paper/execution/risk_rules/exchange_resolver.py
@@ -109,7 +109,7 @@ def resolve_calendar_code(venue: str, symbol: str) -> str | None:
     if v == "fred":
         return None  # 宏观，无交易时段
 
-    if v == "baostock":
+    if v in ("akshare", "baostock"):
         prefix = s.split(".", 1)[0] if "." in s else ""
         return _AKSHARE_PREFIX_TO_CODE.get(prefix)
 

--- a/services/research/src/inalpha_research/analysts/utils.py
+++ b/services/research/src/inalpha_research/analysts/utils.py
@@ -103,21 +103,25 @@ def render_web_results(results: list[dict]) -> str:
 def fundamentals_route(*, venue: str, market_type: str) -> str | None:
     """研究 venue → fundamentals 数据源 venue 的映射。
 
-    data 服务 ``/fundamentals`` 只支持 akshare / yfinance，直接透传研究 venue
+    data 服务 ``/fundamentals`` 只支持 baostock / yfinance，直接透传研究 venue
     （alpaca / binance / ...）会 422 → 永远 unavailable——美股走 alpaca 研究时
     本可从 yfinance 拿到财报却拿不到，这是 fundamental/valuation/persona 一直
     "无 live 数据"的根因之一。
 
     Returns:
-        ``"akshare"`` / ``"yfinance"``，或 ``None``（crypto 无财报，调用方应跳过
+        ``"baostock"`` / ``"yfinance"``，或 ``None``（crypto 无财报，调用方应跳过
         fundamentals 请求省一次 round-trip，转而依赖链上 / web 证据）。
     """
     if market_type == "crypto":
         return None
     v = venue.lower()
-    if v in ("akshare", "yfinance"):
+    if v in ("baostock", "yfinance"):
         return v
-    if market_type in ("cn_stock", "hk_stock"):
-        return "akshare"
+    if v == "akshare" and market_type == "cn_stock":
+        return "baostock"
+    if market_type == "cn_stock":
+        return "baostock"
+    if market_type == "hk_stock":
+        return "yfinance"
     # us_stock / global_stock / 指数：yfinance 全球兜底（查不到时上游返 available=False）
     return "yfinance"

--- a/services/research/src/inalpha_research/researchers/base.py
+++ b/services/research/src/inalpha_research/researchers/base.py
@@ -108,8 +108,8 @@ def infer_asset_type(*, venue: str, symbol: str = "") -> AssetType:
 
     - ``binance`` + ``BTC/USDT`` → ``crypto``
     - ``alpaca`` + ``AAPL``      → ``us_stock``
-    - ``akshare`` + ``sh.600519`` → ``cn_stock``
-    - ``akshare`` + ``hk.00700``  → ``hk_stock``
+    - ``baostock`` + ``sh.600519`` → ``cn_stock``
+    - ``yfinance`` + ``0700.HK``   → ``hk_stock``
     - ``akshare`` + ``jp.6758``   → ``global_stock``（日股目前归全球桶）
     - ``yfinance`` + ``005930.KS`` → ``global_stock``
     - ``yfinance`` + ``AAPL``      → ``us_stock``（无后缀视为美股）
@@ -122,7 +122,7 @@ def infer_asset_type(*, venue: str, symbol: str = "") -> AssetType:
     if v == "alpaca":
         return "us_stock"
 
-    if v == "akshare":
+    if v in ("akshare", "baostock"):
         s = symbol.lower()
         if s.startswith(("sh.", "sz.")):
             return "cn_stock"


### PR DESCRIPTION
## 变更

- 将 A 股 canonical venue 从 `akshare` 拆为 `baostock`
- 保留 `akshare + sh./sz.` 请求兼容，并统一 bars/backfill/ticker/fundamentals/news 路由
- 修复旧别名绕过 Baostock 分钟回溯上限
- 同步 research / factor / paper 消费者和数据服务测试
- 增加迁移，将存量 A 股 bars 从 `akshare` 幂等搬到 `baostock`

## 合并前审查

首次验证发现并修复 4 个阻塞问题：

1. connector 重命名导致 data 测试 collection 失败
2. 旧 venue 别名绕过分钟 K 配额限制
3. research 仍把 A 股基本面路由到已移除的 `akshare`
4. 存量 `akshare` bars 在新 venue 下不可见

安全专项复核无新增发现。

## 验证

- orchestration typecheck 通过
- orchestration 相关 Vitest：74 passed
- data 相关测试：74 passed
- research：30 passed
- paper：67 passed
- factor：25 passed
- Ruff：通过
- `scripts/check-consistency.sh`：10 passed，0 failed
- Alembic：单一 head `0035`

完整 orchestration suite 另有 1 个既存 wall-time 测试失败：`workflows.hello.test.ts` 要求 `<150ms`，本机单跑约 300ms；与本次 venue 变更无关，相关 439 个测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)