### PR TITLE
fix(ci): 自动审查切换 DeepSeek V4 Pro

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,15 +1,15 @@
-name: Claude PR Review
+name: DeepSeek PR Review
 
 # PR 打开 / reopen / 每次 push 新 commit（synchronize）时自动 review diff。
 # 防邮件洪水靠三道闸而非「少触发」：① concurrency + cancel-in-progress 让同一 PR
 # 新 push 立刻取消上一轮；② review step 只维护**一条 sticky 总结评论**
 # （gh pr comment --edit-last 原地覆盖，GitHub 对编辑评论不发邮件，仅首条发一封）；
 # ③ 不逐行贴 inline 评论。需对历史 commit 重审可去 Actions 页跑 workflow_dispatch。
-# 非阻塞设计：即使 GLM 出错（API 超时、token 过期等），
+# 非阻塞设计：即使 DeepSeek 出错（API 超时、token 过期等），
 # 本 workflow 不会阻止 PR 合并。review 评论是锦上添花，不是门禁。
-# Auth: 智谱 GLM API key 存在 GitHub Actions Secret ZHIPUAI_API_KEY
+# Auth: DeepSeek API key 存在 GitHub Actions Secret DEEPSEEK_API_KEY
 #
-# 改编自原始 claude-review.yml——只换了底层模型为 GLM-5.2，prompt 和编排逻辑保留。
+# 保留原始 review prompt 和 sticky 评论编排，只替换底层模型。
 
 on:
   pull_request:
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   review:
-    name: Claude · auto-review PR diff（非阻塞）
+    name: DeepSeek · auto-review PR diff（非阻塞）
     runs-on: ubuntu-latest
     # 🔑 非阻塞关键：即使本 job 失败，也标记为成功，不卡 PR 合并
     continue-on-error: true
@@ -55,22 +55,22 @@ jobs:
           echo "diff_lines=$(wc -l < /tmp/pr_diff.txt)" >> $GITHUB_OUTPUT
           gh pr view "$PR_NUMBER" --json title,body,headRefName,baseRefName --jq '"\(.title) | \(.headRefName) → \(.baseRefName)"' > /tmp/pr_title.txt
 
-      - name: GLM-5.2 · review
+      - name: DeepSeek V4 Pro · review
         id: review
         # 内层 step 也 continue-on-error，防止 Python 抛异常
         continue-on-error: true
         env:
-          ZHIPUAI_API_KEY: ${{ secrets.ZHIPUAI_API_KEY }}
-        run: python3 scripts/glm_review.py
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: python3 scripts/deepseek_review.py
 
-      # 即使 GLM 挂了，也记录一下方便排查
+      # 即使 DeepSeek 挂了，也记录一下方便排查
       - name: Log review status
         if: always()
         run: |
           if [ "${{ steps.review.outcome }}" = "success" ]; then
-            echo "GLM review completed successfully"
+            echo "DeepSeek review completed successfully"
           else
-            echo "GLM review skipped or failed (non-blocking) — outcome: ${{ steps.review.outcome }}"
+            echo "DeepSeek review skipped or failed (non-blocking) — outcome: ${{ steps.review.outcome }}"
           fi
 
       - name: Post/Update sticky comment

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -56,9 +56,11 @@ jobs:
           gh pr view "$PR_NUMBER" --json title,body,headRefName,baseRefName --jq '"\(.title) | \(.headRefName) → \(.baseRefName)"' > /tmp/pr_title.txt
 
       - name: Test review script
+        continue-on-error: true
         run: python3 -m unittest tests/test_deepseek_review.py -v
 
       - name: DeepSeek V4 Pro · review
+        if: always()
         id: review
         # 内层 step 也 continue-on-error，防止 Python 抛异常
         continue-on-error: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,6 +55,9 @@ jobs:
           echo "diff_lines=$(wc -l < /tmp/pr_diff.txt)" >> $GITHUB_OUTPUT
           gh pr view "$PR_NUMBER" --json title,body,headRefName,baseRefName --jq '"\(.title) | \(.headRefName) → \(.baseRefName)"' > /tmp/pr_title.txt
 
