### PR TITLE
fix(deploy): 分离生产环境文件路径变量

### DIFF
--- a/scripts/check-consistency.sh
+++ b/scripts/check-consistency.sh
@@ -264,6 +264,19 @@ for file in infra/docker/Dockerfile.evolver services/evolver/uv.lock; do
     [[ -f "$file" ]] && ok "$file 存在" || fail "$file 不存在"
 done
 
+# ---------- C10: 生产部署环境文件路径不被 Compose 变量覆盖 ----------
+sect "C10 · 生产部署环境文件路径变量隔离"
+
+DEPLOY_SCRIPT="scripts/deploy.sh"
+if grep -qF 'HOST_ENV_FILE="infra/.env.prod"' "$DEPLOY_SCRIPT" \
+    && grep -qF -- '--env-file "$HOST_ENV_FILE"' "$DEPLOY_SCRIPT" \
+    && grep -qF '[ -f "$HOST_ENV_FILE" ]' "$DEPLOY_SCRIPT" \
+    && grep -qF 'export ENV_FILE=.env.prod' "$DEPLOY_SCRIPT"; then
+    ok "主机 env 路径与 Compose ENV_FILE 已分离"
+else
+    fail "$DEPLOY_SCRIPT 必须分别维护主机 env 路径与 Compose ENV_FILE"
+fi
+
 # ---------- 总结 ----------
 echo
 echo "===================="

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,9 +21,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 COMPOSE_FILE="infra/docker-compose.prod.yml"
-ENV_FILE="infra/.env.prod"
+HOST_ENV_FILE="infra/.env.prod"
+# Compose 内的 env_file 相对 compose 文件解析，因此容器侧仍使用文件名。
 export ENV_FILE=.env.prod
-DC=(docker compose --profile tunnel -f "$COMPOSE_FILE" --env-file "$ENV_FILE")
+DC=(docker compose --profile tunnel -f "$COMPOSE_FILE" --env-file "$HOST_ENV_FILE")
 
 do_git_pull=1
 mode="image" # image | build
@@ -37,12 +38,12 @@ for arg in "$@"; do
   esac
 done
 
-[ -f "$ENV_FILE" ] || {
-  echo "缺 $ENV_FILE —— 从 infra/.env.prod.example 复制并填值" >&2
+[ -f "$HOST_ENV_FILE" ] || {
+  echo "缺 $HOST_ENV_FILE —— 从 infra/.env.prod.example 复制并填值" >&2
   exit 1
 }
 
-if ! grep -qE '^CLOUDFLARE_TUNNEL_TOKEN=.+$' "$ENV_FILE"; then
+if ! grep -qE '^CLOUDFLARE_TUNNEL_TOKEN=.+$' "$HOST_ENV_FILE"; then
   echo "缺 CLOUDFLARE_TUNNEL_TOKEN ——生产 tunnel profile 无法启动" >&2
   exit 1
 fi


### PR DESCRIPTION
## 变更
- 分离主机 `infra/.env.prod` 路径与 Compose `ENV_FILE` 变量
- 增加一致性回归检查，防止部署脚本再次检查错误路径

## 验证
- `bash -n scripts/deploy.sh`
- `bash -n scripts/check-consistency.sh`
- `bash scripts/check-consistency.sh`