### PR TITLE
fix(paper): 修复A股下单取价与人民币计价

### DIFF
--- a/packages/orchestration/src/mastra/agents/instructions/market.ts
+++ b/packages/orchestration/src/mastra/agents/instructions/market.ts
@@ -53,7 +53,8 @@ export const MARKET_CONTEXT = `
   港股 / 全球指数 / FRED 宏观）；需后端有该 venue 的历史 K 线（先 backfill）
 - swarm.run_backtest_grid —— 同 paper.run_backtest，**全市场可 grid**；不要
   因为旧 prompt 印象拒绝美股 / A 股 / 指数的 grid 请求
-- trade.create_plan —— 当前 paper service 撮合只对 crypto 完整测过；其它市场跑通需 D-10+ 工作
+- trade.create_plan —— spot 现货模拟下单支持所有可报价市场；执行时由 paper service
+  重新获取 fresh ticker 作为参考价。perp 仍仅支持 crypto 永续标的
 
 ## 多空意识（两种模式：spot 现货做多 + perp 永续做空/杠杆）
 

--- a/packages/orchestration/src/mastra/agents/instructions/market.ts
+++ b/packages/orchestration/src/mastra/agents/instructions/market.ts
@@ -53,13 +53,15 @@ export const MARKET_CONTEXT = `
   港股 / 全球指数 / FRED 宏观）；需后端有该 venue 的历史 K 线（先 backfill）
 - swarm.run_backtest_grid —— 同 paper.run_backtest，**全市场可 grid**；不要
   因为旧 prompt 印象拒绝美股 / A 股 / 指数的 grid 请求
-- trade.create_plan —— spot 现货模拟下单支持所有可报价市场；执行时由 paper service
-  重新获取 fresh ticker 作为参考价。perp 仍仅支持 crypto 永续标的
+- trade.create_plan —— 当前仅支持 spot 现货模拟计划；已验证 crypto / A 股。执行时由
+  paper service 获取 fresh ticker，因此只适用于实现外部 ticker capability 的交易 venue
+  （binance / yfinance / alpaca / baostock），FRED 宏观序列不可交易。plan 的 perp 参数尚未贯通，
+  不要用 trade.create_plan 创建永续计划
 
 ## 多空意识（两种模式：spot 现货做多 + perp 永续做空/杠杆）
 