+      - name: Test review script
+        run: python3 -m unittest tests/test_deepseek_review.py -v
+
       - name: DeepSeek V4 Pro · review
         id: review
         # 内层 step 也 continue-on-error，防止 Python 抛异常

--- a/scripts/deepseek_review.py
+++ b/scripts/deepseek_review.py
@@ -26,6 +26,7 @@ import urllib.request
 
 DIFF_PATH = "/tmp/pr_diff.txt"
 TITLE_PATH = "/tmp/pr_title.txt"
+RULES_PATH = "CLAUDE.md"
 OUT_PATH = "/tmp/review_body.txt"
 
 BASE_URL = os.environ.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
@@ -37,19 +38,20 @@ SYSTEM_PROMPT = """\
 你是这个仓库的资深 reviewer。目标：在合并前尽量拦住真正的 bug、设计缺陷、架构失误。
 **不要只对着固定清单打勾**——清单覆盖不到新功能。要先理解再评审。
 
-## Step 1 · 读项目规则（每次都重新读，规则会随项目迭代而变）
+## Step 1 · 读项目规则（每次都重新注入，规则会随项目迭代而变）
 
-- 用 Read 读仓库根 `CLAUDE.md`；改动目录附近若有 `AGENTS.md` / 相关 `docs/` / ADR 也读。
-- 把里面的硬约束当成本次 review 的**项目专属规则**——
-  CLAUDE.md 更新了，你的评审标准就自动跟着更新，**无需改这个 workflow**。
-- 这是项目规则的唯一权威来源；下面 Step 4 的清单只是提示，以你读到的为准。
+- 用户消息中的“项目规则”就是仓库根 `CLAUDE.md` 的完整内容，把其中硬约束当作
+  本次 review 的项目专属标准。
+- 当前环境没有 Read / Grep / Glob 或其它工具。不要尝试调用工具，也不要输出工具调用协议；
+  只能基于项目规则、PR 标题和完整 diff 评审。
+- 规则更新后会由脚本自动重新注入，无需修改这个 workflow。
 
 ## Step 2 · 重建意图 + 圈定影响面
 
 - 先一句话说清这个 PR 想做什么。
-- 用 Read / Grep / Glob 看 diff **以外**的代码：改动的函数 / 接口 / 契约有哪些调用方？
-  碰了哪些模块边界（Inalpha 是 Next.js → Mastra(TS) → Python services 三层）？
-- 只有理解了"改动如何与系统其余部分交互"，才谈得上架构评审。
+- 只基于给定完整 diff 重建调用关系和模块边界。看不到 diff 外实现时，不要假装已经读取，
+  也不要输出工具请求；仅报告能由现有证据支持的问题。
+- 只有理解了改动如何与系统其余部分交互，才提出架构 finding。
 
 ## Step 3 · 通用工程评审（适用任何功能，新增功能也自动覆盖）
 
@@ -95,16 +97,31 @@ def _fail(msg: str) -> None:
     sys.exit(0)
 
 
-def _call_deepseek(api_key: str, title: str, diff: str) -> str:
-    """调用 DeepSeek；正常响应却无正文时重试一次，禁止发布空 review。"""
+def _is_valid_review(content: object) -> bool:
+    """只接受非空自然语言正文，拒绝模型泄漏的工具调用协议。"""
+    if not isinstance(content, str) or not content.strip():
+        return False
+    protocol_markers = ("<｜｜DSML｜｜tool_calls>", "<tool_call>", '"tool_calls"')
+    return not any(marker in content for marker in protocol_markers)
+
+
+def _call_deepseek(api_key: str, title: str, diff: str, rules: str) -> str:
+    """调用 DeepSeek；空正文或工具协议泄漏时重试一次。"""
     payload = {
         "model": MODEL,
         "messages": [
             {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": f"## PR 标题\n{title}\n\n## Diff\n{diff}"},
+            {
+                "role": "user",
+                "content": (
+                    f"## 项目规则（CLAUDE.md）\n{rules}\n\n"
+                    f"## PR 标题\n{title}\n\n## Diff\n{diff}"
+                ),
+            },
         ],
         "temperature": 0.1,
-        "max_tokens": 4096,
+        # V4 Pro 会把 reasoning tokens 计入 completion；4096 会在输出正文前耗尽。
+        "max_tokens": 16384,
     }
     for attempt in range(MAX_ATTEMPTS):
         req = urllib.request.Request(
@@ -119,16 +136,19 @@ def _call_deepseek(api_key: str, title: str, diff: str) -> str:
         with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
             body = json.loads(resp.read())
         content = body["choices"][0]["message"].get("content")
-        if isinstance(content, str) and content.strip():
+        if _is_valid_review(content):
             return content.strip()
         if attempt + 1 < MAX_ATTEMPTS:
             payload["messages"].append(
                 {
                     "role": "user",
-                    "content": "上一轮没有返回 review 正文。请直接输出最终中文 review。",
+                    "content": (
+                        "上一轮没有返回可发布的 review 正文。当前没有任何工具，"
+                        "禁止输出工具调用协议。请直接输出最终中文 review。"
+                    ),
                 }
             )
-    raise ValueError("DeepSeek 返回空 review 正文")
+    raise ValueError("DeepSeek 未返回可发布的 review 正文")
 
 
 def main() -> None:
@@ -141,6 +161,8 @@ def main() -> None:
             diff = f.read()
         with open(TITLE_PATH) as f:
             title = f.read().strip()
+        with open(RULES_PATH) as f:
+            rules = f.read()
     except OSError as e:
         _fail(f"读输入失败：{e}")
 
@@ -148,7 +170,7 @@ def main() -> None:
         _fail("diff 为空")
 
     try:
-        content = _call_deepseek(api_key, title, diff)
+        content = _call_deepseek(api_key, title, diff, rules)
     except urllib.error.HTTPError as e:
         body = e.read().decode("utf-8", "replace")[:300]
         _fail(f"DeepSeek API HTTP {e.code}：{body}")

--- a/scripts/deepseek_review.py
+++ b/scripts/deepseek_review.py
@@ -141,10 +141,10 @@ def _call_deepseek(api_key: str, title: str, diff: str, rules: str) -> str:
             if attempt + 1 < MAX_ATTEMPTS:
                 continue
             raise
-        content = body["choices"][0]["message"].get("content")
-        if _is_valid_review(content):
-            return content.strip()
         choice = body["choices"][0]
+        content = choice["message"].get("content")
+        if choice.get("finish_reason") == "stop" and _is_valid_review(content):
+            return content.strip()
         usage = body.get("usage", {})
         reasoning_tokens = usage.get("completion_tokens_details", {}).get(
             "reasoning_tokens", "unknown"

--- a/scripts/deepseek_review.py
+++ b/scripts/deepseek_review.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
-"""GLM-5.2 PR review——claude-review.yml 调用,也可本地跑。
+"""DeepSeek V4 Pro PR review——claude-review.yml 调用，也可本地跑。
 
 环境:
-- ``ZHIPUAI_API_KEY``(必填)
-- ``GLM_BASE_URL``(默认 https://yuanyuaicloud.cn/v1)
-- ``GLM_MODEL``(默认 glm-5.2)
+- ``DEEPSEEK_API_KEY``（必填）
+- ``DEEPSEEK_BASE_URL``（默认 https://api.deepseek.com/v1）
+- ``DEEPSEEK_MODEL``（默认 deepseek-v4-pro）
 
 输入:
-- ``/tmp/pr_diff.txt``   PR diff(claude-review.yml 前一步 ``gh pr diff`` 落盘)
+- ``/tmp/pr_diff.txt``   PR diff（claude-review.yml 前一步 ``gh pr diff`` 落盘）
 - ``/tmp/pr_title.txt``  PR 标题
 
 输出:
-- ``/tmp/review_body.txt``  渲染好的 markdown(后一步 gh pr comment 贴出)
+- ``/tmp/review_body.txt``  渲染好的 markdown（后一步 gh pr comment 贴出）
 
-约定:任何失败都写 failure 说明后 exit 0,不让 review 挂 PR checks。
-不截断 diff——GLM-5.2 1M 上下文,全量喂。
+约定:任何失败都写 failure 说明后 exit 0，不让 review 挂 PR checks。
+不截断 diff，完整交给模型评审。
 """
 from __future__ import annotations
 
