### PR TITLE
fix(orchestration): bind E2 campaign approval identity

### DIFF
--- a/infra/migrations/versions/0045_e2_campaign_approval_operations.py
+++ b/infra/migrations/versions/0045_e2_campaign_approval_operations.py
@@ -1,0 +1,36 @@
+"""Allow bounded E2 campaign approvals in the durable operation ledger."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0045"
+down_revision: str | None = "0044"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    """Permit both E1 runs and E2 campaigns in the shared approval-operation ledger."""
+    op.execute(
+        """SET LOCAL lock_timeout = '10s';
+ALTER TABLE evolution_approval_operations
+DROP CONSTRAINT evolution_approval_operations_tool_name_check;
+ALTER TABLE evolution_approval_operations
+ADD CONSTRAINT evolution_approval_operations_tool_name_check
+CHECK (tool_name IN ('evolver.run_evolution','evolver.run_event_campaign'));"""
+    )
+
+
+def downgrade() -> None:
+    """Remove E2 recovery rows before restoring the E1-only ledger constraint."""
+    op.execute(
+        """SET LOCAL lock_timeout = '10s';
+DELETE FROM evolution_approval_operations
+WHERE tool_name='evolver.run_event_campaign';
+ALTER TABLE evolution_approval_operations
+DROP CONSTRAINT evolution_approval_operations_tool_name_check;
+ALTER TABLE evolution_approval_operations
+ADD CONSTRAINT evolution_approval_operations_tool_name_check
+CHECK (tool_name='evolver.run_evolution');"""
+    )

--- a/packages/orchestration/config/permissions.default.yaml
+++ b/packages/orchestration/config/permissions.default.yaml
@@ -43,9 +43,8 @@ allow:
   # 演化状态与候选详情只读
   - "evolver.get_evolution"
   - "evolver.get_candidate"
-  # 事件 campaign 仅在独立 sandbox 中自动迭代；不会 promote、启动或下单
+  # 事件 campaign 查询只读；启动 campaign 会产生 LLM 费用，必须先显式审批
   - "evolver.get_event_campaign"
-  - "evolver.run_event_campaign"
 
   # Swarm 批量回测（ADR-0025）：只读，无下单路径
   - "swarm.*"
@@ -93,8 +92,9 @@ ask:
   - "paper.deposit_cash"
   - "paper.reset_account"
 
-  # LLM 变异会产生费用；取消会改变运行状态，均需明确确认
+  # LLM 演化会产生费用；E2 一次审批覆盖整个五代 campaign，不逐代重复审批
   - "evolver.run_evolution"
+  - "evolver.run_event_campaign"
   - "evolver.abort_evolution"
 
 deny:

--- a/packages/orchestration/src/clients/evolver.ts
+++ b/packages/orchestration/src/clients/evolver.ts
@@ -263,10 +263,21 @@ export class EvolverClient {
       options.request,
       headers,
     );
-    return await this.http.post<EventCampaignResult>(
-      `/api/v1/campaigns/${created.campaign_id}/start`,
-      {},
-    );
+    if (created.status !== "draft") return created;
+
+    try {
+      return await this.http.post<EventCampaignResult>(
+        `/api/v1/campaigns/${created.campaign_id}/start`,
+        {},
+      );
+    } catch (error) {
+      if (!(error instanceof HttpClientError) || error.code !== "CAMPAIGN_STATE_CONFLICT") {
+        throw error;
+      }
+      const current = await this.getEventCampaign(created.campaign_id);
+      if (current.status === "draft") throw error;
+      return current;
+    }
   }
 
   async getEventCampaign(campaignId: string): Promise<EventCampaignResult> {

--- a/packages/orchestration/src/hooks/with-hooks.ts
+++ b/packages/orchestration/src/hooks/with-hooks.ts
@@ -58,6 +58,7 @@ const DURABLE_EVOLUTION_APPROVAL_TOOLS = new Set([
   "evolver.run_evolution",
   "evolver.run_event_campaign",
 ]);
+const E2_CAMPAIGN_RETRY_WINDOW_MS = 2 * 60 * 1_000;
 
 /**
  * mastra ``server.middleware`` 从 Bearer JWT 解出的已认证主体（sub）写进 RequestContext
@@ -232,7 +233,11 @@ export function withHooks<T extends GenericTool>(tool: T, opts: WithHooksOptions
             sessionId,
             toolName,
             approvalInput,
-            reuseAfterConsume: durableEvolutionApproval,
+            reuseAfterConsume: toolName === "evolver.run_evolution",
+            reuseOnceAfterConsumeMs:
+              toolName === "evolver.run_event_campaign"
+                ? E2_CAMPAIGN_RETRY_WINDOW_MS
+                : undefined,
           });
           if (!operationId) {
             const approvalViewInput = llmSnapshot

--- a/packages/orchestration/src/hooks/with-hooks.ts
+++ b/packages/orchestration/src/hooks/with-hooks.ts
@@ -54,6 +54,11 @@ type GenericTool = {
   [key: string]: unknown;
 };
 
+const DURABLE_EVOLUTION_APPROVAL_TOOLS = new Set([
+  "evolver.run_evolution",
+  "evolver.run_event_campaign",
+]);
+
 /**
  * mastra ``server.middleware`` 从 Bearer JWT 解出的已认证主体（sub）写进 RequestContext
  * 的 key（#91）。getSessionId 最高优先读它 → askCache 按已认证主体 scope（替代 __global__）。
@@ -201,14 +206,14 @@ export function withHooks<T extends GenericTool>(tool: T, opts: WithHooksOptions
         if (permDecision === "ask") {
           const store = opts.pendingApprovals ?? defaultPendingApprovals;
           const projectedInput = projectApprovalInput(toolName, effectiveInput);
-          const llmSnapshot =
-            toolName === "evolver.run_evolution"
-              ? getRequestContextValue<EvolutionLLMSnapshot>(ctx, USER_LLM_SNAPSHOT_KEY)
-              : undefined;
+          const durableEvolutionApproval = DURABLE_EVOLUTION_APPROVAL_TOOLS.has(toolName);
+          const llmSnapshot = durableEvolutionApproval
+            ? getRequestContextValue<EvolutionLLMSnapshot>(ctx, USER_LLM_SNAPSHOT_KEY)
+            : undefined;
           const approvalInput = llmSnapshot
             ? { request: projectedInput, llm_snapshot: llmSnapshot }
             : projectedInput;
-          if (!authSub || !sessionId || (toolName === "evolver.run_evolution" && !llmSnapshot)) {
+          if (!authSub || !sessionId || (durableEvolutionApproval && !llmSnapshot)) {
             return {
               isError: true,
               deniedBy: "permission-ask",
@@ -227,7 +232,7 @@ export function withHooks<T extends GenericTool>(tool: T, opts: WithHooksOptions
             sessionId,
             toolName,
             approvalInput,
-            reuseAfterConsume: toolName === "evolver.run_evolution",
+            reuseAfterConsume: durableEvolutionApproval,
           });
           if (!operationId) {
             const approvalViewInput = llmSnapshot
@@ -242,7 +247,7 @@ export function withHooks<T extends GenericTool>(tool: T, opts: WithHooksOptions
               timeoutMs:
                 opts.askTimeoutMs && opts.askTimeoutMs > 0
                   ? opts.askTimeoutMs
-                  : toolName === "evolver.run_evolution"
+                  : durableEvolutionApproval
                     ? 300_000
                     : undefined,
             });

--- a/packages/orchestration/src/permissions/approval-identity.ts
+++ b/packages/orchestration/src/permissions/approval-identity.ts
@@ -58,6 +58,8 @@ export const APPROVAL_IDENTITY_FIELDS: Readonly<Record<string, readonly string[]
   ],
   // 演化审批绑定完整计算范围；idempotencyKey 只是传输重试标识，不改变成本或行为。
   "evolver.run_evolution": ["seedStrategyId", "budget", "config"],
+  // E2 一次审批绑定事件快照、可选来源 run 与完整 campaign 配置。
+  "evolver.run_event_campaign": ["eventSnapshotId", "sourceRunId", "config"],
 };
 
 /**

--- a/packages/orchestration/src/permissions/defaults.ts
+++ b/packages/orchestration/src/permissions/defaults.ts
@@ -46,7 +46,6 @@ export const DEFAULT_PERMISSIONS: PermissionConfig = {
     "evolver.get_evolution",
     "evolver.get_candidate",
     "evolver.get_event_campaign",
-    "evolver.run_event_campaign",
 
     // Swarm 批量回测（ADR-0025）：只读，无下单路径
     "swarm.*",
@@ -94,7 +93,9 @@ export const DEFAULT_PERMISSIONS: PermissionConfig = {
     // reset 是破坏性操作（删全部持仓行），后端另有 running-run 409 硬守门。
     "paper.deposit_cash",
     "paper.reset_account",
+    // E2 只在 campaign 启动时审批一次；内部五代演化继续自动执行。
     "evolver.run_evolution",
+    "evolver.run_event_campaign",
     "evolver.abort_evolution",
   ],
 

--- a/packages/orchestration/src/permissions/pending.ts
+++ b/packages/orchestration/src/permissions/pending.ts
@@ -99,6 +99,7 @@ export class PendingApprovalsStore {
   private readonly records = new Map<string, PendingApprovalRecord>();
   private readonly identityIndex = new Map<string, string>();
   private readonly consumedByIdentity = new Map<string, ConsumedApprovalRecord>();
+  private readonly consumingByIdentity = new Map<string, Promise<string | undefined>>();
   private readonly telemetry: PendingTelemetrySink;
   private readonly persistence?: ApprovalPersistence;
 
@@ -179,6 +180,27 @@ export class PendingApprovalsStore {
   /** Atomically consumes one approved decision and returns its restart-stable operation ID. */
   async consumeApproved(args: PendingConsumeArgs): Promise<string | undefined> {
     const identity = this.identityFor(args);
+    const inFlight = this.consumingByIdentity.get(identity);
+    if (inFlight) {
+      await inFlight;
+      return await this.consumeApproved(args);
+    }
+
+    const run = this.consumeApprovedUnlocked(args, identity);
+    this.consumingByIdentity.set(identity, run);
+    try {
+      return await run;
+    } finally {
+      if (this.consumingByIdentity.get(identity) === run) {
+        this.consumingByIdentity.delete(identity);
+      }
+    }
+  }
+
+  private async consumeApprovedUnlocked(
+    args: PendingConsumeArgs,
+    identity: string,
+  ): Promise<string | undefined> {
     const scope = this.operationScope(args);
     const boundedRetryMs =
       args.reuseOnceAfterConsumeMs && args.reuseOnceAfterConsumeMs > 0

--- a/packages/orchestration/src/permissions/pending.ts
+++ b/packages/orchestration/src/permissions/pending.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import {
+  claimEvolutionOperation,
   findEvolutionOperation,
   insertPending,
   markResolved,
@@ -34,6 +35,7 @@ export interface PendingConsumeArgs {
   sessionId: string;
   authSub: string;
   reuseAfterConsume?: boolean;
+  reuseOnceAfterConsumeMs?: number;
 }
 
 interface PendingApprovalRecord extends PendingApprovalView {
@@ -46,6 +48,7 @@ interface ConsumedApprovalRecord {
   operationId: string;
   expiresAt: string;
   timer: ReturnType<typeof setTimeout>;
+  oneShot?: boolean;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -64,10 +67,16 @@ export interface ApprovalPersistence {
     decision: PendingDecision,
     via: "user" | "timeout",
   ): Promise<void>;
-  rememberEvolutionOperation(args: EvolutionOperationScope & { operationId: string }): Promise<{
+  rememberEvolutionOperation(
+    args: EvolutionOperationScope & { operationId: string; retentionMs?: number },
+  ): Promise<{
     expiresAt: string;
   } | undefined>;
   findEvolutionOperation(args: EvolutionOperationScope): Promise<{
+    operationId: string;
+    expiresAt: string;
+  } | undefined>;
+  claimEvolutionOperation?(args: EvolutionOperationScope): Promise<{
     operationId: string;
     expiresAt: string;
   } | undefined>;
@@ -170,36 +179,76 @@ export class PendingApprovalsStore {
   /** Atomically consumes one approved decision and returns its restart-stable operation ID. */
   async consumeApproved(args: PendingConsumeArgs): Promise<string | undefined> {
     const identity = this.identityFor(args);
-    const consumed = args.reuseAfterConsume ? this.consumedByIdentity.get(identity) : undefined;
-    if (consumed) {
-      if (Date.now() >= Date.parse(consumed.expiresAt)) {
-        this.removeConsumed(identity);
-      } else {
-        this.telemetry({
-          event: "ask_approval_operation_reused",
-          requestId: consumed.operationId,
-          toolName: args.toolName,
-          sessionId: args.sessionId,
-          authSub: args.authSub,
-          ts: new Date().toISOString(),
-        });
-        return consumed.operationId;
-      }
-    }
     const scope = this.operationScope(args);
-    if (args.reuseAfterConsume && this.persistence) {
-      const persisted = await this.persistence.findEvolutionOperation(scope);
-      if (persisted && Date.now() < Date.parse(persisted.expiresAt)) {
-        this.cacheConsumed(identity, persisted);
-        this.telemetry({
-          event: "ask_approval_operation_recovered",
-          requestId: persisted.operationId,
-          toolName: args.toolName,
-          sessionId: args.sessionId,
-          authSub: args.authSub,
-          ts: new Date().toISOString(),
-        });
-        return persisted.operationId;
+    const boundedRetryMs =
+      args.reuseOnceAfterConsumeMs && args.reuseOnceAfterConsumeMs > 0
+        ? args.reuseOnceAfterConsumeMs
+        : undefined;
+
+    if (boundedRetryMs !== undefined) {
+      const consumed = this.consumedByIdentity.get(identity);
+      if (consumed) {
+        if (Date.now() >= Date.parse(consumed.expiresAt)) {
+          this.removeConsumed(identity);
+        } else if (consumed.oneShot) {
+          const operationId = consumed.operationId;
+          this.removeConsumed(identity);
+          this.telemetry({
+            event: "ask_approval_operation_reused",
+            requestId: operationId,
+            toolName: args.toolName,
+            sessionId: args.sessionId,
+            authSub: args.authSub,
+            ts: new Date().toISOString(),
+          });
+          return operationId;
+        }
+      }
+      if (this.persistence?.claimEvolutionOperation) {
+        const claimed = await this.persistence.claimEvolutionOperation(scope);
+        if (claimed && Date.now() < Date.parse(claimed.expiresAt)) {
+          this.telemetry({
+            event: "ask_approval_operation_recovered",
+            requestId: claimed.operationId,
+            toolName: args.toolName,
+            sessionId: args.sessionId,
+            authSub: args.authSub,
+            ts: new Date().toISOString(),
+          });
+          return claimed.operationId;
+        }
+      }
+    } else if (args.reuseAfterConsume) {
+      const consumed = this.consumedByIdentity.get(identity);
+      if (consumed) {
+        if (Date.now() >= Date.parse(consumed.expiresAt)) {
+          this.removeConsumed(identity);
+        } else {
+          this.telemetry({
+            event: "ask_approval_operation_reused",
+            requestId: consumed.operationId,
+            toolName: args.toolName,
+            sessionId: args.sessionId,
+            authSub: args.authSub,
+            ts: new Date().toISOString(),
+          });
+          return consumed.operationId;
+        }
+      }
+      if (this.persistence) {
+        const persisted = await this.persistence.findEvolutionOperation(scope);
+        if (persisted && Date.now() < Date.parse(persisted.expiresAt)) {
+          this.cacheConsumed(identity, persisted);
+          this.telemetry({
+            event: "ask_approval_operation_recovered",
+            requestId: persisted.operationId,
+            toolName: args.toolName,
+            sessionId: args.sessionId,
+            authSub: args.authSub,
+            ts: new Date().toISOString(),
+          });
+          return persisted.operationId;
+        }
       }
     }
     const requestId = this.identityIndex.get(identity);
@@ -209,19 +258,29 @@ export class PendingApprovalsStore {
       this.expire(record.requestId);
       return undefined;
     }
-    let reusable: { operationId: string; expiresAt: string } | undefined;
-    if (args.reuseAfterConsume) {
+    let reusable: { operationId: string; expiresAt: string; oneShot?: boolean } | undefined;
+    const shouldReuse = args.reuseAfterConsume || boundedRetryMs !== undefined;
+    let persistedReusable = false;
+    if (shouldReuse) {
+      const retentionMs = boundedRetryMs ?? EVOLUTION_OPERATION_RETENTION_MS;
       const fallback = {
         operationId: record.requestId,
-        expiresAt: new Date(Date.now() + EVOLUTION_OPERATION_RETENTION_MS).toISOString(),
+        expiresAt: new Date(Date.now() + retentionMs).toISOString(),
+        oneShot: boundedRetryMs !== undefined,
       };
       try {
         const persisted = await this.persistence?.rememberEvolutionOperation({
           ...scope,
           operationId: record.requestId,
+          retentionMs,
         });
+        persistedReusable = Boolean(persisted);
         reusable = persisted
-          ? { operationId: record.requestId, expiresAt: persisted.expiresAt }
+          ? {
+              operationId: record.requestId,
+              expiresAt: persisted.expiresAt,
+              oneShot: boundedRetryMs !== undefined,
+            }
           : fallback;
       } catch (error) {
         this.telemetry({
@@ -237,7 +296,9 @@ export class PendingApprovalsStore {
       }
     }
     this.remove(record);
-    if (reusable) this.cacheConsumed(identity, reusable);
+    if (reusable && !(boundedRetryMs !== undefined && persistedReusable)) {
+      this.cacheConsumed(identity, reusable);
+    }
     this.telemetry({
       event: "ask_approval_consumed",
       requestId: record.requestId,
@@ -303,7 +364,7 @@ export class PendingApprovalsStore {
 
   private cacheConsumed(
     identity: string,
-    record: { operationId: string; expiresAt: string },
+    record: { operationId: string; expiresAt: string; oneShot?: boolean },
   ): void {
     const timer = setTimeout(
       () => this.removeConsumed(identity),
@@ -373,4 +434,5 @@ export const pendingApprovals = new PendingApprovalsStore(undefined, {
   markResolved,
   rememberEvolutionOperation,
   findEvolutionOperation,
+  claimEvolutionOperation,
 });

--- a/packages/orchestration/src/permissions/repo.ts
+++ b/packages/orchestration/src/permissions/repo.ts
@@ -141,11 +141,14 @@ export async function markResolved(
 
 /** Persist one approved evolution identity before the costful tool is allowed to execute. */
 export async function rememberEvolutionOperation(
-  args: EvolutionOperationScope & { operationId: string },
+  args: EvolutionOperationScope & { operationId: string; retentionMs?: number },
 ): Promise<{ expiresAt: string } | undefined> {
   const pool = getPoolOrNull();
   if (!pool) return undefined;
-  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1_000);
+  const retentionMs = args.retentionMs && args.retentionMs > 0
+    ? args.retentionMs
+    : 24 * 60 * 60 * 1_000;
+  const expiresAt = new Date(Date.now() + retentionMs);
   const result = await pool.query(
     `INSERT INTO evolution_approval_operations
        (operation_id,auth_sub,session_id,tool_name,input_digest,approved_at,expires_at)
@@ -178,6 +181,25 @@ export async function findEvolutionOperation(
     `SELECT operation_id,expires_at FROM evolution_approval_operations
      WHERE auth_sub=$1 AND session_id=$2 AND tool_name=$3 AND input_digest=$4
        AND expires_at>NOW()`,
+    [args.authSub, args.sessionId, args.toolName, args.inputDigest],
+  );
+  const row = result.rows[0];
+  return row
+    ? { operationId: String(row.operation_id), expiresAt: toIso(row.expires_at) }
+    : undefined;
+}
+
+/** Atomically consume one unexpired recovery entitlement. */
+export async function claimEvolutionOperation(
+  args: EvolutionOperationScope,
+): Promise<{ operationId: string; expiresAt: string } | undefined> {
+  const pool = getPoolOrNull();
+  if (!pool) return undefined;
+  const result = await pool.query(
+    `DELETE FROM evolution_approval_operations
+     WHERE auth_sub=$1 AND session_id=$2 AND tool_name=$3 AND input_digest=$4
+       AND expires_at>NOW()
+     RETURNING operation_id,expires_at`,
     [args.authSub, args.sessionId, args.toolName, args.inputDigest],
   );
   const row = result.rows[0];

--- a/packages/orchestration/src/tools/evolver-shared.ts
+++ b/packages/orchestration/src/tools/evolver-shared.ts
@@ -1,7 +1,5 @@
 /** Evolver Mastra tools 的共享 schema 与客户端解析。 */
 import { z } from "zod";
-import { randomUUID } from "node:crypto";
-
 import { resolveRequestToken } from "../auth.js";
 import {
   buildEvolutionStartRequest,
@@ -71,8 +69,8 @@ export async function getApprovedEvolutionRunContext(
   };
 }
 
-/** Build a credential-bound automatic campaign without a per-generation approval pause. */
-export async function getAutomaticEventCampaignContext(
+/** Build one approved campaign context; its internal five generations remain automatic. */
+export async function getApprovedEventCampaignContext(
   input: {
     eventSnapshotId: string;
     sourceRunId?: string;
@@ -80,15 +78,18 @@ export async function getAutomaticEventCampaignContext(
   },
   ctx?: ToolRequestContext,
 ) {
+  const operationId = getRequestContextValue<string>(
+    { requestContext: ctx },
+    APPROVAL_OPERATION_ID_KEY,
+  );
   const llmSnapshot = getRequestContextValue<EvolutionLLMSnapshot>(
     { requestContext: ctx },
     USER_LLM_SNAPSHOT_KEY,
   );
   const authSub = ctx?.get?.(AUTH_SUB_KEY);
-  if (!llmSnapshot || typeof authSub !== "string" || !authSub) {
-    throw new Error("event campaign requires a verified owner and frozen LLM configuration");
+  if (!operationId || !llmSnapshot || typeof authSub !== "string" || !authSub) {
+    throw new Error("explicit event campaign approval context is missing");
   }
-  const operationId = randomUUID();
   const request = buildEventCampaignRequest({
     eventSnapshotId: input.eventSnapshotId,
     sourceRunId: input.sourceRunId,

--- a/packages/orchestration/src/tools/evolver.ts
+++ b/packages/orchestration/src/tools/evolver.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import {
   evolutionConfigSchema,
   eventCampaignConfigSchema,
-  getAutomaticEventCampaignContext,
+  getApprovedEventCampaignContext,
   getApprovedEvolutionRunContext,
   getEvolverClient,
   type ToolRequestContext,
@@ -17,7 +17,7 @@ export const evolverRunEventCampaignTool = createTool({
 基于冻结事件事实与模拟盘反馈启动五代双层自动演化；每代两个 Agent proposer 产生八个假设，每个确定性展开三条实现，并锁定唯一冠军等待独立 Forward。
 何时用：用户要求从事件机制发散新策略方向，且已有 point-in-time event snapshot 与 15m/1h/4h 冻结行情。
 何时不用：只优化既有代码用 evolver.run_evolution；没有事件快照、需要实盘或希望自动下单时不要用。
-坑：模拟研究阶段自动迭代不逐代审批，但只产出 sandbox 候选；不会 promote、启动 Runner 或下单，Forward 与一次性 holdout 仍是硬门禁。
+坑：启动整个五代 campaign 需要一次显式审批；审批后内部自动迭代不逐代审批，只产出 sandbox 候选；不会 promote、启动 Runner 或下单，Forward 与一次性 holdout 仍是硬门禁。
   `.trim(),
   inputSchema: z.object({
     eventSnapshotId: z.string().uuid(),
@@ -25,14 +25,14 @@ export const evolverRunEventCampaignTool = createTool({
     config: eventCampaignConfigSchema,
   }),
   execute: async (inputData, ctx) => {
-    const automatic = await getAutomaticEventCampaignContext(
+    const approved = await getApprovedEventCampaignContext(
       inputData,
       ctx?.requestContext as ToolRequestContext | undefined,
     );
-    return await automatic.client.startEventCampaign({
-      request: automatic.request,
-      idempotencyKey: automatic.operationId,
-      credentialGrant: automatic.credentialGrant,
+    return await approved.client.startEventCampaign({
+      request: approved.request,
+      idempotencyKey: approved.operationId,
+      credentialGrant: approved.credentialGrant,
     });
   },
 });

--- a/packages/orchestration/tests/e2-campaign-authorization.test.ts
+++ b/packages/orchestration/tests/e2-campaign-authorization.test.ts
@@ -102,7 +102,7 @@ describe("E2 campaign authorization", () => {
     store.clearAll();
   });
 
-  it("propagates and reuses the trusted approval operation ID for retry", async () => {
+  it("allows exactly one matching compensation retry for the approved E2 operation", async () => {
     const { store, execute, wrapped } = makeApprovedTool();
     const ctx = context();
 
@@ -116,11 +116,40 @@ describe("E2 campaign authorization", () => {
 
     const first = (await wrapped.execute!(campaignInput, ctx)) as { operationId: string };
     const retry = (await wrapped.execute!(campaignInput, ctx)) as { operationId: string };
+    const exhausted = (await wrapped.execute!(campaignInput, ctx)) as {
+      requiresApproval: boolean;
+      requestId: string;
+    };
 
     expect(first.operationId).toBe(pending.requestId);
     expect(retry.operationId).toBe(pending.requestId);
+    expect(exhausted.requiresApproval).toBe(true);
+    expect(exhausted.requestId).not.toBe(pending.requestId);
     expect(execute).toHaveBeenCalledTimes(2);
     store.clearAll();
+  });
+
+  it("expires the E2 compensation retry after two minutes", async () => {
+    vi.useFakeTimers();
+    const { store, execute, wrapped } = makeApprovedTool();
+    const ctx = context();
+
+    const pending = (await wrapped.execute!(campaignInput, ctx)) as { requestId: string };
+    expect(store.respond(pending.requestId, "allow", "user:alice")).toBe(true);
+    const first = (await wrapped.execute!(campaignInput, ctx)) as { operationId: string };
+    expect(first.operationId).toBe(pending.requestId);
+
+    vi.advanceTimersByTime(2 * 60 * 1_000 + 1);
+    const expired = (await wrapped.execute!(campaignInput, ctx)) as {
+      requiresApproval: boolean;
+      requestId: string;
+    };
+
+    expect(expired.requiresApproval).toBe(true);
+    expect(expired.requestId).not.toBe(pending.requestId);
+    expect(execute).toHaveBeenCalledTimes(1);
+    store.clearAll();
+    vi.useRealTimers();
   });
 
   it("does not consume an approval after material campaign input is changed", async () => {

--- a/packages/orchestration/tests/e2-campaign-authorization.test.ts
+++ b/packages/orchestration/tests/e2-campaign-authorization.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AUTH_SUB_KEY, HookRunner, withHooks } from "../src/hooks/index.js";
+import {
+  APPROVAL_OPERATION_ID_KEY,
+  buildEvolutionLLMSnapshot,
+  USER_LLM_SNAPSHOT_KEY,
+} from "../src/mastra/llm/evolution-snapshot.js";
+import { DEFAULT_PERMISSIONS, PermissionEngine } from "../src/permissions/index.js";
+import { PendingApprovalsStore } from "../src/permissions/pending.js";
+import { getApprovedEventCampaignContext } from "../src/tools/evolver-shared.js";
+
+const snapshotA = buildEvolutionLLMSnapshot({
+  id: "config-a",
+  provider: "deepseek",
+  model: "deepseek-v4-pro",
+  api_key: "not-forwarded-a",
+});
+
+const snapshotB = buildEvolutionLLMSnapshot({
+  id: "config-b",
+  provider: "deepseek",
+  model: "deepseek-v4-pro",
+  api_key: "not-forwarded-b",
+});
+
+const campaignInput = {
+  eventSnapshotId: "11111111-1111-4111-8111-111111111111",
+  sourceRunId: "22222222-2222-4222-8222-222222222222",
+  config: {
+    venue: "binance",
+    symbol: "BTCUSDT",
+    timeframe: "1h" as const,
+    from_ts: "2026-08-01T00:00:00Z",
+    as_of: "2026-08-02T00:00:00Z",
+    initial_cash: 10_000,
+    fee_rate: 0.001,
+    trading_mode: "perp" as const,
+    leverage: 1,
+    random_seed: 7,
+  },
+};
+
+type ToolCtx = { requestContext: Map<string, unknown> };
+
+function context(snapshot = snapshotA): ToolCtx {
+  return {
+    requestContext: new Map<string, unknown>([[USER_LLM_SNAPSHOT_KEY, snapshot]]),
+  };
+}
+
+function makeApprovedTool(options?: {
+  store?: PendingApprovalsStore;
+  owner?: () => string | undefined;
+}) {
+  const store = options?.store ?? new PendingApprovalsStore();
+  const execute = vi.fn(async (_input: unknown, ctx?: unknown) => {
+    const requestContext = (ctx as ToolCtx).requestContext;
+    return { operationId: requestContext.get(APPROVAL_OPERATION_ID_KEY) };
+  });
+  const wrapped = withHooks(
+    { id: "evolver.run_event_campaign", execute },
+    {
+      runner: new HookRunner(),
+      permissionResolver: () => "ask",
+      pendingApprovals: store,
+      getAuthSub: options?.owner ?? (() => "user:alice"),
+      getSessionId: () => "thread-e2",
+    },
+  );
+  return { store, execute, wrapped };
+}
+
+describe("E2 campaign authorization", () => {
+  it("requires ask permission instead of the automatic allow path", () => {
+    const engine = new PermissionEngine(DEFAULT_PERMISSIONS);
+    expect(engine.authorize("evolver.run_event_campaign", campaignInput).decision).toBe("ask");
+    expect(engine.authorize("evolver.get_event_campaign", {}).decision).toBe("allow");
+  });
+
+  it("rejects direct campaign-context construction without a trusted approval operation", async () => {
+    const requestContext = new Map<string, unknown>([
+      [AUTH_SUB_KEY, "user:alice"],
+      [USER_LLM_SNAPSHOT_KEY, snapshotA],
+    ]);
+
+    await expect(
+      getApprovedEventCampaignContext(campaignInput, requestContext),
+    ).rejects.toThrow("explicit event campaign approval context is missing");
+  });
+
+  it("fails closed when the frozen LLM approval context is missing", async () => {
+    const { store, execute, wrapped } = makeApprovedTool();
+    const result = (await wrapped.execute!(campaignInput, {
+      requestContext: new Map<string, unknown>(),
+    })) as { requiresApproval: boolean; message: string };
+
+    expect(result.requiresApproval).toBe(true);
+    expect(result.message).toContain("APPROVAL_UNAVAILABLE");
+    expect(execute).not.toHaveBeenCalled();
+    expect(store.list("user:alice")).toHaveLength(0);
+    store.clearAll();
+  });
+
+  it("propagates and reuses the trusted approval operation ID for retry", async () => {
+    const { store, execute, wrapped } = makeApprovedTool();
+    const ctx = context();
+
+    const pending = (await wrapped.execute!(campaignInput, ctx)) as {
+      requiresApproval: boolean;
+      requestId: string;
+    };
+    expect(pending.requiresApproval).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+    expect(store.respond(pending.requestId, "allow", "user:alice")).toBe(true);
+
+    const first = (await wrapped.execute!(campaignInput, ctx)) as { operationId: string };
+    const retry = (await wrapped.execute!(campaignInput, ctx)) as { operationId: string };
+
+    expect(first.operationId).toBe(pending.requestId);
+    expect(retry.operationId).toBe(pending.requestId);
+    expect(execute).toHaveBeenCalledTimes(2);
+    store.clearAll();
+  });
+
+  it("does not consume an approval after material campaign input is changed", async () => {
+    const { store, execute, wrapped } = makeApprovedTool();
+    const ctx = context();
+
+    const pending = (await wrapped.execute!(campaignInput, ctx)) as { requestId: string };
+    expect(store.respond(pending.requestId, "allow", "user:alice")).toBe(true);
+
+    const changed = {
+      ...campaignInput,
+      config: { ...campaignInput.config, symbol: "ETHUSDT" },
+    };
+    const blocked = (await wrapped.execute!(changed, ctx)) as { requiresApproval: boolean };
+
+    expect(blocked.requiresApproval).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+
+    const original = (await wrapped.execute!(campaignInput, ctx)) as { operationId: string };
+    expect(original.operationId).toBe(pending.requestId);
+    store.clearAll();
+  });
+
+  it("does not consume an approval after the frozen LLM snapshot is substituted", async () => {
+    const { store, execute, wrapped } = makeApprovedTool();
+    const ctx = context(snapshotA);
+
+    const pending = (await wrapped.execute!(campaignInput, ctx)) as { requestId: string };
+    expect(store.respond(pending.requestId, "allow", "user:alice")).toBe(true);
+
+    ctx.requestContext.set(USER_LLM_SNAPSHOT_KEY, snapshotB);
+    const blocked = (await wrapped.execute!(campaignInput, ctx)) as {
+      requiresApproval: boolean;
+    };
+    expect(blocked.requiresApproval).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+
+    ctx.requestContext.set(USER_LLM_SNAPSHOT_KEY, snapshotA);
+    const original = (await wrapped.execute!(campaignInput, ctx)) as { operationId: string };
+    expect(original.operationId).toBe(pending.requestId);
+    store.clearAll();
+  });
+
+  it("does not let another owner consume the approved operation", async () => {
+    let owner = "user:alice";
+    const store = new PendingApprovalsStore();
+    const { execute, wrapped } = makeApprovedTool({
+      store,
+      owner: () => owner,
+    });
+    const ctx = context();
+
+    const pending = (await wrapped.execute!(campaignInput, ctx)) as { requestId: string };
+    expect(store.respond(pending.requestId, "allow", "user:alice")).toBe(true);
+
+    owner = "user:bob";
+    const blocked = (await wrapped.execute!(campaignInput, ctx)) as {
+      requiresApproval: boolean;
+    };
+    expect(blocked.requiresApproval).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+
+    owner = "user:alice";
+    const original = (await wrapped.execute!(campaignInput, ctx)) as { operationId: string };
+    expect(original.operationId).toBe(pending.requestId);
+    store.clearAll();
+  });
+});

--- a/packages/orchestration/tests/evolver-client.test.ts
+++ b/packages/orchestration/tests/evolver-client.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildEvolutionStartRequest,
   buildEventCampaignRequest,
+  eventCampaignRequestDigest,
   evolutionRequestDigest,
   EvolverClient,
 } from "../src/clients/evolver.js";
@@ -17,7 +18,7 @@ import {
 } from "../src/mastra/llm/evolution-snapshot.js";
 import {
   getApprovedEvolutionRunContext,
-  getAutomaticEventCampaignContext,
+  getApprovedEventCampaignContext,
 } from "../src/tools/evolver-shared.js";
 
 const snapshot = buildEvolutionLLMSnapshot({
@@ -34,6 +35,20 @@ function response(status: number): Response {
         ? { run_id: "run-1", status: "queued" }
         : { code: `HTTP_${status}`, message: "temporary upstream failure" },
     ),
+    { status, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function campaignResponse(status = 200): Response {
+  return new Response(
+    JSON.stringify({
+      campaign_id: "33333333-3333-4333-8333-333333333333",
+      status: "replaying",
+      active_generation: 1,
+      max_generations: 5,
+      event_snapshot_id: "11111111-1111-4111-8111-111111111111",
+      llm_cost_usd: 0,
+    }),
     { status, headers: { "Content-Type": "application/json" } },
   );
 }
@@ -100,7 +115,7 @@ describe("EvolverClient", () => {
     expect(Number(credential.exp) - Number(credential.iat)).toBe(108_000);
   });
 
-  it("marks automatic campaign grants for bounded restart recovery", async () => {
+  it("binds an approved E2 campaign grant to the shared durable operation identity", async () => {
     const keys = generateKeyPairSync("ed25519");
     vi.stubEnv(
       "EVOLUTION_CREDENTIAL_PRIVATE_KEY_B64",
@@ -108,6 +123,7 @@ describe("EvolverClient", () => {
     );
     const requestContext = new Map<string, unknown>([
       [AUTH_SUB_KEY, "user:alice"],
+      [APPROVAL_OPERATION_ID_KEY, "approval-operation-e2"],
       [USER_LLM_SNAPSHOT_KEY, snapshot],
     ]);
     const config = {
@@ -118,7 +134,7 @@ describe("EvolverClient", () => {
       as_of: "2026-08-02T00:00:00Z",
     };
 
-    const campaign = await getAutomaticEventCampaignContext(
+    const campaign = await getApprovedEventCampaignContext(
       { eventSnapshotId: "11111111-1111-4111-8111-111111111111", config },
       requestContext,
     );
@@ -127,7 +143,14 @@ describe("EvolverClient", () => {
       audience: "inalpha-dashboard-credential",
     });
 
-    expect(payload.grant_purpose).toBe("event_campaign");
+    expect(payload).toMatchObject({
+      sub: "user:alice",
+      grant_purpose: "event_campaign",
+      operation_id: "approval-operation-e2",
+      llm_config_digest: snapshot.config_digest,
+      request_digest: eventCampaignRequestDigest(campaign.request),
+    });
+    expect(campaign.operationId).toBe("approval-operation-e2");
     expect(campaign.request).toEqual(
       buildEventCampaignRequest({
         eventSnapshotId: "11111111-1111-4111-8111-111111111111",
@@ -135,6 +158,54 @@ describe("EvolverClient", () => {
         llmSnapshot: snapshot,
       }),
     );
+  });
+
+  it("uses the approved E2 operation ID as the campaign idempotency key on retry", async () => {
+    const request = buildEventCampaignRequest({
+      eventSnapshotId: "11111111-1111-4111-8111-111111111111",
+      config: {
+        venue: "binance",
+        symbol: "BTCUSDT",
+        timeframe: "1h",
+        from_ts: "2026-08-01T00:00:00Z",
+        as_of: "2026-08-02T00:00:00Z",
+      },
+      llmSnapshot: snapshot,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(campaignResponse(201))
+      .mockResolvedValueOnce(campaignResponse())
+      .mockResolvedValueOnce(campaignResponse(201))
+      .mockResolvedValueOnce(campaignResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new EvolverClient({
+      baseUrl: "http://evolver.test",
+      token: "owner-token",
+    });
+    const options = {
+      request,
+      idempotencyKey: "approval-operation-e2",
+      credentialGrant: "event-campaign-grant",
+    };
+
+    await client.startEventCampaign(options);
+    await client.startEventCampaign(options);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    for (const index of [0, 2]) {
+      const [url, init] = fetchMock.mock.calls[index] as [string, RequestInit];
+      expect(url).toContain("/api/v1/campaigns");
+      expect(url).not.toContain("/start");
+      expect((init.headers as Record<string, string>)["Idempotency-Key"]).toBe(
+        "approval-operation-e2",
+      );
+      expect((init.headers as Record<string, string>)["X-Evolution-Credential"]).toBe(
+        "event-campaign-grant",
+      );
+      expect(init.body).not.toContain("not-forwarded");
+    }
   });
 
   it("retries 502/504 with the same approval-derived operation ID", async () => {

--- a/packages/orchestration/tests/evolver-client.test.ts
+++ b/packages/orchestration/tests/evolver-client.test.ts
@@ -39,17 +39,30 @@ function response(status: number): Response {
   );
 }
 
-function campaignResponse(status = 200): Response {
+function campaignResponse(
+  status = 200,
+  campaignStatus = "replaying",
+): Response {
   return new Response(
     JSON.stringify({
       campaign_id: "33333333-3333-4333-8333-333333333333",
-      status: "replaying",
-      active_generation: 1,
+      status: campaignStatus,
+      active_generation: campaignStatus === "draft" ? 0 : 1,
       max_generations: 5,
       event_snapshot_id: "11111111-1111-4111-8111-111111111111",
       llm_cost_usd: 0,
     }),
     { status, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function campaignConflict(): Response {
+  return new Response(
+    JSON.stringify({
+      code: "CAMPAIGN_STATE_CONFLICT",
+      message: "campaign cannot start",
+    }),
+    { status: 409, headers: { "Content-Type": "application/json" } },
   );
 }
 
@@ -160,7 +173,7 @@ describe("EvolverClient", () => {
     );
   });
 
-  it("uses the approved E2 operation ID as the campaign idempotency key on retry", async () => {
+  it("recovers a lost start response by returning the already-started campaign on whole-operation retry", async () => {
     const request = buildEventCampaignRequest({
       eventSnapshotId: "11111111-1111-4111-8111-111111111111",
       config: {
@@ -174,10 +187,9 @@ describe("EvolverClient", () => {
     });
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(campaignResponse(201))
-      .mockResolvedValueOnce(campaignResponse())
-      .mockResolvedValueOnce(campaignResponse(201))
-      .mockResolvedValueOnce(campaignResponse());
+      .mockResolvedValueOnce(campaignResponse(201, "draft"))
+      .mockRejectedValueOnce(new TypeError("start response lost"))
+      .mockResolvedValueOnce(campaignResponse(201, "replaying"));
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new EvolverClient({
@@ -190,10 +202,15 @@ describe("EvolverClient", () => {
       credentialGrant: "event-campaign-grant",
     };
 
-    await client.startEventCampaign(options);
-    await client.startEventCampaign(options);
+    await expect(client.startEventCampaign(options)).rejects.toMatchObject({
+      code: "UPSTREAM_UNREACHABLE",
+    });
+    await expect(client.startEventCampaign(options)).resolves.toMatchObject({
+      campaign_id: "33333333-3333-4333-8333-333333333333",
+      status: "replaying",
+    });
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     for (const index of [0, 2]) {
       const [url, init] = fetchMock.mock.calls[index] as [string, RequestInit];
       expect(url).toContain("/api/v1/campaigns");
@@ -206,6 +223,76 @@ describe("EvolverClient", () => {
       );
       expect(init.body).not.toContain("not-forwarded");
     }
+  });
+
+  it("reconciles a concurrent E2 start conflict when the campaign already advanced", async () => {
+    const request = buildEventCampaignRequest({
+      eventSnapshotId: "11111111-1111-4111-8111-111111111111",
+      config: {
+        venue: "binance",
+        symbol: "BTCUSDT",
+        timeframe: "1h",
+        from_ts: "2026-08-01T00:00:00Z",
+        as_of: "2026-08-02T00:00:00Z",
+      },
+      llmSnapshot: snapshot,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(campaignResponse(201, "draft"))
+      .mockResolvedValueOnce(campaignConflict())
+      .mockResolvedValueOnce(campaignResponse(200, "replaying"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      new EvolverClient({
+        baseUrl: "http://evolver.test",
+        token: "owner-token",
+      }).startEventCampaign({
+        request,
+        idempotencyKey: "approval-operation-e2",
+        credentialGrant: "event-campaign-grant",
+      }),
+    ).resolves.toMatchObject({ status: "replaying" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain("/start");
+    expect(String(fetchMock.mock.calls[2]?.[0])).not.toContain("/start");
+  });
+
+  it("preserves E2 start conflicts when reconciliation still finds a draft campaign", async () => {
+    const request = buildEventCampaignRequest({
+      eventSnapshotId: "11111111-1111-4111-8111-111111111111",
+      config: {
+        venue: "binance",
+        symbol: "BTCUSDT",
+        timeframe: "1h",
+        from_ts: "2026-08-01T00:00:00Z",
+        as_of: "2026-08-02T00:00:00Z",
+      },
+      llmSnapshot: snapshot,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(campaignResponse(201, "draft"))
+      .mockResolvedValueOnce(campaignConflict())
+      .mockResolvedValueOnce(campaignResponse(200, "draft"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      new EvolverClient({
+        baseUrl: "http://evolver.test",
+        token: "owner-token",
+      }).startEventCampaign({
+        request,
+        idempotencyKey: "approval-operation-e2",
+        credentialGrant: "event-campaign-grant",
+      }),
+    ).rejects.toMatchObject({
+      code: "CAMPAIGN_STATE_CONFLICT",
+      status: 409,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("retries 502/504 with the same approval-derived operation ID", async () => {

--- a/packages/orchestration/tests/permissions-pending.test.ts
+++ b/packages/orchestration/tests/permissions-pending.test.ts
@@ -252,7 +252,9 @@ describe("PendingApprovalsStore", () => {
     expect(await initial).toBe(view.requestId);
     expect(await concurrent).toBe(view.requestId);
     expect(persistence.rememberEvolutionOperation).toHaveBeenCalledTimes(1);
-    expect(persistence.claimEvolutionOperation).toHaveBeenCalledTimes(1);
+    // Initial consumption probes for a prior durable retry before persisting this approval;
+    // the serialized concurrent call performs the second claim and consumes that retry.
+    expect(persistence.claimEvolutionOperation).toHaveBeenCalledTimes(2);
     expect(await store.consumeApproved(consume)).toBeUndefined();
     store.clearAll();
   });

--- a/packages/orchestration/tests/permissions-pending.test.ts
+++ b/packages/orchestration/tests/permissions-pending.test.ts
@@ -189,6 +189,74 @@ describe("PendingApprovalsStore", () => {
     store.clearAll();
   });
 
+  it("serializes concurrent initial E2 consumption into initial plus one retry", async () => {
+    let releasePersist!: () => void;
+    const persistGate = new Promise<void>((resolve) => {
+      releasePersist = resolve;
+    });
+    const operations = new Map<string, { operationId: string; expiresAt: string }>();
+    const persistence = {
+      insertPending: vi.fn(async () => {}),
+      markResolved: vi.fn(async () => {}),
+      rememberEvolutionOperation: vi.fn(async (scope: {
+        inputDigest: string;
+        operationId: string;
+        retentionMs?: number;
+      }) => {
+        await persistGate;
+        const value = {
+          operationId: scope.operationId,
+          expiresAt: new Date(Date.now() + (scope.retentionMs ?? 86_400_000)).toISOString(),
+        };
+        operations.set(scope.inputDigest, value);
+        return { expiresAt: value.expiresAt };
+      }),
+      findEvolutionOperation: vi.fn(async (scope: { inputDigest: string }) =>
+        operations.get(scope.inputDigest),
+      ),
+      claimEvolutionOperation: vi.fn(async (scope: { inputDigest: string }) => {
+        const value = operations.get(scope.inputDigest);
+        if (!value || Date.now() >= Date.parse(value.expiresAt)) return undefined;
+        operations.delete(scope.inputDigest);
+        return value;
+      }),
+    };
+    const args = {
+      authSub: "user:alice",
+      sessionId: "thread-E2",
+      toolName: "evolver.run_event_campaign",
+      toolInput: { eventSnapshotId: "event-1" },
+      approvalInput: {
+        request: { eventSnapshotId: "event-1" },
+        llm_snapshot: { config_digest: "digest" },
+      },
+      timeoutMs: 5_000,
+    };
+    const store = new PendingApprovalsStore(() => {}, persistence);
+    const view = store.request(args);
+    expect(store.respond(view.requestId, "allow", args.authSub)).toBe(true);
+    const consume = {
+      authSub: args.authSub,
+      sessionId: args.sessionId,
+      toolName: args.toolName,
+      approvalInput: args.approvalInput,
+      reuseOnceAfterConsumeMs: 120_000,
+    };
+
+    const initial = store.consumeApproved(consume);
+    const concurrent = store.consumeApproved(consume);
+    await Promise.resolve();
+    expect(persistence.rememberEvolutionOperation).toHaveBeenCalledTimes(1);
+
+    releasePersist();
+    expect(await initial).toBe(view.requestId);
+    expect(await concurrent).toBe(view.requestId);
+    expect(persistence.rememberEvolutionOperation).toHaveBeenCalledTimes(1);
+    expect(persistence.claimEvolutionOperation).toHaveBeenCalledTimes(1);
+    expect(await store.consumeApproved(consume)).toBeUndefined();
+    store.clearAll();
+  });
+
   it("atomically allows only one bounded recovery across fresh stores", async () => {
     const operations = new Map<string, { operationId: string; expiresAt: string }>();
     const persistence = {

--- a/packages/orchestration/tests/permissions-pending.test.ts
+++ b/packages/orchestration/tests/permissions-pending.test.ts
@@ -136,6 +136,126 @@ describe("PendingApprovalsStore", () => {
     store.clearAll();
   });
 
+  it("allows one bounded recovery retry and then exhausts it", async () => {
+    vi.useFakeTimers();
+    const store = new PendingApprovalsStore(() => {});
+    const args = {
+      authSub: "user:alice",
+      sessionId: "thread-E2",
+      toolName: "evolver.run_event_campaign",
+      toolInput: { eventSnapshotId: "event-1" },
+      approvalInput: { request: { eventSnapshotId: "event-1" }, llm_snapshot: { config_digest: "digest" } },
+      timeoutMs: 5_000,
+    };
+    const view = store.request(args);
+    expect(store.respond(view.requestId, "allow", args.authSub)).toBe(true);
+    const consume = {
+      authSub: args.authSub,
+      sessionId: args.sessionId,
+      toolName: args.toolName,
+      approvalInput: args.approvalInput,
+      reuseOnceAfterConsumeMs: 120_000,
+    };
+
+    expect(await store.consumeApproved(consume)).toBe(view.requestId);
+    expect(await store.consumeApproved(consume)).toBe(view.requestId);
+    expect(await store.consumeApproved(consume)).toBeUndefined();
+    store.clearAll();
+  });
+
+  it("does not allow the bounded recovery retry after two minutes", async () => {
+    vi.useFakeTimers();
+    const store = new PendingApprovalsStore(() => {});
+    const args = {
+      authSub: "user:alice",
+      sessionId: "thread-E2",
+      toolName: "evolver.run_event_campaign",
+      toolInput: { eventSnapshotId: "event-1" },
+      approvalInput: { request: { eventSnapshotId: "event-1" }, llm_snapshot: { config_digest: "digest" } },
+      timeoutMs: 5_000,
+    };
+    const view = store.request(args);
+    expect(store.respond(view.requestId, "allow", args.authSub)).toBe(true);
+    const consume = {
+      authSub: args.authSub,
+      sessionId: args.sessionId,
+      toolName: args.toolName,
+      approvalInput: args.approvalInput,
+      reuseOnceAfterConsumeMs: 120_000,
+    };
+    expect(await store.consumeApproved(consume)).toBe(view.requestId);
+    vi.advanceTimersByTime(120_001);
+    expect(await store.consumeApproved(consume)).toBeUndefined();
+    store.clearAll();
+  });
+
+  it("atomically allows only one bounded recovery across fresh stores", async () => {
+    const operations = new Map<string, { operationId: string; expiresAt: string }>();
+    const persistence = {
+      insertPending: vi.fn(async () => {}),
+      markResolved: vi.fn(async () => {}),
+      rememberEvolutionOperation: vi.fn(async (scope: {
+        inputDigest: string;
+        operationId: string;
+        retentionMs?: number;
+      }) => {
+        const value = {
+          operationId: scope.operationId,
+          expiresAt: new Date(Date.now() + (scope.retentionMs ?? 86_400_000)).toISOString(),
+        };
+        operations.set(scope.inputDigest, value);
+        return { expiresAt: value.expiresAt };
+      }),
+      findEvolutionOperation: vi.fn(async (scope: { inputDigest: string }) =>
+        operations.get(scope.inputDigest),
+      ),
+      claimEvolutionOperation: vi.fn(async (scope: { inputDigest: string }) => {
+        const value = operations.get(scope.inputDigest);
+        if (!value || Date.now() >= Date.parse(value.expiresAt)) return undefined;
+        operations.delete(scope.inputDigest);
+        return value;
+      }),
+    };
+    const args = {
+      authSub: "user:alice",
+      sessionId: "thread-E2",
+      toolName: "evolver.run_event_campaign",
+      toolInput: { eventSnapshotId: "event-1" },
+      approvalInput: {
+        request: { eventSnapshotId: "event-1" },
+        llm_snapshot: { config_digest: "digest" },
+      },
+      timeoutMs: 5_000,
+    };
+    const first = new PendingApprovalsStore(() => {}, persistence);
+    const view = first.request(args);
+    expect(first.respond(view.requestId, "allow", args.authSub)).toBe(true);
+    const consume = {
+      authSub: args.authSub,
+      sessionId: args.sessionId,
+      toolName: args.toolName,
+      approvalInput: args.approvalInput,
+      reuseOnceAfterConsumeMs: 120_000,
+    };
+    expect(await first.consumeApproved(consume)).toBe(view.requestId);
+
+    const retryA = new PendingApprovalsStore(() => {}, persistence);
+    const retryB = new PendingApprovalsStore(() => {}, persistence);
+    const claims = await Promise.all([
+      retryA.consumeApproved(consume),
+      retryB.consumeApproved(consume),
+    ]);
+
+    expect(claims.filter((value) => value === view.requestId)).toHaveLength(1);
+    expect(claims.filter((value) => value === undefined)).toHaveLength(1);
+    expect(await new PendingApprovalsStore(() => {}, persistence).consumeApproved(consume))
+      .toBeUndefined();
+
+    first.clearAll();
+    retryA.clearAll();
+    retryB.clearAll();
+  });
+
   it("does not reuse a consumed evolution operation after its retention deadline", async () => {
     vi.useFakeTimers();
     const store = new PendingApprovalsStore(() => {});


### PR DESCRIPTION
<!--
Thanks for contributing! Please review the items below before submitting.
This project is licensed under GNU AGPL-3.0; your contribution ships under the same license.

感谢贡献！提交 PR 前请确认以下事项。
本项目 LICENSE 是 GNU AGPL-3.0，你的贡献也将以同样许可发布。
-->

## What this PR does / 这个 PR 做了什么

修复 E2 事件演化 campaign 的经济授权身份断链：`evolver.run_event_campaign` 不再走自动 `allow` + 独立 `randomUUID()`，而是复用 trusted approval 路径，并把一次显式 owner 审批绑定到一个有界的 E2 五代 campaign。

审批产生的 durable operation ID 继续绑定 signed `event_campaign` grant，并作为 Evolver `Idempotency-Key` 使用。campaign 内部五代执行保持自动，不增加逐代审批。

This PR also closes the retry/durability issues identified during maintainer and Codex review:

- a lost `/start` response is recoverable without starting the same campaign twice;
- one E2 approval permits the initial execution plus **at most one matching compensation retry within two minutes**;
- the durable retry entitlement is atomically consumed across restart/concurrency;
- concurrent initial calls for the same approval identity are serialized;
- migration `0045` permits `evolver.run_event_campaign` in the shared approval-operation ledger.

This remains a maintainer-aligned authorization-boundary fix. No public issue was opened because the repository security policy directs permission/authorization bypass reports to private channels.

## Problem

At the stacked base, E1 and E2 used different economic authorization models.

E1:

`permission ask → explicit trusted approval → durable operation ID → request/LLM-bound grant → Idempotency-Key → run`

E2 before this PR:

`permission allow → getAutomaticEventCampaignContext() → randomUUID() → grant → Idempotency-Key → campaign`

An E2 campaign can perform cost-bearing proposer calls across a fixed five-generation run, so creating the economic operation identity independently of owner approval breaks the authorization/provenance chain.

Two additional retry/durability gaps were identified during review:

1. if `/start` committed but its response was lost, whole-tool retry could hit `CAMPAIGN_STATE_CONFLICT`;
2. the initial durable-approval reuse inherited a 24-hour reusable capability instead of the repository contract of one compensation retry within two minutes, and concurrent initial consumers could race.

## Invariant

**One explicit owner approval authorizes one bounded E2 campaign.**

`approval → operation ID → signed event_campaign grant → Idempotency-Key → campaign`

After approval:

- the five internal generations execute automatically;
- there is no approval per generation, hypothesis, or proposer call;
- the initial operation may be followed by **at most one matching compensation retry within two minutes**;
- that retry reuses the same durable operation identity;
- restart/concurrent recovery cannot consume the retry entitlement more than once.

## Implementation

- Move `evolver.run_event_campaign` from `allow` to `ask` in both permission representations.
- Bind approval identity to `eventSnapshotId`, optional `sourceRunId`, complete campaign `config`, and the frozen non-secret LLM snapshot.
- Require `APPROVAL_OPERATION_ID_KEY` in `getApprovedEventCampaignContext()`.
- Remove E2's independent post-authorization economic `randomUUID()`.
- Keep the purpose-separated `event_campaign` Ed25519 grant.
- Pass the approved operation ID unchanged as Evolver `Idempotency-Key`.
- Keep the five-generation execution loop unchanged.
- Make whole-operation retry idempotent:
  - idempotent create returning a non-`draft` campaign returns that campaign without another `/start`;
  - an exact concurrent `CAMPAIGN_STATE_CONFLICT` is reconciled through owner-scoped GET;
  - the conflict remains an error if the campaign is still `draft`.
- Add an E2-specific bounded recovery policy:
  - initial execution + one matching retry;
  - two-minute retry window;
  - atomic durable retry claim via `DELETE ... RETURNING`;
  - same-identity initial consumption serialized to prevent two initial executions.
- Add Alembic migration `0045_e2_campaign_approval_operations.py` to expand the approval-ledger `tool_name` constraint for E2.
- Leave E1's pre-existing durable reuse behavior unchanged.

## Security model

The normal path fails closed at two layers:

1. permission middleware requires explicit trusted approval plus verified owner/session/frozen LLM context;
2. E2 context construction refuses to mint a campaign grant without the approval-derived operation ID.

The signed grant binds owner, approved operation ID, `grant_purpose=event_campaign`, LLM config identity, and canonical campaign request digest. Evolver requires grant `operation_id` to match the backend `Idempotency-Key`.

Existing `(owner_account_id, idempotency_key)` uniqueness prevents a second economic campaign under the same operation.

The recovery entitlement is separately bounded: exactly one matching retry within two minutes, atomically consumed across restart/concurrency. This preserves durable recovery without turning one explicit approval into a reusable long-lived capability.

## Non-goals

This PR does **not** address:

- Forward evidence authority
- global event-ledger service identity
- holdout crash durability
- lease fencing
- deterministic champion locking
- frozen bars
- owner-blind holdout visibility
- per-LLM-call provenance
- dashboard cleanup
- promotion / Runner startup / order execution

## Scope / 涉及范围

- Primary affected service: `packages/orchestration`
- Supporting schema change: `infra/migrations/versions/0045_e2_campaign_approval_operations.py`
- Current Phase: E2
- Type: `fix`
- Dependency: stacked on Draft PR #164 (`codex/evolution-task27`)

## Acceptance criteria

- [x] `evolver.run_event_campaign` requires explicit approval.
- [x] Missing owner/session/frozen LLM approval context fails closed.
- [x] Material campaign input is bound to approval.
- [x] Frozen LLM configuration is bound to approval and signed grant.
- [x] Approval-derived operation ID reaches grant minting unchanged.
- [x] The same operation ID is used as backend `Idempotency-Key`.
- [x] Retrying the same approved operation resolves the same campaign identity.
- [x] Lost `/start` response recovery does not issue a second start after the campaign advanced.
- [x] Concurrent start conflict is recovered only when owner-scoped GET proves the campaign advanced.
- [x] A start conflict remains an error while the campaign is still `draft`.
- [x] E2 approval permits only one matching compensation retry within two minutes.
- [x] Durable retry entitlement is atomically consumed across restart/concurrency.
- [x] Concurrent initial consumers cannot both become initial executions.
- [x] The durable ledger accepts `evolver.run_event_campaign` after migration `0045`.
- [x] Input, owner, or LLM snapshot substitution cannot consume the prior approval.
- [x] E1/E2 credential purpose separation remains enforced.
- [x] E1 durable reuse behavior is unchanged.
- [x] Five internal generations remain automatic after the one campaign approval.
- [x] No promotion, Runner startup, live execution, or order path is introduced.

## Tests / 验证

Validated on final contribution SHA `e1ec52ec48c3c6889c7faac0b8393bf1ec06f4bb`:

- orchestration typecheck + unit tests: **54 files / 551 tests passed**
  - E2 campaign authorization: **8/8**
  - approval-store tests: **12/12**
  - Evolver client/grant/idempotency/retry tests: **8/8**
- orchestration agent eval: passed
- E1 Evolver regression suite: passed
- migration apply + round-trip verification: passed, including migration `0045`
- E1 Paper regression suite: passed
- Python ruff/mypy: data, paper, research, factor, evolver passed
- web typecheck/build: passed
- dashboard typecheck/tests/build: passed
- `scripts/check-consistency.sh`: passed
- self-host build + health smoke: passed

Fork CI run on the exact final head: `33384343793` — **success**.

A validation-only fork PR was used to run exact repository CI and was closed without merging: `TheBayoumi/inalpha#1`.

## Codex review

Codex reviewed the contribution iteratively and identified three P1 issues during development:

1. E2 approval reuse was broader than the one-retry/two-minute contract;
2. the approval-operation ledger schema did not yet accept `evolver.run_event_campaign`;
3. concurrent initial approval consumption could race before persistence.

All three were fixed and regression-tested.

Final Codex review on `e1ec52ec48`:

> **Codex Review: Didn't find any major issues. Nice work!**

No actionable P0/P1/P2 findings remain in the final Codex pass.

## Reproducibility

- Upstream: `mirror29/inalpha`
- PR #164 / contribution base: `b75928d57fbeb7c978ccd33b84812921ca65408a`
- Contribution head: `TheBayoumi:fix/e2-campaign-authorization`
- Final head: `e1ec52ec48c3c6889c7faac0b8393bf1ec06f4bb`
- Intended base: `mirror29:codex/evolution-task27`

Commits:

1. `89d586c161297a49c65ff59512a5e31079e9562c` — `fix(orchestration): 绑定 E2 campaign 审批操作身份`
2. `e1d10d9623885f4d458c67ddb138187dc40e8c8b` — `fix(orchestration): 使 E2 campaign 启动重试幂等`
3. `e2196c5dedd01ffce43ac125018a5b1c1bdc1ed3` — `fix(orchestration): 收紧 E2 campaign 补偿重试`
4. `28eaea0ec3f57ba397115d7e163649bcb2bbca18` — `fix(orchestration): 封闭 E2 审批并发与持久化约束`
5. `e1ec52ec48c3c6889c7faac0b8393bf1ec06f4bb` — `test(orchestration): 校正 E2 并发重试声明`

## Current upstream gate

PR #167 remains Draft because the upstream fork workflow is still `action_required`. The implementation, fork CI, migration verification, and final Codex review are complete; the remaining external gate is maintainer approval/run of the upstream workflow.

