### PR TITLE
fix(infra): selfhost 补服务间 URL,修 factor/data 容器内自连失败

### DIFF
--- a/infra/.env.selfhost.example
+++ b/infra/.env.selfhost.example
@@ -21,6 +21,13 @@ ENV_FILE=.env.selfhost
 IMAGE_PREFIX=inalpha
 IMAGE_TAG=latest
 
+# 服务间互访地址(容器内):由 orchestrator(mastra) 与各 Python 服务
+# 通过 env_file 注入。缺任一 → 对应服务拿 localhost 默认值,容器内自连失败。
+DATA_SERVICE_URL=http://data:8001
+PAPER_SERVICE_URL=http://paper:8002
+RESEARCH_SERVICE_URL=http://research:8003
+FACTOR_SERVICE_URL=http://factor:8004
+
 # Each authenticated user configures their own LLM API key in the dashboard.
 # Do not add provider API keys here as a shared fallback.
 


### PR DESCRIPTION
## 问题

selfhost 部署下 `factor.timing` 报 `failed to reach data-service after 3 attempts`(502)。

根因:容器化迁移时,`.env.selfhost.example` **漏了 `DATA_SERVICE_URL` 等 4 个服务间互访地址**。factor/research 走 `x-svc-common` 的 `env_file`(读 `${ENV_FILE}`)注入配置,而 `.env.selfhost` 里没有 `DATA_SERVICE_URL` → factor 的 `settings.data_service_url` 回落默认值 `http://localhost:8001`,容器内 **连自己** → 全部连接失败 → 502。

对比:
- `.env.prod.example` **本就有**这 4 个 URL(`DATA_SERVICE_URL` / `PAPER_SERVICE_URL` / `RESEARCH_SERVICE_URL` / `FACTOR_SERVICE_URL`)
- prod compose 里 mastra 也在 `environment:` 显式配了同样的 4 个 URL

唯独 selfhost 的 env example 漏了 → selfhost 容器化后 factor/research 与 data/paper 之间互访断裂。

## 修复

在 `.env.selfhost.example` 补上这 4 个服务间 URL(与 `.env.prod.example` 对齐)。

运行时生效方式:`bash scripts/selfhost.sh init` 会把它拷成 `.env.selfhost`;已部署的实例需手动把这 4 行补进 `.env.selfhost` 后 `bash scripts/selfhost.sh up` 重建 factor。

## 验证

- factor 容器注入 `DATA_SERVICE_URL=http://data:8001` 后,容器内 `http://data:8001/health` → 200
- dashboard 重新跑 `factor.timing` → 恢复可用

## 与 #107 的关系

#107 是"data-service 高并发饱和"的**容量**专项,排障时基于"factor 能连到 data"的前提。本 PR 是**配置**回归修复(容器化迁移丢 URL),两者正交:#107 解决的"持续过载拒连"与本 PR 解决的"根本连不上"是不同层。补上 URL 后 #107 的容量优化仍有意义。

Closes 后关联 #107。