@@ -28,9 +28,9 @@ DIFF_PATH = "/tmp/pr_diff.txt"
 TITLE_PATH = "/tmp/pr_title.txt"
 OUT_PATH = "/tmp/review_body.txt"
 
-BASE_URL = os.environ.get("GLM_BASE_URL", "https://yuanyuaicloud.cn/v1")
-MODEL = os.environ.get("GLM_MODEL", "glm-5.2")
-TIMEOUT_S = 900  # 全量 diff + 1M 上下文,给足推理时间
+BASE_URL = os.environ.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
+MODEL = os.environ.get("DEEPSEEK_MODEL", "deepseek-v4-pro")
+TIMEOUT_S = 900  # 全量 diff 给足推理时间
 
 SYSTEM_PROMPT = """\
 你是这个仓库的资深 reviewer。目标：在合并前尽量拦住真正的 bug、设计缺陷、架构失误。
@@ -87,14 +87,14 @@ _SEV_ICON = {"critical": "🔴", "major": "🟠", "medium": "🟡"}  # unused, k
 
 
 def _fail(msg: str) -> None:
-    """写失败说明后正常退出(非阻塞)。"""
-    print(f"glm_review: {msg}", file=sys.stderr)
+    """写失败说明后正常退出（非阻塞）。"""
+    print(f"deepseek_review: {msg}", file=sys.stderr)
     with open(OUT_PATH, "w") as f:
-        f.write(f"## 🤖 GLM-5.2 PR Review\n\n⚠️ review 未完成：{msg}\n")
+        f.write(f"## 🤖 DeepSeek V4 Pro PR Review\n\n⚠️ review 未完成：{msg}\n")
     sys.exit(0)
 
 
-def _call_glm(api_key: str, title: str, diff: str) -> str:
+def _call_deepseek(api_key: str, title: str, diff: str) -> str:
     payload = {
         "model": MODEL,
         "messages": [
@@ -119,9 +119,9 @@ def _call_glm(api_key: str, title: str, diff: str) -> str:
 
 
 def main() -> None:
-    api_key = os.environ.get("ZHIPUAI_API_KEY", "")
+    api_key = os.environ.get("DEEPSEEK_API_KEY", "")
     if not api_key:
-        _fail("ZHIPUAI_API_KEY 未配置(repo Settings → Secrets → Actions)")
+        _fail("DEEPSEEK_API_KEY 未配置（repo Settings → Secrets → Actions）")
 
     try:
         with open(DIFF_PATH) as f:
@@ -135,17 +135,17 @@ def main() -> None:
         _fail("diff 为空")
 
     try:
-        content = _call_glm(api_key, title, diff)
+        content = _call_deepseek(api_key, title, diff)
     except urllib.error.HTTPError as e:
         body = e.read().decode("utf-8", "replace")[:300]
-        _fail(f"GLM API HTTP {e.code}：{body}")
+        _fail(f"DeepSeek API HTTP {e.code}：{body}")
     except Exception as e:
-        _fail(f"GLM API 调用失败：{e}")
+        _fail(f"DeepSeek API 调用失败：{e}")
 
-    body = "## 🤖 GLM-5.2 PR Review\n\n" + content
+    body = "## 🤖 DeepSeek V4 Pro PR Review\n\n" + content
     with open(OUT_PATH, "w") as f:
         f.write(body)
-    print(f"glm_review: done, {len(body)} chars → {OUT_PATH}")
+    print(f"deepseek_review: done, {len(body)} chars → {OUT_PATH}")
 
 
 if __name__ == "__main__":

--- a/scripts/deepseek_review.py
+++ b/scripts/deepseek_review.py
@@ -31,6 +31,7 @@ OUT_PATH = "/tmp/review_body.txt"
 BASE_URL = os.environ.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
 MODEL = os.environ.get("DEEPSEEK_MODEL", "deepseek-v4-pro")
 TIMEOUT_S = 900  # 全量 diff 给足推理时间
+MAX_ATTEMPTS = 2  # 正常结束但 content 为空时仅重试一次
 
 SYSTEM_PROMPT = """\
 你是这个仓库的资深 reviewer。目标：在合并前尽量拦住真正的 bug、设计缺陷、架构失误。