-模拟盘有两种模式，由 \`paper.run_backtest\` / \`paper.start_strategy\` /
-\`trade.create_plan\` 的 \`tradingMode\` 参数选择：
+模拟盘回测与策略运行由 \`paper.run_backtest\` / \`paper.start_strategy\` 的
+\`tradingMode\` 参数选择；\`trade.create_plan\` 当前固定为 spot：
 
 - **spot（默认）**：现货做多。BUY 开多 → SELL 平多。标的：所有市场。
 - **perp**：USDT-M 永续 + 逐仓。**可做多也可做空**（BUY 开多 / SELL 开空 / 反方向平仓）。

--- a/services/data/src/inalpha_data/connectors/baostock.py
+++ b/services/data/src/inalpha_data/connectors/baostock.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import threading as _threading
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -69,9 +70,65 @@ _PERIOD_MAP: dict[str, str] = {
 _FETCH_LOCK = asyncio.Lock()
 #: 最小拉取间隔（秒）。公开页比 Yahoo API 更脆弱，≥1s；A 股按直连配方限速。
 _MIN_FETCH_INTERVAL_S = 1.0
-#: 锁内单次拉取超时上限——网络挂起时快速放锁，不把整个 panel 拖死。
+#: 锁内单次拉取超时上限。caller 按时失败，但后台线程退出前继续持锁，避免请求重叠。
 _FETCH_TIMEOUT_S = 30.0
 _last_fetch_mono: float = 0.0
+_LOCK_RELEASE_TASKS: set[asyncio.Task[None]] = set()
+
+
+async def _release_fetch_lock_after_worker(
+    worker: asyncio.Task[Any],
+    lock: asyncio.Lock,
+) -> None:
+    """caller 已超时/取消时，等线程退出后再推进间隔并释放源站锁。"""
+    global _last_fetch_mono
+    try:
+        await worker
+    except BaseException:
+        pass
+    finally:
+        _last_fetch_mono = time.monotonic()
+        lock.release()
+
+
+def _handoff_fetch_lock(
+    worker: asyncio.Task[Any],
+    lock: asyncio.Lock,
+) -> None:
+    """把锁释放责任转交后台 task，并保留强引用直到 task 完成。"""
+    release_task = asyncio.create_task(_release_fetch_lock_after_worker(worker, lock))
+    _LOCK_RELEASE_TASKS.add(release_task)
+    release_task.add_done_callback(_LOCK_RELEASE_TASKS.discard)
+
+
+async def _throttled_to_thread[FetchResult](
+    func: Callable[..., FetchResult],
+    /,
+    **kwargs: Any,
+) -> FetchResult:
+    """串行执行同步源站请求；超时后等线程真正退出才释放共享锁。"""
+    global _last_fetch_mono
+    lock = _FETCH_LOCK
+    await lock.acquire()
+    release_here = True
+    try:
+        wait = _MIN_FETCH_INTERVAL_S - (time.monotonic() - _last_fetch_mono)
+        if wait > 0:
+            await asyncio.sleep(wait)
+        worker = asyncio.create_task(asyncio.to_thread(func, **kwargs))
+        try:
+            return await asyncio.wait_for(
+                asyncio.shield(worker),
+                timeout=_FETCH_TIMEOUT_S,
+            )
+        except (TimeoutError, asyncio.CancelledError):
+            _handoff_fetch_lock(worker, lock)
+            release_here = False
+            raise
+    finally:
+        if release_here:
+            _last_fetch_mono = time.monotonic()
+            lock.release()
 
 # ── baostock 持久会话 ────────────────────────────────────────────────
 # baostock login 需 ~4.3s/次；每个 fetch 单独 login+logout 会把跑批拖慢一个数量级。
@@ -295,27 +352,10 @@ class BaostockConnector:
     @staticmethod
     async def _throttled_fetch_ticker_sync(*, symbol: str) -> tuple[datetime, float]:
         """让实时 ticker 与 K 线请求共用腾讯源站串行限流。"""
-        global _last_fetch_mono
-        async with _FETCH_LOCK:
-            try:
-                wait = _MIN_FETCH_INTERVAL_S - (time.monotonic() - _last_fetch_mono)
-                if wait > 0:
-                    await asyncio.sleep(wait)
-                worker = asyncio.create_task(
-                    asyncio.to_thread(_fetch_tencent_ticker_sync, symbol=symbol)
-                )
-                try:
-                    return await asyncio.shield(worker)
-                except asyncio.CancelledError:
-                    # to_thread 无法终止；等线程真正退出再释放源站锁，避免超时/断连后
-                    # 下一请求与后台残留请求并发。
-                    try:
-                        await worker
-                    except Exception:
-                        pass
-                    raise
-            finally:
-                _last_fetch_mono = time.monotonic()
+        return await _throttled_to_thread(
+            _fetch_tencent_ticker_sync,
+            symbol=symbol,
+        )
 
     @staticmethod
     async def _throttled_fetch_sync(
@@ -330,31 +370,21 @@ class BaostockConnector:
         """串行 + 最小间隔跑 A 股公开行情请求，防并发突发触发反爬。
 
         进程级 ``_FETCH_LOCK`` 保证同一时刻只有一个请求在飞；锁内再补足
-        ``_MIN_FETCH_INTERVAL_S`` 的最小间隔。锁内每请求超时 ``_FETCH_TIMEOUT_S``，
-        TCP 挂起时快速放锁让队列继续。
+        ``_MIN_FETCH_INTERVAL_S`` 的最小间隔。caller 超过 ``_FETCH_TIMEOUT_S``
+        后及时失败；同步线程不可取消，因此其真正退出前仍持有共享锁，避免后续
+        K 线或 ticker 请求与残留线程重叠。
 
         对齐 yfinance ``_throttled_fetch_sync`` 模式。
         """
-        global _last_fetch_mono
-        async with _FETCH_LOCK:
-            try:
-                wait = _MIN_FETCH_INTERVAL_S - (time.monotonic() - _last_fetch_mono)
-                if wait > 0:
-                    await asyncio.sleep(wait)
-                return await asyncio.wait_for(
-                    asyncio.to_thread(
-                        _fetch_sync,
-                        prefix=prefix,
-                        code=code,
-                        period=period,
-                        start_str=start_str,
-                        end_str=end_str,
-                        limit=limit,
-                    ),
-                    timeout=_FETCH_TIMEOUT_S,
-                )
-            finally:
-                _last_fetch_mono = time.monotonic()
+        return await _throttled_to_thread(
+            _fetch_sync,
+            prefix=prefix,
+            code=code,
+            period=period,
+            start_str=start_str,
+            end_str=end_str,
+            limit=limit,
+        )
 
     async def fetch_financials(self, symbol: str, as_of: str | None = None) -> dict[str, Any]:
         """拉 A股 / 港股 财报基本面数据。

--- a/services/data/src/inalpha_data/connectors/baostock.py
+++ b/services/data/src/inalpha_data/connectors/baostock.py
@@ -288,12 +288,25 @@ class BaostockConnector:
         """从腾讯财经实时行情接口返回最新报价时间和价格。"""
         prefix, code = _parse_symbol(symbol)
         try:
-            return await asyncio.wait_for(
-                asyncio.to_thread(_fetch_tencent_ticker_sync, symbol=f"{prefix}.{code}"),
-                timeout=_FETCH_TIMEOUT_S,
-            )
+            return await self._throttled_fetch_ticker_sync(symbol=f"{prefix}.{code}")
         except Exception as exc:
             raise RuntimeError(f"A-share ticker unavailable for {symbol}: {exc}") from exc
+
+    @staticmethod
+    async def _throttled_fetch_ticker_sync(*, symbol: str) -> tuple[datetime, float]:
+        """让实时 ticker 与 K 线请求共用腾讯源站串行限流。"""
+        global _last_fetch_mono
+        async with _FETCH_LOCK:
+            try:
+                wait = _MIN_FETCH_INTERVAL_S - (time.monotonic() - _last_fetch_mono)
+                if wait > 0:
+                    await asyncio.sleep(wait)
+                return await asyncio.wait_for(
+                    asyncio.to_thread(_fetch_tencent_ticker_sync, symbol=symbol),
+                    timeout=_FETCH_TIMEOUT_S,
+                )
+            finally:
+                _last_fetch_mono = time.monotonic()
 
     @staticmethod
     async def _throttled_fetch_sync(

--- a/services/data/src/inalpha_data/connectors/baostock.py
+++ b/services/data/src/inalpha_data/connectors/baostock.py
@@ -106,10 +106,14 @@ async def _throttled_to_thread[FetchResult](
     /,
     **kwargs: Any,
 ) -> FetchResult:
-    """串行执行同步源站请求；超时后等线程真正退出才释放共享锁。"""
+    """串行执行同步源站请求；等待锁或执行超时均及时失败。
+
+    同步 worker 超时后仍在后台运行时，锁只由 handoff task 在 worker 真正退出后
+    释放；后续 caller 等锁也受 ``_FETCH_TIMEOUT_S`` 约束，不会跟随残留线程永久挂起。
+    """
     global _last_fetch_mono
     lock = _FETCH_LOCK
-    await lock.acquire()
+    await asyncio.wait_for(lock.acquire(), timeout=_FETCH_TIMEOUT_S)
     release_here = True
     try:
         wait = _MIN_FETCH_INTERVAL_S - (time.monotonic() - _last_fetch_mono)

--- a/services/data/src/inalpha_data/connectors/baostock.py
+++ b/services/data/src/inalpha_data/connectors/baostock.py
@@ -301,10 +301,19 @@ class BaostockConnector:
                 wait = _MIN_FETCH_INTERVAL_S - (time.monotonic() - _last_fetch_mono)
                 if wait > 0:
                     await asyncio.sleep(wait)
-                return await asyncio.wait_for(
-                    asyncio.to_thread(_fetch_tencent_ticker_sync, symbol=symbol),
-                    timeout=_FETCH_TIMEOUT_S,
+                worker = asyncio.create_task(
+                    asyncio.to_thread(_fetch_tencent_ticker_sync, symbol=symbol)
                 )
+                try:
+                    return await asyncio.shield(worker)
+                except asyncio.CancelledError:
+                    # to_thread 无法终止；等线程真正退出再释放源站锁，避免超时/断连后
+                    # 下一请求与后台残留请求并发。
+                    try:
+                        await worker
+                    except Exception:
+                        pass
+                    raise
             finally:
                 _last_fetch_mono = time.monotonic()
 

--- a/services/data/src/inalpha_data/schemas.py
+++ b/services/data/src/inalpha_data/schemas.py
@@ -90,10 +90,9 @@ class TickerQuery(BaseModel):
     fresh: bool = Field(
         default=False,
         description=(
-            "true 时绕过 DB 缓存，直接调外部市场实时 ticker。"
-            "支持 venue：binance / yfinance / alpaca；baostock / fred 不支持，"
-            "会返 422 FRESH_NOT_SUPPORTED_FOR_VENUE 并提示切 fresh=false。"
-            "适合 scheduler 周期性拉真·最新价的场景。"
+            "true 时绕过 DB 缓存，直接调用 venue 的外部 ticker capability。"
+            "当前支持 binance / yfinance / alpaca / baostock；其它 venue 若未实现，"
+            "会返回 422 FRESH_NOT_SUPPORTED_FOR_VENUE。适合实时行情和交易执行取价。"
         ),
     )
 

--- a/services/data/tests/test_connectors.py
+++ b/services/data/tests/test_connectors.py
@@ -217,6 +217,39 @@ def test_baostock_fetch_ticker_rejects_missing_quote_fields(monkeypatch) -> None
         asyncio.run(BaostockConnector().fetch_ticker("sh.000001"))
 
 
+def test_baostock_fetch_ticker_serializes_tencent_requests(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """并发 ticker 必须复用公开源站锁，不能同时打腾讯接口。"""
+    from inalpha_data.connectors import baostock as baostock_mod
+    from inalpha_data.connectors.baostock import BaostockConnector
+
+    active = 0
+    max_active = 0
+
+    def _fake_fetch(*, symbol: str) -> tuple[datetime, float]:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        time.sleep(0.02)
+        active -= 1
+        return datetime(2026, 7, 22, 7, 0, tzinfo=UTC), float(symbol[-1])
+
+    monkeypatch.setattr(baostock_mod, "_FETCH_LOCK", asyncio.Lock())
+    monkeypatch.setattr(baostock_mod, "_MIN_FETCH_INTERVAL_S", 0.0)
+    monkeypatch.setattr(baostock_mod, "_last_fetch_mono", 0.0)
+    monkeypatch.setattr(baostock_mod, "_fetch_tencent_ticker_sync", _fake_fetch)
+
+    async def _run() -> list[tuple[datetime, float]]:
+        connector = BaostockConnector()
+        return await asyncio.gather(
+            connector.fetch_ticker("sh.000001"),
+            connector.fetch_ticker("sz.000002"),
+        )
+
+    results = asyncio.run(_run())
+    assert max_active == 1
+    assert [price for _, price in results] == [1.0, 2.0]
+
+
 @pytest.mark.parametrize(
     ("timeframe", "expected_url", "expected_period", "expected_end"),
     [

--- a/services/data/tests/test_connectors.py
+++ b/services/data/tests/test_connectors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from datetime import UTC, datetime
 
@@ -248,6 +249,48 @@ def test_baostock_fetch_ticker_serializes_tencent_requests(monkeypatch) -> None:
     results = asyncio.run(_run())
     assert max_active == 1
     assert [price for _, price in results] == [1.0, 2.0]
+
+
+def test_baostock_cancelled_ticker_holds_lock_until_thread_exits(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """caller 取消不能提前放锁，让仍在运行的 to_thread 与下一请求重叠。"""
+    from inalpha_data.connectors import baostock as baostock_mod
+    from inalpha_data.connectors.baostock import BaostockConnector
+
+    active = 0
+    max_active = 0
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def _fake_fetch(*, symbol: str) -> tuple[datetime, float]:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        if symbol == "sh.000001":
+            first_started.set()
+            release_first.wait(timeout=1)
+        active -= 1
+        return datetime(2026, 7, 22, 7, 0, tzinfo=UTC), float(symbol[-1])
+
+    monkeypatch.setattr(baostock_mod, "_FETCH_LOCK", asyncio.Lock())
+    monkeypatch.setattr(baostock_mod, "_MIN_FETCH_INTERVAL_S", 0.0)
+    monkeypatch.setattr(baostock_mod, "_last_fetch_mono", 0.0)
+    monkeypatch.setattr(baostock_mod, "_fetch_tencent_ticker_sync", _fake_fetch)
+
+    async def _run() -> float:
+        connector = BaostockConnector()
+        first = asyncio.create_task(connector.fetch_ticker("sh.000001"))
+        assert await asyncio.to_thread(first_started.wait, 1)
+        first.cancel()
+        second = asyncio.create_task(connector.fetch_ticker("sz.000002"))
+        await asyncio.sleep(0.01)
+        assert max_active == 1
+        release_first.set()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        return (await second)[1]
+
+    assert asyncio.run(_run()) == 2.0
+    assert max_active == 1
 
 
 @pytest.mark.parametrize(

--- a/services/data/tests/test_connectors.py
+++ b/services/data/tests/test_connectors.py
@@ -293,6 +293,47 @@ def test_baostock_cancelled_ticker_holds_lock_until_thread_exits(monkeypatch) ->
     assert max_active == 1
 
 
+def test_baostock_ticker_timeout_keeps_lock_until_thread_exits(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """ticker 按时返回超时，但后台线程结束前下一请求仍不能进入源站。"""
+    from inalpha_data.connectors import baostock as baostock_mod
+    from inalpha_data.connectors.baostock import BaostockConnector
+
+    active = 0
+    max_active = 0
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def _fake_fetch(*, symbol: str) -> tuple[datetime, float]:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        if symbol == "sh.000001":
+            first_started.set()
+            release_first.wait(timeout=1)
+        active -= 1
+        return datetime(2026, 7, 22, 7, 0, tzinfo=UTC), float(symbol[-1])
+
+    monkeypatch.setattr(baostock_mod, "_FETCH_LOCK", asyncio.Lock())
+    monkeypatch.setattr(baostock_mod, "_MIN_FETCH_INTERVAL_S", 0.0)
+    monkeypatch.setattr(baostock_mod, "_FETCH_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(baostock_mod, "_last_fetch_mono", 0.0)
+    monkeypatch.setattr(baostock_mod, "_fetch_tencent_ticker_sync", _fake_fetch)
+
+    async def _run() -> float:
+        connector = BaostockConnector()
+        with pytest.raises(RuntimeError, match="A-share ticker unavailable"):
+            await connector.fetch_ticker("sh.000001")
+        assert first_started.is_set()
+        second = asyncio.create_task(connector.fetch_ticker("sz.000002"))
+        await asyncio.sleep(0.01)
+        assert max_active == 1
+        release_first.set()
+        return (await second)[1]
+
+    assert asyncio.run(_run()) == 2.0
+    assert max_active == 1
+
+
 @pytest.mark.parametrize(
     ("timeframe", "expected_url", "expected_period", "expected_end"),
     [

--- a/services/data/tests/test_connectors.py
+++ b/services/data/tests/test_connectors.py
@@ -324,11 +324,11 @@ def test_baostock_ticker_timeout_keeps_lock_until_thread_exits(monkeypatch) -> N
         with pytest.raises(RuntimeError, match="A-share ticker unavailable"):
             await connector.fetch_ticker("sh.000001")
         assert first_started.is_set()
-        second = asyncio.create_task(connector.fetch_ticker("sz.000002"))
-        await asyncio.sleep(0.01)
+        with pytest.raises(RuntimeError, match="A-share ticker unavailable"):
+            await connector.fetch_ticker("sz.000002")
         assert max_active == 1
         release_first.set()
-        return (await second)[1]
+        return (await connector.fetch_ticker("sz.000002"))[1]
 
     assert asyncio.run(_run()) == 2.0
     assert max_active == 1

--- a/services/paper/src/inalpha_paper/api/orders.py
+++ b/services/paper/src/inalpha_paper/api/orders.py
@@ -663,10 +663,9 @@ async def _resolve_ref_price(
     user_token = authorization.removeprefix("Bearer ").strip()
     async with DataClient(settings.data_service_url, user_token) as data_client:
         try:
-            ticker = await data_client.get_ticker(
+            ticker = await data_client.get_execution_ticker(
                 venue=req.venue,
                 symbol=req.symbol,
-                fresh=True,
             )
         except Exception as e:
             raise RefPriceUnavailableError(

--- a/services/paper/src/inalpha_paper/api/orders.py
+++ b/services/paper/src/inalpha_paper/api/orders.py
@@ -663,7 +663,11 @@ async def _resolve_ref_price(
     user_token = authorization.removeprefix("Bearer ").strip()
     async with DataClient(settings.data_service_url, user_token) as data_client:
         try:
-            ticker = await data_client.get_ticker(venue=req.venue, symbol=req.symbol)
+            ticker = await data_client.get_ticker(
+                venue=req.venue,
+                symbol=req.symbol,
+                fresh=True,
+            )
         except Exception as e:
             raise RefPriceUnavailableError(
                 f"failed to fetch ref_price for {req.symbol}@{req.venue}: {e}",

--- a/services/paper/src/inalpha_paper/api/trade_plans.py
+++ b/services/paper/src/inalpha_paper/api/trade_plans.py
@@ -261,10 +261,9 @@ async def execute_plan(
     user_token = authorization.removeprefix("Bearer ").strip()
     async with DataClient(settings.data_service_url, user_token) as data_client:
         try:
-            ticker = await data_client.get_ticker(
+            ticker = await data_client.get_execution_ticker(
                 venue=venue,
                 symbol=symbol,
-                fresh=True,
             )
         except Exception as e:
             raise PlanHttpError(

--- a/services/paper/src/inalpha_paper/api/trade_plans.py
+++ b/services/paper/src/inalpha_paper/api/trade_plans.py
@@ -30,6 +30,7 @@ from ..data_client import DataClient
 from ..execution import risk_guard as risk_guard_mod
 from ..execution.order_executor import OrderExecutor
 from ..fills import apply_fill_to_positions_and_cash
+from ..market_identity import canonicalize_market_identity
 from ..schemas import (
     ApprovePlanRequest,
     CreatePlanRequest,
@@ -234,8 +235,10 @@ async def execute_plan(
         )
 
     order_params: dict[str, Any] = plan_row["order_params"]
-    venue: str = plan_row["venue"]
-    symbol: str = plan_row["symbol"]
+    venue, symbol = canonicalize_market_identity(
+        plan_row["venue"],
+        plan_row["symbol"],
+    )
     side: str = order_params["side"]
     order_type: str = order_params["type"]
     quantity: float = float(order_params["quantity"])

--- a/services/paper/src/inalpha_paper/api/trade_plans.py
+++ b/services/paper/src/inalpha_paper/api/trade_plans.py
@@ -207,7 +207,7 @@ async def execute_plan(
 
     1. 读 plan（**不消费 token**）拿 venue/symbol —— 失败可重试
     2. 取 refPrice（网络调用，**不消费 token**）—— REF_PRICE_UNAVAILABLE 时
-       token 仍有效，caller backfill 后再来即可
+       token 仍有效，报价源恢复后可用同一 token 重试
     3. OrderExecutor 算成交（pure）
     4. **单一事务**：consume_approval → orders insert → positions/cash
        → record_execution；任何一步失败回滚 token 也回滚（保持 'approved' 可重试）
@@ -261,7 +261,11 @@ async def execute_plan(
     user_token = authorization.removeprefix("Bearer ").strip()
     async with DataClient(settings.data_service_url, user_token) as data_client:
         try:
-            ticker = await data_client.get_ticker(venue=venue, symbol=symbol)
+            ticker = await data_client.get_ticker(
+                venue=venue,
+                symbol=symbol,
+                fresh=True,
+            )
         except Exception as e:
             raise PlanHttpError(
                 f"failed to fetch ref_price for {symbol}@{venue}: {e}",

--- a/services/paper/src/inalpha_paper/data_client.py
+++ b/services/paper/src/inalpha_paper/data_client.py
@@ -97,6 +97,27 @@ class DataClient:
             )
         return result
 
+    async def get_execution_ticker(
+        self,
+        *,
+        venue: str,
+        symbol: str,
+    ) -> dict[str, Any]:
+        """获取交易执行报价；陈旧或缺少 freshness 标记时 fail-closed。"""
+        ticker = await self.get_ticker(venue=venue, symbol=symbol, fresh=True)
+        if ticker.get("is_stale") is not False:
+            raise DataServiceError(
+                f"stale ticker for {symbol}@{venue}",
+                code="STALE_TICKER",
+                details={
+                    "venue": venue,
+                    "symbol": symbol,
+                    "ts": ticker.get("ts"),
+                    "stale_seconds": ticker.get("stale_seconds"),
+                },
+            )
+        return ticker
+
     async def get_perp_funding(self, *, venue: str, symbol: str) -> dict[str, Any]:
         """``GET /perp/funding`` —— USDT-M 永续 mark price + 当期 funding rate(perp 记账用)。
 

--- a/services/paper/src/inalpha_paper/data_client.py
+++ b/services/paper/src/inalpha_paper/data_client.py
@@ -60,10 +60,11 @@ class DataClient:
         symbol: str,
         fresh: bool | None = None,
     ) -> dict[str, Any]:
-        """``GET /ticker`` —— 服务端取最新价（D-8a' 加，给 /orders/submit 自取 refPrice）。
+        """``GET /ticker`` —— 获取单值行情，供订单参考价与账户估值使用。
 
-        ``fresh=False``:只读 data 缓存不触发慢 backfill(快照类调用用,如 /accounts/me
-        mark-to-market 估值);``None`` 用服务端默认(下单 refPrice 保持 fresh 语义)。
+        ``fresh=True`` 要求 data-service 直接调用 venue 的 ticker capability；
+        ``fresh=False`` 只读 DB 缓存。``fresh=None`` 会省略 query 参数，当前服务端
+        默认是 DB-only；交易执行调用方必须显式传 ``True``。
 
         Returns dict with: ``venue, symbol, price, ts, source, is_stale, stale_seconds``。
         """

--- a/services/paper/src/inalpha_paper/execution/risk_rules/exchange_resolver.py
+++ b/services/paper/src/inalpha_paper/execution/risk_rules/exchange_resolver.py
@@ -82,6 +82,7 @@ _YF_SUFFIX_TO_CODE: dict[str, str] = {
     ".sa": "BVMF",
     ".pa": "XPAR",
     ".de": "XFRA",
+    ".hk": "XHKG",
     ".l": "XLON",
     ".t": "XTKS",
 }

--- a/services/paper/src/inalpha_paper/execution/risk_rules/exchange_resolver.py
+++ b/services/paper/src/inalpha_paper/execution/risk_rules/exchange_resolver.py
@@ -1,11 +1,10 @@
 """``(venue, symbol)`` → ``exchange_calendars`` 日历 code 解析。
 
 D-9.1a 收尾（多市场 ``MarketHoursRule``）：``InstrumentId.venue`` 是**数据源**
-标识（``yfinance`` / ``baostock`` / ``binance``），**不是交易所**。同一 venue 跨多
-市场——``yfinance`` 同时服务美股 / 全球指数 / 韩澳印，``baostock`` 同时服务
-A股 / 港股 / 日英德。因此必须结合 ``symbol`` 的前缀（``sh.`` / ``sz.`` / ``hk.`` /
-``jp.`` / ``uk.`` / ``de.``）或后缀（``.KS`` / ``.AX`` / ``.NS`` / ``.T`` / ``.L`` /
-``.DE`` / ``.PA`` / ``.TO`` / ``.SA``）/ 指数前缀（``^``）才能定位真实交易所。
+标识（``yfinance`` / ``baostock`` / ``binance``），**不是交易所**。``yfinance`` 同时服务
+美股、全球指数和海外单股，必须结合 symbol 的后缀（``.KS`` / ``.AX`` / ``.NS`` /
+``.T`` / ``.L`` / ``.DE`` / ``.PA`` / ``.TO`` / ``.SA``）或指数前缀（``^``）定位市场；
+``baostock`` / legacy ``akshare`` 的 A 股则兼容 ``sh.600519`` 与 ``600519.SH`` 两种格式。
 
 返回 ``exchange_calendars`` 的 calendar code（``XNYS`` / ``XSHG`` / ``XHKG`` …）；
 下列情形返 ``None``（由上层 :class:`RoutingCalendar` 特判）：
@@ -42,15 +41,36 @@ _CRYPTO_VENUES: frozenset[str] = frozenset(
 # 走 yfinance / alpaca 的美股 + 全球单股 + 指数数据源
 _US_DATA_VENUES: frozenset[str] = frozenset({"yfinance", "alpaca"})
 
-# baostock symbol 前缀 → calendar code（sz. 复用 XSHG）
-_AKSHARE_PREFIX_TO_CODE: dict[str, str] = {
+# baostock / legacy akshare 的 A 股 market code。前缀格式用于 canonical identity；
+# 后缀格式仅为兼容仍在调用 data API 的旧客户端，paper 的币种/日历判断必须与 data
+# 的 canonicalize_market_identity 接受范围一致，避免行情按 A 股返回却按 USD 落账。
+_A_SHARE_VENUES: frozenset[str] = frozenset({"akshare", "baostock"})
+_A_SHARE_PREFIX_TO_CODE: dict[str, str] = {
     "sh": "XSHG",
     "sz": "XSHG",
+}
+_LEGACY_AKSHARE_GLOBAL_PREFIX_TO_CODE: dict[str, str] = {
     "hk": "XHKG",
     "jp": "XTKS",
     "uk": "XLON",
     "de": "XFRA",
 }
+
+
+def _a_share_calendar_code(symbol: str) -> str | None:
+    """识别 ``sh.600519`` / ``600519.SH``，返回沪深共用的 ``XSHG``。"""
+    s = symbol.strip().lower()
+    if "." not in s:
+        return None
+
+    prefix, code = s.split(".", 1)
+    if prefix in _A_SHARE_PREFIX_TO_CODE and code.isdigit() and len(code) == 6:
+        return _A_SHARE_PREFIX_TO_CODE[prefix]
+
+    code, suffix = s.rsplit(".", 1)
+    if suffix in _A_SHARE_PREFIX_TO_CODE and code.isdigit() and len(code) == 6:
+        return _A_SHARE_PREFIX_TO_CODE[suffix]
+    return None
 
 # yfinance / alpaca symbol 后缀 → calendar code（.ns 复用 XBOM）。
 # 按长度降序匹配，避免 ".to"（加拿大）被 ".t"（日本）误截。
@@ -109,9 +129,14 @@ def resolve_calendar_code(venue: str, symbol: str) -> str | None:
     if v == "fred":
         return None  # 宏观，无交易时段
 
-    if v in ("akshare", "baostock"):
-        prefix = s.split(".", 1)[0] if "." in s else ""
-        return _AKSHARE_PREFIX_TO_CODE.get(prefix)
+    if v in _A_SHARE_VENUES:
+        a_share_code = _a_share_calendar_code(s)
+        if a_share_code is not None:
+            return a_share_code
+        if v == "akshare":
+            prefix = s.split(".", 1)[0] if "." in s else ""
+            return _LEGACY_AKSHARE_GLOBAL_PREFIX_TO_CODE.get(prefix)
+        return None
 
     if v in _US_DATA_VENUES:
         if s.startswith("^"):

--- a/services/paper/src/inalpha_paper/execution/risk_rules/exchange_resolver.py
+++ b/services/paper/src/inalpha_paper/execution/risk_rules/exchange_resolver.py
@@ -49,7 +49,7 @@ _A_SHARE_PREFIX_TO_CODE: dict[str, str] = {
     "sh": "XSHG",
     "sz": "XSHG",
 }
-_LEGACY_AKSHARE_GLOBAL_PREFIX_TO_CODE: dict[str, str] = {
+_LEGACY_GLOBAL_PREFIX_TO_CODE: dict[str, str] = {
     "hk": "XHKG",
     "jp": "XTKS",
     "uk": "XLON",
@@ -134,10 +134,8 @@ def resolve_calendar_code(venue: str, symbol: str) -> str | None:
         a_share_code = _a_share_calendar_code(s)
         if a_share_code is not None:
             return a_share_code
-        if v == "akshare":
-            prefix = s.split(".", 1)[0] if "." in s else ""
-            return _LEGACY_AKSHARE_GLOBAL_PREFIX_TO_CODE.get(prefix)
-        return None
+        prefix = s.split(".", 1)[0] if "." in s else ""
+        return _LEGACY_GLOBAL_PREFIX_TO_CODE.get(prefix)
 
     if v in _US_DATA_VENUES:
         if s.startswith("^"):

--- a/services/paper/src/inalpha_paper/market_identity.py
+++ b/services/paper/src/inalpha_paper/market_identity.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 
 LEGACY_A_SHARE_VENUE = "akshare"
 A_SHARE_VENUE = "baostock"
+YFINANCE_VENUE = "yfinance"
 _A_SHARE_PREFIXES = frozenset({"sh", "sz"})
+_LEGACY_GLOBAL_PREFIX_TO_SUFFIX = {
+    "hk": ".HK",
+    "jp": ".T",
+    "uk": ".L",
+    "de": ".DE",
+}
 
 
 def canonicalize_market_identity(venue: str, symbol: str) -> tuple[str, str]:
@@ -15,6 +22,10 @@ def canonicalize_market_identity(venue: str, symbol: str) -> tuple[str, str]:
         A_SHARE_VENUE,
     }:
         return A_SHARE_VENUE, normalized_symbol
+    if normalized_venue == LEGACY_A_SHARE_VENUE:
+        global_symbol = _canonicalize_legacy_global_symbol(symbol)
+        if global_symbol is not None:
+            return YFINANCE_VENUE, global_symbol
     return normalized_venue, symbol.strip()
 
 
@@ -31,6 +42,42 @@ def a_share_identity_variants(
         return None
     prefix, code = normalized_symbol.split(".", 1)
     return A_SHARE_VENUE, normalized_symbol, f"{code}.{prefix}"
+
+
+def legacy_global_identity_variants(
+    venue: str,
+    symbol: str,
+) -> tuple[str, str, str] | None:
+    """返回 legacy ``akshare/<prefix>.<code>`` 对应的 yfinance identity。"""
+    canonical_venue, canonical_symbol = canonicalize_market_identity(venue, symbol)
+    if canonical_venue != YFINANCE_VENUE or "." not in canonical_symbol:
+        return None
+    code, suffix = canonical_symbol.rsplit(".", 1)
+    suffix_with_dot = f".{suffix.upper()}"
+    reverse = {value: key for key, value in _LEGACY_GLOBAL_PREFIX_TO_SUFFIX.items()}
+    prefix = reverse.get(suffix_with_dot)
+    if prefix is None:
+        return None
+    legacy_code = code.zfill(5) if prefix == "hk" else code
+    return YFINANCE_VENUE, canonical_symbol, f"{prefix}.{legacy_code}"
+
+
+def _canonicalize_legacy_global_symbol(symbol: str) -> str | None:
+    """把 ``hk.00700`` 等历史 akshare 格式转换为 yfinance 后缀格式。"""
+    normalized = symbol.strip()
+    if "." not in normalized:
+        return None
+    prefix, code = normalized.split(".", 1)
+    suffix = _LEGACY_GLOBAL_PREFIX_TO_SUFFIX.get(prefix.lower())
+    if suffix is None or not code:
+        return None
+    if prefix.lower() == "hk":
+        if not code.isdigit():
+            return None
+        code = code.lstrip("0").zfill(4)
+    else:
+        code = code.upper()
+    return f"{code}{suffix}"
 
 
 def _canonicalize_a_share_symbol(symbol: str) -> str | None:

--- a/services/paper/src/inalpha_paper/market_identity.py
+++ b/services/paper/src/inalpha_paper/market_identity.py
@@ -1,0 +1,34 @@
+"""paper 交易入口的 market identity 规范化。"""
+from __future__ import annotations
+
+LEGACY_A_SHARE_VENUE = "akshare"
+A_SHARE_VENUE = "baostock"
+_A_SHARE_PREFIXES = frozenset({"sh", "sz"})
+
+
+def canonicalize_market_identity(venue: str, symbol: str) -> tuple[str, str]:
+    """返回与 data-service 一致的 canonical ``(venue, symbol)``。"""
+    normalized_venue = venue.strip().lower()
+    normalized_symbol = _canonicalize_a_share_symbol(symbol)
+    if normalized_symbol is not None and normalized_venue in {
+        LEGACY_A_SHARE_VENUE,
+        A_SHARE_VENUE,
+    }:
+        return A_SHARE_VENUE, normalized_symbol
+    return normalized_venue, symbol.strip()
+
+
+def _canonicalize_a_share_symbol(symbol: str) -> str | None:
+    """把 ``SH.600519`` / ``600519.SH`` 归一为 ``sh.600519``。"""
+    normalized = symbol.strip()
+    if "." not in normalized:
+        return None
+
+    prefix, code = normalized.split(".", 1)
+    if prefix.lower() in _A_SHARE_PREFIXES and code.isdigit() and len(code) == 6:
+        return f"{prefix.lower()}.{code}"
+
+    code, suffix = normalized.rsplit(".", 1)
+    if suffix.lower() in _A_SHARE_PREFIXES and code.isdigit() and len(code) == 6:
+        return f"{suffix.lower()}.{code}"
+    return None

--- a/services/paper/src/inalpha_paper/market_identity.py
+++ b/services/paper/src/inalpha_paper/market_identity.py
@@ -22,7 +22,7 @@ def canonicalize_market_identity(venue: str, symbol: str) -> tuple[str, str]:
         A_SHARE_VENUE,
     }:
         return A_SHARE_VENUE, normalized_symbol
-    if normalized_venue == LEGACY_A_SHARE_VENUE:
+    if normalized_venue in {LEGACY_A_SHARE_VENUE, A_SHARE_VENUE}:
         global_symbol = _canonicalize_legacy_global_symbol(symbol)
         if global_symbol is not None:
             return YFINANCE_VENUE, global_symbol
@@ -48,7 +48,7 @@ def legacy_global_identity_variants(
     venue: str,
     symbol: str,
 ) -> tuple[str, str, str] | None:
-    """返回 legacy ``akshare/<prefix>.<code>`` 对应的 yfinance identity。"""
+    """返回旧 ``akshare|baostock/<prefix>.<code>`` 对应的 yfinance identity。"""
     canonical_venue, canonical_symbol = canonicalize_market_identity(venue, symbol)
     if canonical_venue != YFINANCE_VENUE or "." not in canonical_symbol:
         return None

--- a/services/paper/src/inalpha_paper/market_identity.py
+++ b/services/paper/src/inalpha_paper/market_identity.py
@@ -18,6 +18,21 @@ def canonicalize_market_identity(venue: str, symbol: str) -> tuple[str, str]:
     return normalized_venue, symbol.strip()
 
 
+def a_share_identity_variants(
+    venue: str,
+    symbol: str,
+) -> tuple[str, str, str] | None:
+    """返回 canonical identity 与另一种前后缀 symbol；非 A 股返回 ``None``。"""
+    normalized_venue = venue.strip().lower()
+    normalized_symbol = _canonicalize_a_share_symbol(symbol)
+    if normalized_venue not in {LEGACY_A_SHARE_VENUE, A_SHARE_VENUE}:
+        return None
+    if normalized_symbol is None:
+        return None
+    prefix, code = normalized_symbol.split(".", 1)
+    return A_SHARE_VENUE, normalized_symbol, f"{code}.{prefix}"
+
+
 def _canonicalize_a_share_symbol(symbol: str) -> str | None:
     """把 ``SH.600519`` / ``600519.SH`` 归一为 ``sh.600519``。"""
     normalized = symbol.strip()

--- a/services/paper/src/inalpha_paper/schemas.py
+++ b/services/paper/src/inalpha_paper/schemas.py
@@ -8,6 +8,8 @@ from uuid import UUID
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 
+from .market_identity import canonicalize_market_identity
+
 
 def _assume_utc_if_naive(v: datetime) -> datetime:
     return v.replace(tzinfo=UTC) if v.tzinfo is None else v
@@ -644,7 +646,8 @@ class SubmitOrderRequest(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _check_price_for_type(self) -> SubmitOrderRequest:
+    def _normalize_and_check_order(self) -> SubmitOrderRequest:
+        self.venue, self.symbol = canonicalize_market_identity(self.venue, self.symbol)
         # 用 PydanticCustomError 而不是 ValueError —— 后者会把 exception 对象塞进
         # error.ctx，FastAPI 的统一错误响应里 errors() 无法 JSON 序列化（trip TypeError）
         if self.order_type == "LIMIT" and self.price is None:
@@ -879,6 +882,11 @@ class CreatePlanRequest(BaseModel):
     price: float | None = Field(default=None, description="LIMIT 必填；MARKET 必须省略")
     rationale: str = Field(..., min_length=1)
     expire_in_seconds: int = Field(default=300, ge=1, le=3600)
+
+    @model_validator(mode="after")
+    def _normalize_market_identity(self) -> CreatePlanRequest:
+        self.venue, self.symbol = canonicalize_market_identity(self.venue, self.symbol)
+        return self
 
     model_config = {"populate_by_name": True}
 

--- a/services/paper/src/inalpha_paper/storage/positions.py
+++ b/services/paper/src/inalpha_paper/storage/positions.py
@@ -27,6 +27,62 @@ from uuid import UUID
 
 from psycopg import AsyncConnection
 
+from ..market_identity import (
+    A_SHARE_VENUE,
+    LEGACY_A_SHARE_VENUE,
+    a_share_identity_variants,
+)
+
+
+async def _migrate_legacy_a_share_identity(
+    conn: AsyncConnection,
+    *,
+    account_id: UUID,
+    venue: str,
+    symbol: str,
+) -> tuple[str, str]:
+    """锁住单个旧 A 股仓位并迁到 canonical key；重复 key 时 fail-closed。"""
+    variants = a_share_identity_variants(venue, symbol)
+    if variants is None:
+        return venue, symbol
+    canonical_venue, canonical_symbol, suffix_symbol = variants
+    async with conn.cursor() as cur:
+        await cur.execute(
+            "SELECT venue, symbol FROM positions WHERE account_id = %s "
+            "AND LOWER(BTRIM(venue)) IN (%s, %s) "
+            "AND LOWER(BTRIM(symbol)) IN (%s, %s) FOR UPDATE",
+            (
+                str(account_id),
+                A_SHARE_VENUE,
+                LEGACY_A_SHARE_VENUE,
+                canonical_symbol,
+                suffix_symbol,
+            ),
+        )
+        rows = await cur.fetchall()
+        if len(rows) > 1:
+            identities = sorted(f"{row['venue']}/{row['symbol']}" for row in rows)
+            raise RuntimeError(
+                "duplicate A-share position identities require reconciliation: "
+                + ", ".join(identities)
+            )
+        if rows:
+            stored_venue = rows[0]["venue"]
+            stored_symbol = rows[0]["symbol"]
+            if (stored_venue, stored_symbol) != (canonical_venue, canonical_symbol):
+                await cur.execute(
+                    "UPDATE positions SET venue = %s, symbol = %s, updated_at = NOW() "
+                    "WHERE account_id = %s AND venue = %s AND symbol = %s",
+                    (
+                        canonical_venue,
+                        canonical_symbol,
+                        str(account_id),
+                        stored_venue,
+                        stored_symbol,
+                    ),
+                )
+    return canonical_venue, canonical_symbol
+
 
 @dataclass(frozen=True, slots=True)
 class ClosedTradeInfo:
@@ -74,6 +130,13 @@ async def apply_fill(
     D-11 增强：``currency`` 记录该持仓的计价货币（``execution.currency_resolver``
     解析），供 ``/accounts/me`` 跨币种 equity 折算。``None`` 时不更新该列（向后兼容）。
     """
+    venue, symbol = await _migrate_legacy_a_share_identity(
+        conn,
+        account_id=account_id,
+        venue=venue,
+        symbol=symbol,
+    )
+
     # 1. 读当前持仓（不存在视为 flat）
     async with conn.cursor() as cur:
         await cur.execute(
@@ -269,6 +332,13 @@ async def get(
     "读-检-写"必须在同一事务里 FOR UPDATE，否则并发 SELL 各自读到旧持仓双双过闸、
     apply_fill 把持仓打成负仓（TOCTOU）。**仅在事务内使用**（行锁随事务释放）。
     """
+    if for_update:
+        venue, symbol = await _migrate_legacy_a_share_identity(
+            conn,
+            account_id=account_id,
+            venue=venue,
+            symbol=symbol,
+        )
     sql = (
         "SELECT venue, symbol, quantity, avg_open_price, realized_pnl, "
         "generation, ts_opened, open_order_id, currency, updated_at, "

--- a/services/paper/src/inalpha_paper/storage/positions.py
+++ b/services/paper/src/inalpha_paper/storage/positions.py
@@ -32,6 +32,7 @@ from ..market_identity import (
     LEGACY_A_SHARE_VENUE,
     YFINANCE_VENUE,
     a_share_identity_variants,
+    canonicalize_market_identity,
     legacy_global_identity_variants,
 )
 
@@ -45,26 +46,32 @@ async def _migrate_legacy_market_identity(
 ) -> tuple[str, str]:
     """锁住单个旧市场仓位并迁到 canonical key；重复 key 时 fail-closed。"""
     variants = a_share_identity_variants(venue, symbol)
-    legacy_venue = LEGACY_A_SHARE_VENUE
     market_label = "A-share"
     if variants is None:
         variants = legacy_global_identity_variants(venue, symbol)
         if variants is None:
             return venue, symbol
         canonical_venue = YFINANCE_VENUE
+        venue_predicate = "AND LOWER(BTRIM(venue)) IN (%s, %s, %s) "
+        venue_params = (
+            canonical_venue,
+            LEGACY_A_SHARE_VENUE,
+            A_SHARE_VENUE,
+        )
         market_label = "global"
     else:
         canonical_venue = A_SHARE_VENUE
+        venue_predicate = "AND LOWER(BTRIM(venue)) IN (%s, %s) "
+        venue_params = (canonical_venue, LEGACY_A_SHARE_VENUE)
     _, canonical_symbol, legacy_symbol = variants
     async with conn.cursor() as cur:
         await cur.execute(
-            "SELECT venue, symbol FROM positions WHERE account_id = %s "
-            "AND LOWER(BTRIM(venue)) IN (%s, %s) "
-            "AND LOWER(BTRIM(symbol)) IN (%s, %s) FOR UPDATE",
+            "SELECT venue, symbol, currency FROM positions WHERE account_id = %s "
+            + venue_predicate
+            + "AND LOWER(BTRIM(symbol)) IN (%s, %s) FOR UPDATE",
             (
                 str(account_id),
-                canonical_venue,
-                legacy_venue,
+                *venue_params,
                 canonical_symbol.lower(),
                 legacy_symbol.lower(),
             ),
@@ -77,15 +84,23 @@ async def _migrate_legacy_market_identity(
                 + ", ".join(identities)
             )
         if rows:
+            from ..execution.currency_resolver import resolve_currency
+
             stored_venue = rows[0]["venue"]
             stored_symbol = rows[0]["symbol"]
-            if (stored_venue, stored_symbol) != (canonical_venue, canonical_symbol):
+            stored_currency = rows[0]["currency"]
+            canonical_currency = resolve_currency(canonical_venue, canonical_symbol)
+            if (
+                (stored_venue, stored_symbol) != (canonical_venue, canonical_symbol)
+                or stored_currency != canonical_currency
+            ):
                 await cur.execute(
-                    "UPDATE positions SET venue = %s, symbol = %s, updated_at = NOW() "
-                    "WHERE account_id = %s AND venue = %s AND symbol = %s",
+                    "UPDATE positions SET venue = %s, symbol = %s, currency = %s, "
+                    "updated_at = NOW() WHERE account_id = %s AND venue = %s AND symbol = %s",
                     (
                         canonical_venue,
                         canonical_symbol,
+                        canonical_currency,
                         str(account_id),
                         stored_venue,
                         stored_symbol,
@@ -369,7 +384,11 @@ async def list_by_account(
     *,
     include_flat: bool = False,
 ) -> list[dict[str, Any]]:
-    """列出某 account 的所有持仓。默认过滤掉 quantity=0 的（已平仓但保留行）。"""
+    """列出账户持仓；默认过滤 flat，并在读侧规范化历史市场 identity/币种。
+
+    读侧转换不写库，确保账户估值与持仓展示会用当前 data connector identity；
+    下一次成交的事务迁移会再把同样的 canonical identity 和币种持久化。
+    """
     sql = (
         "SELECT venue, symbol, quantity, avg_open_price, realized_pnl, "
         "generation, ts_opened, open_order_id, currency, updated_at, "
@@ -383,7 +402,35 @@ async def list_by_account(
     async with conn.cursor() as cur:
         await cur.execute(sql, (str(account_id),))
         rows = await cur.fetchall()
-    return list(rows)  # type: ignore[arg-type]
+
+    from ..execution.currency_resolver import resolve_currency
+
+    normalized_rows: list[dict[str, Any]] = []
+    for row in rows:
+        normalized = dict(row)
+        canonical_venue, canonical_symbol = canonicalize_market_identity(
+            normalized["venue"],
+            normalized["symbol"],
+        )
+        identity_changed = (canonical_venue, canonical_symbol) != (
+            normalized["venue"],
+            normalized["symbol"],
+        )
+        if identity_changed:
+            normalized["venue"] = canonical_venue
+            normalized["symbol"] = canonical_symbol
+        if (
+            identity_changed
+            or a_share_identity_variants(canonical_venue, canonical_symbol) is not None
+            or legacy_global_identity_variants(canonical_venue, canonical_symbol)
+            is not None
+        ):
+            normalized["currency"] = resolve_currency(
+                canonical_venue,
+                canonical_symbol,
+            )
+        normalized_rows.append(normalized)
+    return normalized_rows
 
 
 async def sum_other_margin_used(

--- a/services/paper/src/inalpha_paper/storage/positions.py
+++ b/services/paper/src/inalpha_paper/storage/positions.py
@@ -30,22 +30,32 @@ from psycopg import AsyncConnection
 from ..market_identity import (
     A_SHARE_VENUE,
     LEGACY_A_SHARE_VENUE,
+    YFINANCE_VENUE,
     a_share_identity_variants,
+    legacy_global_identity_variants,
 )
 
 
-async def _migrate_legacy_a_share_identity(
+async def _migrate_legacy_market_identity(
     conn: AsyncConnection,
     *,
     account_id: UUID,
     venue: str,
     symbol: str,
 ) -> tuple[str, str]:
-    """锁住单个旧 A 股仓位并迁到 canonical key；重复 key 时 fail-closed。"""
+    """锁住单个旧市场仓位并迁到 canonical key；重复 key 时 fail-closed。"""
     variants = a_share_identity_variants(venue, symbol)
+    legacy_venue = LEGACY_A_SHARE_VENUE
+    market_label = "A-share"
     if variants is None:
-        return venue, symbol
-    canonical_venue, canonical_symbol, suffix_symbol = variants
+        variants = legacy_global_identity_variants(venue, symbol)
+        if variants is None:
+            return venue, symbol
+        canonical_venue = YFINANCE_VENUE
+        market_label = "global"
+    else:
+        canonical_venue = A_SHARE_VENUE
+    _, canonical_symbol, legacy_symbol = variants
     async with conn.cursor() as cur:
         await cur.execute(
             "SELECT venue, symbol FROM positions WHERE account_id = %s "
@@ -53,17 +63,17 @@ async def _migrate_legacy_a_share_identity(
             "AND LOWER(BTRIM(symbol)) IN (%s, %s) FOR UPDATE",
             (
                 str(account_id),
-                A_SHARE_VENUE,
-                LEGACY_A_SHARE_VENUE,
-                canonical_symbol,
-                suffix_symbol,
+                canonical_venue,
+                legacy_venue,
+                canonical_symbol.lower(),
+                legacy_symbol.lower(),
             ),
         )
         rows = await cur.fetchall()
         if len(rows) > 1:
             identities = sorted(f"{row['venue']}/{row['symbol']}" for row in rows)
             raise RuntimeError(
-                "duplicate A-share position identities require reconciliation: "
+                f"duplicate {market_label} position identities require reconciliation: "
                 + ", ".join(identities)
             )
         if rows:
@@ -130,7 +140,7 @@ async def apply_fill(
     D-11 增强：``currency`` 记录该持仓的计价货币（``execution.currency_resolver``
     解析），供 ``/accounts/me`` 跨币种 equity 折算。``None`` 时不更新该列（向后兼容）。
     """
-    venue, symbol = await _migrate_legacy_a_share_identity(
+    venue, symbol = await _migrate_legacy_market_identity(
         conn,
         account_id=account_id,
         venue=venue,
@@ -333,7 +343,7 @@ async def get(
     apply_fill 把持仓打成负仓（TOCTOU）。**仅在事务内使用**（行锁随事务释放）。
     """
     if for_update:
-        venue, symbol = await _migrate_legacy_a_share_identity(
+        venue, symbol = await _migrate_legacy_market_identity(
             conn,
             account_id=account_id,
             venue=venue,

--- a/services/paper/tests/test_currency_resolver.py
+++ b/services/paper/tests/test_currency_resolver.py
@@ -26,6 +26,7 @@ from inalpha_paper.execution.currency_resolver import resolve_currency
         # 旧 akshare 全球前缀只为已持久化记录保留
         ("akshare", "hk.00700", "HKD"),
         # 全球单股（yfinance 后缀）
+        ("yfinance", "0700.HK", "HKD"),
         ("yfinance", "005930.KS", "KRW"),
         ("yfinance", "7203.T", "JPY"),
         ("yfinance", "VOD.L", "GBP"),

--- a/services/paper/tests/test_currency_resolver.py
+++ b/services/paper/tests/test_currency_resolver.py
@@ -17,9 +17,11 @@ from inalpha_paper.execution.currency_resolver import resolve_currency
         # 美股 / yfinance 无后缀 → USD
         ("yfinance", "AAPL", "USD"),
         ("alpaca", "TSLA", "USD"),
-        # A股 canonical venue + 迁移前旧值
+        # A股 canonical / 兼容格式 + 迁移前旧 venue
         ("baostock", "sh.600519", "CNY"),
         ("baostock", "sz.000001", "CNY"),
+        ("baostock", "600519.SH", "CNY"),
+        ("akshare", "000001.SZ", "CNY"),
         ("akshare", "sh.600519", "CNY"),
         # 旧 akshare 全球前缀只为已持久化记录保留
         ("akshare", "hk.00700", "HKD"),

--- a/services/paper/tests/test_currency_resolver.py
+++ b/services/paper/tests/test_currency_resolver.py
@@ -25,6 +25,7 @@ from inalpha_paper.execution.currency_resolver import resolve_currency
         ("akshare", "sh.600519", "CNY"),
         # 旧 akshare 全球前缀只为已持久化记录保留
         ("akshare", "hk.00700", "HKD"),
+        ("baostock", "hk.00700", "HKD"),
         # 全球单股（yfinance 后缀）
         ("yfinance", "0700.HK", "HKD"),
         ("yfinance", "005930.KS", "KRW"),

--- a/services/paper/tests/test_exchange_resolver.py
+++ b/services/paper/tests/test_exchange_resolver.py
@@ -17,6 +17,7 @@ from inalpha_paper.execution.risk_rules.exchange_resolver import resolve_calenda
         # 迁移前持久化的 akshare 记录继续兼容
         ("akshare", "sh.600519", "XSHG"),
         ("akshare", "hk.00700", "XHKG"),
+        ("baostock", "hk.00700", "XHKG"),
         ("akshare", "jp.6758", "XTKS"),
         ("akshare", "uk.VOD", "XLON"),
         ("akshare", "de.BMW", "XFRA"),

--- a/services/paper/tests/test_exchange_resolver.py
+++ b/services/paper/tests/test_exchange_resolver.py
@@ -26,6 +26,7 @@ from inalpha_paper.execution.risk_rules.exchange_resolver import resolve_calenda
         ("yfinance", "aapl", "XNYS"),  # 大小写不敏感
         ("alpaca", "TSLA", "XNYS"),
         # yfinance 后缀（注意 .to vs .t 不互相误截）
+        ("yfinance", "0700.HK", "XHKG"),
         ("yfinance", "7203.T", "XTKS"),
         ("yfinance", "005930.KS", "XKRX"),
         ("yfinance", "BHP.AX", "XASX"),

--- a/services/paper/tests/test_exchange_resolver.py
+++ b/services/paper/tests/test_exchange_resolver.py
@@ -9,9 +9,11 @@ from inalpha_paper.execution.risk_rules.exchange_resolver import resolve_calenda
 @pytest.mark.parametrize(
     ("venue", "symbol", "expected"),
     [
-        # A股 canonical venue（sz 复用 XSHG）
+        # A股 canonical / 兼容格式（sz 复用 XSHG）
         ("baostock", "sh.600519", "XSHG"),
         ("baostock", "sz.000001", "XSHG"),
+        ("baostock", "600519.SH", "XSHG"),
+        ("akshare", "000001.SZ", "XSHG"),
         # 迁移前持久化的 akshare 记录继续兼容
         ("akshare", "sh.600519", "XSHG"),
         ("akshare", "hk.00700", "XHKG"),

--- a/services/paper/tests/test_trade_quote_resolution.py
+++ b/services/paper/tests/test_trade_quote_resolution.py
@@ -1,0 +1,187 @@
+"""交易执行的 fresh ticker 跨服务契约回归测试。"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from inalpha_paper.data_client import DataClient
+
+from .conftest import fresh_account_token
+
+pytestmark = pytest.mark.integration
+
+
+def _ticker_response(
+    *, venue: str, symbol: str, price: float, source: str
+) -> dict[str, Any]:
+    """构造 data-service 的完整 ticker 响应。"""
+    return {
+        "venue": venue,
+        "symbol": symbol,
+        "price": price,
+        "ts": "2026-08-13T02:20:00Z",
+        "source": source,
+        "is_stale": False,
+        "stale_seconds": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("fresh", "expected"),
+    [(True, "true"), (False, "false"), (None, None)],
+)
+@respx.mock
+async def test_data_client_serializes_fresh_query(
+    fresh: bool | None, expected: str | None
+) -> None:
+    """DataClient 只在 caller 明确选择时发送 fresh 参数。"""
+    route = respx.get("http://data-mock.test/ticker").mock(
+        return_value=Response(
+            200,
+            json=_ticker_response(
+                venue="baostock",
+                symbol="sh.600519",
+                price=1_415.0,
+                source="baostock_ticker",
+            ),
+        )
+    )
+
+    async with DataClient("http://data-mock.test", "test-token") as data_client:
+        await data_client.get_ticker(
+            venue="baostock",
+            symbol="sh.600519",
+            fresh=fresh,
+        )
+
+    assert route.called
+    request = route.calls.last.request
+    assert request.url.params.get("venue") == "baostock"
+    assert request.url.params.get("symbol") == "sh.600519"
+    assert request.url.params.get("fresh") == expected
+
+
+@respx.mock
+def test_submit_order_without_ref_price_requests_fresh_ticker(
+    client: TestClient,
+) -> None:
+    """直接下单的自动参考价必须来自 fresh ticker，而不是 DB bar 缓存。"""
+    _, token = fresh_account_token("fresh-order")
+    route = respx.get(
+        "http://data-mock.test/ticker",
+        params={"venue": "binance", "symbol": "BTC/USDT", "fresh": "true"},
+    ).mock(
+        return_value=Response(
+            200,
+            json=_ticker_response(
+                venue="binance",
+                symbol="BTC/USDT",
+                price=50_000.0,
+                source="binance_ticker",
+            ),
+        )
+    )
+
+    response = client.post(
+        "/orders/submit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "venue": "binance",
+            "symbol": "BTC/USDT",
+            "side": "BUY",
+            "type": "MARKET",
+            "quantity": 0.01,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "FILLED"
+    assert body["avg_fill_price"] == 50_000.0
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_a_share_plan_retries_same_token_after_fresh_quote_recovers(
+    client: TestClient,
+) -> None:
+    """A 股报价失败不消费 token，恢复后同一 plan 可按 fresh ticker 成交。"""
+    _, token = fresh_account_token("fresh-a-share-plan")
+    headers = {"Authorization": f"Bearer {token}"}
+    route = respx.get(
+        "http://data-mock.test/ticker",
+        params={"venue": "baostock", "symbol": "sh.600519", "fresh": "true"},
+    ).mock(
+        side_effect=[
+            Response(
+                404,
+                json={
+                    "code": "NO_PRICE_AVAILABLE",
+                    "message": "no cached or live price available",
+                },
+            ),
+            Response(
+                200,
+                json=_ticker_response(
+                    venue="baostock",
+                    symbol="sh.600519",
+                    price=1_415.0,
+                    source="baostock_ticker",
+                ),
+            ),
+        ]
+    )
+
+    created = client.post(
+        "/plans",
+        headers=headers,
+        json={
+            "intent": "open_long",
+            "venue": "baostock",
+            "symbol": "sh.600519",
+            "side": "BUY",
+            "type": "MARKET",
+            "quantity": 1,
+            "rationale": "verify A-share fresh quote execution",
+            "expire_in_seconds": 300,
+        },
+    )
+    assert created.status_code == 200, created.text
+    plan_id = created.json()["plan_id"]
+
+    approved = client.post(
+        f"/plans/{plan_id}/approve",
+        headers=headers,
+        json={"approver": "tester"},
+    )
+    assert approved.status_code == 200, approved.text
+    approval_token = approved.json()["approval_token"]
+
+    first = client.post(
+        f"/plans/{plan_id}/execute",
+        headers=headers,
+        json={"approvalToken": approval_token},
+    )
+    assert first.status_code == 400, first.text
+    assert first.json()["code"] == "REF_PRICE_UNAVAILABLE"
+
+    after_failure = client.get(f"/plans/{plan_id}", headers=headers)
+    assert after_failure.status_code == 200, after_failure.text
+    assert after_failure.json()["status"] == "approved"
+    assert after_failure.json()["resulting_order_id"] is None
+
+    second = client.post(
+        f"/plans/{plan_id}/execute",
+        headers=headers,
+        json={"approvalToken": approval_token},
+    )
+    assert second.status_code == 200, second.text
+    result = second.json()
+    assert result["plan_status"] == "executed"
+    assert result["order"]["status"] == "FILLED"
+    assert result["order"]["avg_fill_price"] == 1_415.0
+    assert route.call_count == 2

--- a/services/paper/tests/test_trade_quote_resolution.py
+++ b/services/paper/tests/test_trade_quote_resolution.py
@@ -140,7 +140,7 @@ def test_submit_sell_migrates_single_legacy_a_share_position(client: TestClient)
                         Decimal("1415"),
                         Decimal("0"),
                         1,
-                        "CNY",
+                        "USD",
                     ),
                 )
 
@@ -161,14 +161,29 @@ def test_submit_sell_migrates_single_legacy_a_share_position(client: TestClient)
 
     assert response.status_code == 200, response.text
     assert response.json()["status"] == "FILLED"
+
+    async def _read_currency() -> str:
+        async with get_conn() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT currency FROM positions WHERE account_id = %s",
+                    (str(account_id),),
+                )
+                row = await cur.fetchone()
+                assert row is not None
+                return str(row["currency"])
+
+    assert asyncio.run(_read_currency()) == "CNY"
     assert client.get("/positions", headers=headers).json() == []
 
 
+@pytest.mark.parametrize("legacy_venue", ["akshare", "baostock"])
 @respx.mock
 def test_submit_sell_migrates_legacy_global_position_with_fresh_ticker(
     client: TestClient,
+    legacy_venue: str,
 ) -> None:
-    """旧 akshare 港股持仓可用 canonical fresh ticker 完成市价平仓。"""
+    """旧前缀格式港股持仓可用 canonical fresh ticker 完成市价平仓。"""
     import asyncio
     from decimal import Decimal
 
@@ -177,7 +192,7 @@ def test_submit_sell_migrates_legacy_global_position_with_fresh_ticker(
     from inalpha_paper.account_id import account_id_from_sub
     from inalpha_paper.storage import accounts as accounts_store
 
-    sub, token = fresh_account_token("legacy-global-position")
+    sub, token = fresh_account_token(f"legacy-global-position-{legacy_venue}")
     account_id = account_id_from_sub(sub)
     headers = {"Authorization": f"Bearer {token}"}
 
@@ -192,17 +207,24 @@ def test_submit_sell_migrates_legacy_global_position_with_fresh_ticker(
                     ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())",
                     (
                         str(account_id),
-                        "akshare",
+                        legacy_venue,
                         "hk.00700",
                         Decimal("1"),
                         Decimal("600"),
                         Decimal("0"),
                         1,
-                        "HKD",
+                        "USD",
                     ),
                 )
 
     asyncio.run(_seed_legacy_position())
+    visible_rows = client.get("/positions", headers=headers).json()
+    assert len(visible_rows) == 1
+    assert (visible_rows[0]["venue"], visible_rows[0]["symbol"]) == (
+        "yfinance",
+        "0700.HK",
+    )
+    assert visible_rows[0]["currency"] == "HKD"
     route = respx.get(
         "http://data-mock.test/ticker",
         params={"venue": "yfinance", "symbol": "0700.HK", "fresh": "true"},
@@ -222,7 +244,7 @@ def test_submit_sell_migrates_legacy_global_position_with_fresh_ticker(
         "/orders/submit",
         headers=headers,
         json={
-            "venue": "akshare",
+            "venue": legacy_venue,
             "symbol": "hk.00700",
             "side": "SELL",
             "type": "MARKET",
@@ -236,7 +258,96 @@ def test_submit_sell_migrates_legacy_global_position_with_fresh_ticker(
     assert (body["venue"], body["symbol"]) == ("yfinance", "0700.HK")
     assert body["avg_fill_price"] == 620.0
     assert route.call_count == 1
+
+    async def _read_raw_position() -> dict[str, Any]:
+        async with get_conn() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT venue, symbol, currency FROM positions WHERE account_id = %s",
+                    (str(account_id),),
+                )
+                row = await cur.fetchone()
+                assert row is not None
+                return dict(row)
+
+    stored = asyncio.run(_read_raw_position())
+    assert (stored["venue"], stored["symbol"]) == ("yfinance", "0700.HK")
+    assert stored["currency"] == "HKD"
     assert client.get("/positions", headers=headers).json() == []
+
+
+def test_account_snapshot_canonicalizes_legacy_global_position_for_mark(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """账户估值读取旧全球仓位时使用 canonical ticker 与正确计价币种。"""
+    import asyncio
+    from decimal import Decimal
+
+    from inalpha_shared.db import get_conn
+
+    from inalpha_paper.account_id import account_id_from_sub
+    from inalpha_paper.storage import accounts as accounts_store
+
+    ticker_calls: list[tuple[str, str, bool | None]] = []
+    fx_calls: list[tuple[str, str]] = []
+
+    class _StubDataClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def get_ticker(
+            self,
+            *,
+            venue: str,
+            symbol: str,
+            fresh: bool | None = None,
+        ) -> dict[str, Any]:
+            ticker_calls.append((venue, symbol, fresh))
+            return {"price": 620.0, "is_stale": False}
+
+        async def get_fx(self, *, base: str, quote: str) -> dict[str, Any]:
+            fx_calls.append((base, quote))
+            return {"rate": 0.1, "is_stale": False}
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("inalpha_paper.api.orders.DataClient", _StubDataClient)
+    sub, token = fresh_account_token("legacy-global-account-snapshot")
+    account_id = account_id_from_sub(sub)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async def _seed_legacy_position() -> None:
+        async with get_conn() as conn:
+            await accounts_store.get_or_create(conn, account_id)
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO positions ("
+                    "account_id, venue, symbol, quantity, avg_open_price, "
+                    "realized_pnl, generation, currency, updated_at"
+                    ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())",
+                    (
+                        str(account_id),
+                        "baostock",
+                        "hk.00700",
+                        Decimal("1"),
+                        Decimal("600"),
+                        Decimal("0"),
+                        1,
+                        "USD",
+                    ),
+                )
+
+    asyncio.run(_seed_legacy_position())
+    response = client.get("/accounts/me", headers=headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert ticker_calls == [("yfinance", "0700.HK", False)]
+    assert fx_calls == [("HKD", "USD")]
+    assert body["positions_value"] == pytest.approx(62.0)
+    assert body["fx_warnings"] == []
 
 
 @respx.mock

--- a/services/paper/tests/test_trade_quote_resolution.py
+++ b/services/paper/tests/test_trade_quote_resolution.py
@@ -99,6 +99,61 @@ def test_trade_request_schemas_canonicalize_a_share_identity() -> None:
     assert (plan.venue, plan.symbol) == ("baostock", "sz.000001")
 
 
+def test_submit_sell_migrates_single_legacy_a_share_position(client: TestClient) -> None:
+    """升级前旧 key 的持仓仍能被 canonical SELL 找到并平仓。"""
+    import asyncio
+    from decimal import Decimal
+
+    from inalpha_shared.db import get_conn
+
+    from inalpha_paper.account_id import account_id_from_sub
+    from inalpha_paper.storage import accounts as accounts_store
+
+    sub, token = fresh_account_token("legacy-a-share-position")
+    account_id = account_id_from_sub(sub)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async def _seed_legacy_position() -> None:
+        async with get_conn() as conn:
+            await accounts_store.get_or_create(conn, account_id)
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO positions ("
+                    "account_id, venue, symbol, quantity, avg_open_price, "
+                    "realized_pnl, generation, currency, updated_at"
+                    ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())",
+                    (
+                        str(account_id),
+                        "akshare",
+                        "600519.SH",
+                        Decimal("1"),
+                        Decimal("1415"),
+                        Decimal("0"),
+                        1,
+                        "CNY",
+                    ),
+                )
+
+    asyncio.run(_seed_legacy_position())
+
+    response = client.post(
+        "/orders/submit",
+        headers=headers,
+        json={
+            "venue": "baostock",
+            "symbol": "sh.600519",
+            "side": "SELL",
+            "type": "MARKET",
+            "quantity": 1,
+            "ref_price": 1_415.0,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "FILLED"
+    assert client.get("/positions", headers=headers).json() == []
+
+
 @respx.mock
 def test_submit_order_without_ref_price_requests_fresh_ticker(
     client: TestClient,
@@ -212,6 +267,10 @@ def test_a_share_plan_retries_same_token_after_fresh_quote_recovers(
     first_response: Response,
 ) -> None:
     """A 股报价失败不消费 token，恢复后同一 plan 可按 fresh ticker 成交。"""
+    import asyncio
+
+    from inalpha_shared.db import get_conn
+
     _, token = fresh_account_token("fresh-a-share-plan")
     headers = {"Authorization": f"Bearer {token}"}
     route = respx.get(
@@ -253,6 +312,16 @@ def test_a_share_plan_retries_same_token_after_fresh_quote_recovers(
         "sh.600519",
     )
     plan_id = created_body["plan_id"]
+
+    async def _rewrite_as_legacy_plan() -> None:
+        async with get_conn() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "UPDATE trade_plans SET venue = %s, symbol = %s WHERE plan_id = %s",
+                    ("akshare", "600519.SH", plan_id),
+                )
+
+    asyncio.run(_rewrite_as_legacy_plan())
 
     approved = client.post(
         f"/plans/{plan_id}/approve",

--- a/services/paper/tests/test_trade_quote_resolution.py
+++ b/services/paper/tests/test_trade_quote_resolution.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from httpx import Response
 
 from inalpha_paper.data_client import DataClient
+from inalpha_paper.schemas import CreatePlanRequest, SubmitOrderRequest
 
 from .conftest import fresh_account_token
 
@@ -69,6 +70,33 @@ async def test_data_client_serializes_fresh_query(
     assert request.url.params.get("venue") == "baostock"
     assert request.url.params.get("symbol") == "sh.600519"
     assert request.url.params.get("fresh") == expected
+
+
+def test_trade_request_schemas_canonicalize_a_share_identity() -> None:
+    """direct order 与 plan 都在持久化前统一 A 股 venue/symbol。"""
+    order = SubmitOrderRequest.model_validate(
+        {
+            "venue": "akshare",
+            "symbol": "600519.SH",
+            "side": "BUY",
+            "type": "MARKET",
+            "quantity": 1,
+        }
+    )
+    plan = CreatePlanRequest.model_validate(
+        {
+            "intent": "open_long",
+            "venue": "baostock",
+            "symbol": "000001.SZ",
+            "side": "BUY",
+            "type": "MARKET",
+            "quantity": 1,
+            "rationale": "canonical identity regression",
+        }
+    )
+
+    assert (order.venue, order.symbol) == ("baostock", "sh.600519")
+    assert (plan.venue, plan.symbol) == ("baostock", "sz.000001")
 
 
 @respx.mock
@@ -210,7 +238,7 @@ def test_a_share_plan_retries_same_token_after_fresh_quote_recovers(
         json={
             "intent": "open_long",
             "venue": "baostock",
-            "symbol": "sh.600519",
+            "symbol": "600519.SH",
             "side": "BUY",
             "type": "MARKET",
             "quantity": 1,
@@ -219,7 +247,12 @@ def test_a_share_plan_retries_same_token_after_fresh_quote_recovers(
         },
     )
     assert created.status_code == 200, created.text
-    plan_id = created.json()["plan_id"]
+    created_body = created.json()
+    assert (created_body["venue"], created_body["symbol"]) == (
+        "baostock",
+        "sh.600519",
+    )
+    plan_id = created_body["plan_id"]
 
     approved = client.post(
         f"/plans/{plan_id}/approve",
@@ -251,5 +284,35 @@ def test_a_share_plan_retries_same_token_after_fresh_quote_recovers(
     result = second.json()
     assert result["plan_status"] == "executed"
     assert result["order"]["status"] == "FILLED"
+    assert result["order"]["symbol"] == "sh.600519"
     assert result["order"]["avg_fill_price"] == 1_415.0
+
+    opened_positions = client.get("/positions", headers=headers)
+    assert opened_positions.status_code == 200, opened_positions.text
+    opened_rows = opened_positions.json()
+    assert len(opened_rows) == 1
+    assert opened_rows[0]["venue"] == "baostock"
+    assert opened_rows[0]["symbol"] == "sh.600519"
+    assert opened_rows[0]["currency"] == "CNY"
+    assert opened_rows[0]["quantity"] == 1.0
+
+    closed = client.post(
+        "/orders/submit",
+        headers=headers,
+        json={
+            "venue": "baostock",
+            "symbol": "sh.600519",
+            "side": "SELL",
+            "type": "MARKET",
+            "quantity": 1,
+            "ref_price": 1_415.0,
+        },
+    )
+    assert closed.status_code == 200, closed.text
+    assert closed.json()["status"] == "FILLED"
+
+    positions = client.get("/positions", headers=headers)
+    assert positions.status_code == 200, positions.text
+    rows = positions.json()
+    assert rows == []
     assert route.call_count == 2

--- a/services/paper/tests/test_trade_quote_resolution.py
+++ b/services/paper/tests/test_trade_quote_resolution.py
@@ -16,7 +16,13 @@ pytestmark = pytest.mark.integration
 
 
 def _ticker_response(
-    *, venue: str, symbol: str, price: float, source: str
+    *,
+    venue: str,
+    symbol: str,
+    price: float,
+    source: str,
+    is_stale: bool = False,
+    stale_seconds: int = 1,
 ) -> dict[str, Any]:
     """构造 data-service 的完整 ticker 响应。"""
     return {
@@ -25,8 +31,8 @@ def _ticker_response(
         "price": price,
         "ts": "2026-08-13T02:20:00Z",
         "source": source,
-        "is_stale": False,
-        "stale_seconds": 1,
+        "is_stale": is_stale,
+        "stale_seconds": stale_seconds,
     }
 
 
@@ -106,8 +112,76 @@ def test_submit_order_without_ref_price_requests_fresh_ticker(
 
 
 @respx.mock
+def test_submit_order_rejects_stale_execution_ticker(client: TestClient) -> None:
+    """交易执行不得把 data 明确标记的陈旧报价当作成交价。"""
+    _, token = fresh_account_token("stale-order")
+    route = respx.get(
+        "http://data-mock.test/ticker",
+        params={"venue": "binance", "symbol": "BTC/USDT", "fresh": "true"},
+    ).mock(
+        return_value=Response(
+            200,
+            json=_ticker_response(
+                venue="binance",
+                symbol="BTC/USDT",
+                price=50_000.0,
+                source="binance_ticker",
+                is_stale=True,
+                stale_seconds=900,
+            ),
+        )
+    )
+
+    response = client.post(
+        "/orders/submit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "venue": "binance",
+            "symbol": "BTC/USDT",
+            "side": "BUY",
+            "type": "MARKET",
+            "quantity": 0.01,
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["code"] == "REF_PRICE_UNAVAILABLE"
+    assert route.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "first_response",
+    [
+        pytest.param(
+            Response(
+                404,
+                json={
+                    "code": "NO_PRICE_AVAILABLE",
+                    "message": "no cached or live price available",
+                },
+            ),
+            id="unavailable",
+        ),
+        pytest.param(
+            Response(
+                200,
+                json=_ticker_response(
+                    venue="baostock",
+                    symbol="sh.600519",
+                    price=1_415.0,
+                    source="baostock_ticker",
+                    is_stale=True,
+                    stale_seconds=900,
+                ),
+            ),
+            id="stale",
+        ),
+    ],
+)
+@respx.mock
 def test_a_share_plan_retries_same_token_after_fresh_quote_recovers(
     client: TestClient,
+    first_response: Response,
 ) -> None:
     """A 股报价失败不消费 token，恢复后同一 plan 可按 fresh ticker 成交。"""
     _, token = fresh_account_token("fresh-a-share-plan")
@@ -117,13 +191,7 @@ def test_a_share_plan_retries_same_token_after_fresh_quote_recovers(
         params={"venue": "baostock", "symbol": "sh.600519", "fresh": "true"},
     ).mock(
         side_effect=[
-            Response(
-                404,
-                json={
-                    "code": "NO_PRICE_AVAILABLE",
-                    "message": "no cached or live price available",
-                },
-            ),
+            first_response,
             Response(
                 200,
                 json=_ticker_response(

--- a/services/paper/tests/test_trade_quote_resolution.py
+++ b/services/paper/tests/test_trade_quote_resolution.py
@@ -72,8 +72,8 @@ async def test_data_client_serializes_fresh_query(
     assert request.url.params.get("fresh") == expected
 
 
-def test_trade_request_schemas_canonicalize_a_share_identity() -> None:
-    """direct order 与 plan 都在持久化前统一 A 股 venue/symbol。"""
+def test_trade_request_schemas_canonicalize_market_identities() -> None:
+    """direct order 与 plan 都在持久化前统一 legacy venue/symbol。"""
     order = SubmitOrderRequest.model_validate(
         {
             "venue": "akshare",
@@ -94,9 +94,19 @@ def test_trade_request_schemas_canonicalize_a_share_identity() -> None:
             "rationale": "canonical identity regression",
         }
     )
+    legacy_global = SubmitOrderRequest.model_validate(
+        {
+            "venue": "akshare",
+            "symbol": "hk.00700",
+            "side": "SELL",
+            "type": "MARKET",
+            "quantity": 1,
+        }
+    )
 
     assert (order.venue, order.symbol) == ("baostock", "sh.600519")
     assert (plan.venue, plan.symbol) == ("baostock", "sz.000001")
+    assert (legacy_global.venue, legacy_global.symbol) == ("yfinance", "0700.HK")
 
 
 def test_submit_sell_migrates_single_legacy_a_share_position(client: TestClient) -> None:
@@ -151,6 +161,81 @@ def test_submit_sell_migrates_single_legacy_a_share_position(client: TestClient)
 
     assert response.status_code == 200, response.text
     assert response.json()["status"] == "FILLED"
+    assert client.get("/positions", headers=headers).json() == []
+
+
+@respx.mock
+def test_submit_sell_migrates_legacy_global_position_with_fresh_ticker(
+    client: TestClient,
+) -> None:
+    """旧 akshare 港股持仓可用 canonical fresh ticker 完成市价平仓。"""
+    import asyncio
+    from decimal import Decimal
+
+    from inalpha_shared.db import get_conn
+
+    from inalpha_paper.account_id import account_id_from_sub
+    from inalpha_paper.storage import accounts as accounts_store
+
+    sub, token = fresh_account_token("legacy-global-position")
+    account_id = account_id_from_sub(sub)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async def _seed_legacy_position() -> None:
+        async with get_conn() as conn:
+            await accounts_store.get_or_create(conn, account_id)
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO positions ("
+                    "account_id, venue, symbol, quantity, avg_open_price, "
+                    "realized_pnl, generation, currency, updated_at"
+                    ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())",
+                    (
+                        str(account_id),
+                        "akshare",
+                        "hk.00700",
+                        Decimal("1"),
+                        Decimal("600"),
+                        Decimal("0"),
+                        1,
+                        "HKD",
+                    ),
+                )
+
+    asyncio.run(_seed_legacy_position())
+    route = respx.get(
+        "http://data-mock.test/ticker",
+        params={"venue": "yfinance", "symbol": "0700.HK", "fresh": "true"},
+    ).mock(
+        return_value=Response(
+            200,
+            json=_ticker_response(
+                venue="yfinance",
+                symbol="0700.HK",
+                price=620.0,
+                source="yfinance_ticker",
+            ),
+        )
+    )
+
+    response = client.post(
+        "/orders/submit",
+        headers=headers,
+        json={
+            "venue": "akshare",
+            "symbol": "hk.00700",
+            "side": "SELL",
+            "type": "MARKET",
+            "quantity": 1,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "FILLED"
+    assert (body["venue"], body["symbol"]) == ("yfinance", "0700.HK")
+    assert body["avg_fill_price"] == 620.0
+    assert route.call_count == 1
     assert client.get("/positions", headers=headers).json() == []
 
 


### PR DESCRIPTION
## Summary

- 修复 paper 交易执行遗漏 `fresh=true` 的跨服务契约，避免 A 股 K 线可用但下单因 DB-only ticker 返回 `NO_PRICE_AVAILABLE`。
- 直接订单与 trade plan 都改为从 data-service 的实时 ticker capability 获取参考价；报价失败仍保留审批 token，可恢复后重试。
- 兼容 `sh.600519` / `600519.SH` 与 legacy `akshare` A 股身份，避免 data 按人民币行情取价而 paper 回退为 USD 记账。
- 更新 data OpenAPI 与 orchestrator 市场能力说明。

## Test Coverage

- 新增 fresh 参数序列化、直接下单取价、A 股 plan 报价失败重试回归。
- 补充 A 股前缀/后缀 symbol 的币种和交易日历解析用例。

## Verification

- `services/paper`: 937 tests passed
- 聚焦回归：57 tests passed
- `packages/orchestration`: typecheck passed
- `packages/orchestration`: 478 tests passed
- Ruff passed
- `scripts/check-consistency.sh`: 10 passed, 0 failed
- `git diff --check`: passed

## Scope

- 仅包含两个 A 股修复提交；未包含工作树中的 evolution/dashboard 等 WIP。
- 未修改 VERSION 或 CHANGELOG。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