@@ -95,6 +96,7 @@ def _fail(msg: str) -> None:
 
 
 def _call_deepseek(api_key: str, title: str, diff: str) -> str:
+    """调用 DeepSeek；正常响应却无正文时重试一次，禁止发布空 review。"""
     payload = {
         "model": MODEL,
         "messages": [
@@ -104,18 +106,29 @@ def _call_deepseek(api_key: str, title: str, diff: str) -> str:
         "temperature": 0.1,
         "max_tokens": 4096,
     }
-    req = urllib.request.Request(
-        f"{BASE_URL}/chat/completions",
-        data=json.dumps(payload).encode(),
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
-        body = json.loads(resp.read())
-    return body["choices"][0]["message"]["content"]
+    for attempt in range(MAX_ATTEMPTS):
+        req = urllib.request.Request(
+            f"{BASE_URL}/chat/completions",
+            data=json.dumps(payload).encode(),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+            body = json.loads(resp.read())
+        content = body["choices"][0]["message"].get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+        if attempt + 1 < MAX_ATTEMPTS:
+            payload["messages"].append(
+                {
+                    "role": "user",
+                    "content": "上一轮没有返回 review 正文。请直接输出最终中文 review。",
+                }
+            )
+    raise ValueError("DeepSeek 返回空 review 正文")
 
 
 def main() -> None:

--- a/scripts/deepseek_review.py
+++ b/scripts/deepseek_review.py
@@ -121,8 +121,8 @@ def _call_deepseek(api_key: str, title: str, diff: str, rules: str) -> str:
             },
         ],
         "temperature": 0.1,
-        # V4 Pro 会把 reasoning tokens 计入 completion；4096 会在输出正文前耗尽。
-        "max_tokens": 16384,
+        # V4 Pro 会把 reasoning tokens 计入 completion；大 diff 下 16384 也可能在正文前耗尽。
+        "max_tokens": 32768,
     }
     for attempt in range(MAX_ATTEMPTS):
         req = urllib.request.Request(
@@ -144,6 +144,18 @@ def _call_deepseek(api_key: str, title: str, diff: str, rules: str) -> str:
         content = body["choices"][0]["message"].get("content")
         if _is_valid_review(content):
             return content.strip()
+        choice = body["choices"][0]
+        usage = body.get("usage", {})
+        reasoning_tokens = usage.get("completion_tokens_details", {}).get(
+            "reasoning_tokens", "unknown"
+        )
+        print(
+            "deepseek_review: invalid response "
+            f"attempt={attempt + 1} finish_reason={choice.get('finish_reason')} "
+            f"content_chars={len(content) if isinstance(content, str) else 0} "
+            f"reasoning_tokens={reasoning_tokens}",
+            file=sys.stderr,
+        )
         if attempt + 1 < MAX_ATTEMPTS:
             payload["messages"].append(
                 {

--- a/scripts/deepseek_review.py
+++ b/scripts/deepseek_review.py
@@ -18,6 +18,7 @@
 """
 from __future__ import annotations
 
+import http.client
 import json
 import os
 import sys
@@ -133,8 +134,13 @@ def _call_deepseek(api_key: str, title: str, diff: str, rules: str) -> str:
             },
             method="POST",
         )
-        with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
-            body = json.loads(resp.read())
+        try:
+            with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+                body = json.loads(resp.read())
+        except (http.client.IncompleteRead, TimeoutError):
+            if attempt + 1 < MAX_ATTEMPTS:
+                continue
+            raise
         content = body["choices"][0]["message"].get("content")
         if _is_valid_review(content):
             return content.strip()

--- a/tests/test_deepseek_review.py
+++ b/tests/test_deepseek_review.py
@@ -23,6 +23,9 @@ def _load_module():
 
 
 class _FakeResponse:
+    def __init__(self, content: str = "LGTM") -> None:
+        self._content = content
+
     def __enter__(self):
         return self
 
@@ -31,7 +34,7 @@ class _FakeResponse:
 
     def read(self) -> bytes:
         return json.dumps(
-            {"choices": [{"message": {"content": "LGTM"}}]}
+            {"choices": [{"message": {"content": self._content}}]}
         ).encode()
 
 
@@ -62,6 +65,31 @@ class DeepSeekReviewTest(unittest.TestCase):
         self.assertEqual(request.get_header("Authorization"), "Bearer secret-value")
         self.assertEqual(payload["model"], "deepseek-v4-pro")
         self.assertEqual(captured["timeout"], module.TIMEOUT_S)
+
+    def test_empty_content_retries_then_returns_review(self) -> None:
+        module = _load_module()
+        responses = [_FakeResponse(""), _FakeResponse("最终 review")]
+
+        with patch.object(
+            module.urllib.request,
+            "urlopen",
+            side_effect=responses,
+        ) as urlopen:
+            result = module._call_deepseek("secret-value", "PR title", "diff body")
+
+        self.assertEqual(result, "最终 review")
+        self.assertEqual(urlopen.call_count, 2)
+
+    def test_repeated_empty_content_fails_instead_of_publishing_blank_review(self) -> None:
+        module = _load_module()
+
+        with patch.object(
+            module.urllib.request,
+            "urlopen",
+            side_effect=[_FakeResponse(""), _FakeResponse("   ")],
+        ):
+            with self.assertRaisesRegex(ValueError, "空 review 正文"):
+                module._call_deepseek("secret-value", "PR title", "diff body")
 
     def test_missing_key_writes_non_blocking_failure(self) -> None:
         module = _load_module()

--- a/tests/test_deepseek_review.py
+++ b/tests/test_deepseek_review.py
@@ -1,6 +1,7 @@
 """DeepSeek PR review 脚本回归测试。"""
 from __future__ import annotations
 
+import http.client
 import importlib.util
 import json
 import os
@@ -78,6 +79,21 @@ class DeepSeekReviewTest(unittest.TestCase):
             side_effect=responses,
         ) as urlopen:
             result = module._call_deepseek("secret-value", "PR title", "diff body", "project rules")
+
+        self.assertEqual(result, "最终 review")
+        self.assertEqual(urlopen.call_count, 2)
+
+    def test_incomplete_response_retries_then_returns_review(self) -> None:
+        module = _load_module()
+
+        with patch.object(
+            module.urllib.request,
+            "urlopen",
+            side_effect=[http.client.IncompleteRead(b"{}"), _FakeResponse("最终 review")],
+        ) as urlopen:
+            result = module._call_deepseek(
+                "secret-value", "PR title", "diff body", "project rules"
+            )
 
         self.assertEqual(result, "最终 review")
         self.assertEqual(urlopen.call_count, 2)

--- a/tests/test_deepseek_review.py
+++ b/tests/test_deepseek_review.py
@@ -1,0 +1,81 @@
+"""DeepSeek PR review 脚本回归测试。"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "deepseek_review.py"
+
+
+def _load_module():
+    """从脚本路径加载独立模块实例。"""
+    spec = importlib.util.spec_from_file_location("deepseek_review", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(
+            {"choices": [{"message": {"content": "LGTM"}}]}
+        ).encode()
+
+
+class DeepSeekReviewTest(unittest.TestCase):
+    def test_defaults_target_deepseek_v4_pro(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            module = _load_module()
+
+        self.assertEqual(module.BASE_URL, "https://api.deepseek.com/v1")
+        self.assertEqual(module.MODEL, "deepseek-v4-pro")
+
+    def test_request_uses_deepseek_model_and_bearer_key(self) -> None:
+        module = _load_module()
+        captured = {}
+
+        def fake_urlopen(request, *, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return _FakeResponse()
+
+        with patch.object(module.urllib.request, "urlopen", side_effect=fake_urlopen):
+            result = module._call_deepseek("secret-value", "PR title", "diff body")
+
+        request = captured["request"]
+        payload = json.loads(request.data)
+        self.assertEqual(result, "LGTM")
+        self.assertEqual(request.full_url, "https://api.deepseek.com/v1/chat/completions")
+        self.assertEqual(request.get_header("Authorization"), "Bearer secret-value")
+        self.assertEqual(payload["model"], "deepseek-v4-pro")
+        self.assertEqual(captured["timeout"], module.TIMEOUT_S)
+
+    def test_missing_key_writes_non_blocking_failure(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module.OUT_PATH = str(Path(tmpdir) / "review.md")
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(SystemExit, "0"):
+                    module.main()
+            body = Path(module.OUT_PATH).read_text()
+
+        self.assertIn("DeepSeek V4 Pro PR Review", body)
+        self.assertIn("DEEPSEEK_API_KEY 未配置", body)
+        self.assertNotIn("GLM-5.2", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deepseek_review.py
+++ b/tests/test_deepseek_review.py
@@ -39,6 +39,11 @@ class _FakeResponse:
         ).encode()
 
 
+class _IncompleteResponse(_FakeResponse):
+    def read(self) -> bytes:
+        raise http.client.IncompleteRead(b"{}")
+
+
 class DeepSeekReviewTest(unittest.TestCase):
     def test_defaults_target_deepseek_v4_pro(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
@@ -89,7 +94,7 @@ class DeepSeekReviewTest(unittest.TestCase):
         with patch.object(
             module.urllib.request,
             "urlopen",
-            side_effect=[http.client.IncompleteRead(b"{}"), _FakeResponse("最终 review")],
+            side_effect=[_IncompleteResponse(), _FakeResponse("最终 review")],
         ) as urlopen:
             result = module._call_deepseek(
                 "secret-value", "PR title", "diff body", "project rules"

--- a/tests/test_deepseek_review.py
+++ b/tests/test_deepseek_review.py
@@ -24,8 +24,9 @@ def _load_module():
 
 
 class _FakeResponse:
-    def __init__(self, content: str = "LGTM") -> None:
+    def __init__(self, content: str = "LGTM", finish_reason: str = "stop") -> None:
         self._content = content
+        self._finish_reason = finish_reason
 
     def __enter__(self):
         return self
@@ -35,7 +36,14 @@ class _FakeResponse:
 
     def read(self) -> bytes:
         return json.dumps(
-            {"choices": [{"message": {"content": self._content}}]}
+            {
+                "choices": [
+                    {
+                        "finish_reason": self._finish_reason,
+                        "message": {"content": self._content},
+                    }
+                ]
+            }
         ).encode()
 
 
@@ -73,6 +81,25 @@ class DeepSeekReviewTest(unittest.TestCase):
         self.assertEqual(payload["max_tokens"], 32768)
         self.assertIn("## 项目规则（CLAUDE.md）\nproject rules", payload["messages"][1]["content"])
         self.assertEqual(captured["timeout"], module.TIMEOUT_S)
+
+    def test_truncated_content_retries_instead_of_publishing_partial_review(self) -> None:
+        module = _load_module()
+        responses = [
+            _FakeResponse("未完成的 finding", finish_reason="length"),
+            _FakeResponse("完整 review"),
+        ]
+
+        with patch.object(
+            module.urllib.request,
+            "urlopen",
+            side_effect=responses,
+        ) as urlopen:
+            result = module._call_deepseek(
+                "secret-value", "PR title", "diff body", "project rules"
+            )
+
+        self.assertEqual(result, "完整 review")
+        self.assertEqual(urlopen.call_count, 2)
 
     def test_empty_content_retries_then_returns_review(self) -> None:
         module = _load_module()

--- a/tests/test_deepseek_review.py
+++ b/tests/test_deepseek_review.py
@@ -70,7 +70,7 @@ class DeepSeekReviewTest(unittest.TestCase):
         self.assertEqual(request.full_url, "https://api.deepseek.com/v1/chat/completions")
         self.assertEqual(request.get_header("Authorization"), "Bearer secret-value")
         self.assertEqual(payload["model"], "deepseek-v4-pro")
-        self.assertEqual(payload["max_tokens"], 16384)
+        self.assertEqual(payload["max_tokens"], 32768)
         self.assertIn("## 项目规则（CLAUDE.md）\nproject rules", payload["messages"][1]["content"])
         self.assertEqual(captured["timeout"], module.TIMEOUT_S)
 

--- a/tests/test_deepseek_review.py
+++ b/tests/test_deepseek_review.py
@@ -56,7 +56,7 @@ class DeepSeekReviewTest(unittest.TestCase):
             return _FakeResponse()
 
         with patch.object(module.urllib.request, "urlopen", side_effect=fake_urlopen):
-            result = module._call_deepseek("secret-value", "PR title", "diff body")
+            result = module._call_deepseek("secret-value", "PR title", "diff body", "project rules")
 
         request = captured["request"]
         payload = json.loads(request.data)
@@ -64,6 +64,8 @@ class DeepSeekReviewTest(unittest.TestCase):
         self.assertEqual(request.full_url, "https://api.deepseek.com/v1/chat/completions")
         self.assertEqual(request.get_header("Authorization"), "Bearer secret-value")
         self.assertEqual(payload["model"], "deepseek-v4-pro")
+        self.assertEqual(payload["max_tokens"], 16384)
+        self.assertIn("## 项目规则（CLAUDE.md）\nproject rules", payload["messages"][1]["content"])
         self.assertEqual(captured["timeout"], module.TIMEOUT_S)
 
     def test_empty_content_retries_then_returns_review(self) -> None:
@@ -75,7 +77,24 @@ class DeepSeekReviewTest(unittest.TestCase):
             "urlopen",
             side_effect=responses,
         ) as urlopen:
-            result = module._call_deepseek("secret-value", "PR title", "diff body")
+            result = module._call_deepseek("secret-value", "PR title", "diff body", "project rules")
+
+        self.assertEqual(result, "最终 review")
+        self.assertEqual(urlopen.call_count, 2)
+
+    def test_tool_protocol_retries_then_returns_review(self) -> None:
+        module = _load_module()
+        protocol = '<｜｜DSML｜｜tool_calls><｜｜DSML｜｜invoke name="Read">'
+        responses = [_FakeResponse(protocol), _FakeResponse("最终 review")]
+
+        with patch.object(
+            module.urllib.request,
+            "urlopen",
+            side_effect=responses,
+        ) as urlopen:
+            result = module._call_deepseek(
+                "secret-value", "PR title", "diff body", "project rules"
+            )
 
         self.assertEqual(result, "最终 review")
         self.assertEqual(urlopen.call_count, 2)
@@ -88,8 +107,10 @@ class DeepSeekReviewTest(unittest.TestCase):
             "urlopen",
             side_effect=[_FakeResponse(""), _FakeResponse("   ")],
         ):
-            with self.assertRaisesRegex(ValueError, "空 review 正文"):
-                module._call_deepseek("secret-value", "PR title", "diff body")
+            with self.assertRaisesRegex(ValueError, "未返回可发布"):
+                module._call_deepseek(
+                    "secret-value", "PR title", "diff body", "project rules"
+                )
 
     def test_missing_key_writes_non_blocking_failure(self) -> None:
         module = _load_module()


### PR DESCRIPTION
## 变更\n\n- PR 自动 review 从 GLM-5.2 切换到 DeepSeek V4 Pro\n- workflow 改读 GitHub Actions Secret `DEEPSEEK_API_KEY`\n- 审查脚本改用 DeepSeek OpenAI-compatible endpoint，并同步重命名\n- 增加模型、鉴权请求与缺密钥非阻塞失败路径测试\n\n## 验证\n\n- `python3 -m unittest tests/test_deepseek_review.py -v`\n- `uv run --project services/paper ruff check scripts/deepseek_review.py tests/test_deepseek_review.py`\n- 使用本地 `.env` 的 `DEEPSEEK_API_KEY` 完成真实 API smoke test\n- `bash scripts/check-consistency.sh`（18 通过，0 失败；已有告警）\n- GitHub Actions Secret `DEEPSEEK_API_KEY` 已安全同步，密钥值未输出、未提交\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)