### PR TITLE
docs: prefer English for GitHub collaboration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,6 +5,8 @@ title: "[bug] "
 labels: bug
 ---
 
+> Please write the issue title and description in English by default. Other languages are welcome when needed for localized content or participant accessibility.
+>
 > Inalpha is in **alpha** (Phase D-11 landed). **Please confirm the problem is "implemented incorrectly," not "not yet implemented."**
 > See `CLAUDE.md §3` and `docs/04-current-state.md` for the roadmap.
 >

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,5 @@
 blank_issues_enabled: false
+# GitHub collaboration defaults to English; localized content and accessibility needs are exceptions.
 contact_links:
   - name: Open-ended design discussion / 设计讨论
     url: https://github.com/mirror29/inalpha/discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,6 +5,8 @@ title: "[feature] "
 labels: enhancement
 ---
 
+> Please write the issue title and description in English by default. Other languages are welcome when needed for localized content or participant accessibility.
+>
 > Before proposing, please confirm: Inalpha is **not** a plug-and-play strategy platform, **nor** a LangChain / AutoGen wrapper.
 > Boundaries live in `docs/00-context.md`. We only accept features at the intersection of **AI agent orchestration × quant research**.
 >

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,11 @@
 <!--
 Thanks for contributing! Please review the items below before submitting.
 This project is licensed under GNU AGPL-3.0; your contribution ships under the same license.
+Please write the PR title, description, review comments, and commit messages in English by default.
 
 感谢贡献！提交 PR 前请确认以下事项。
 本项目 LICENSE 是 GNU AGPL-3.0，你的贡献也将以同样许可发布。
+PR 标题、正文、review comment 与 commit message 默认请使用英文。
 -->
 
 ## What this PR does / 这个 PR 做了什么
@@ -20,7 +22,8 @@ Briefly describe the change (1–3 sentences). For bug fixes, link the related i
 
 ## Self-review checklist / 自检清单
 
-- [ ] **Commit message follows `<type>(<scope>): <desc>` in Chinese** (see `CLAUDE.md §3`). This project commits in Chinese even when contributors usually commit in English — please keep the convention.
+- [ ] **Commit messages follow `<type>(<scope>): <desc>` in English** (see `CLAUDE.md §3`), with one logical change per commit.
+- [ ] The PR title and description are in English unless localized content or participant accessibility requires another language.
 - [ ] Ran `bash scripts/check-consistency.sh` locally; all checks pass.
 - [ ] If you touched tool descriptions, they follow the three-part style: *function + when to use + when not to use + gotchas*.
 - [ ] If you changed code related to hard constraints (permissions / hooks / LLM order paths), it's called out in the PR description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,9 @@ Inalpha = AI agent 编排 + 多 Python kernel 的**量化实验框架**：agent 
   - `docs/miro/`（gitignored 个人空间）
   - `services/_shared/`（基础设施稳定层，改前先谨慎评估）
 - **tool description 必须三段式**："功能 + 何时用 + 何时不用 + 坑"
-- **commit message**：中文 + `<type>(<scope>): <desc>`，可标 Phase D-N
+- **GitHub 协作语言**：commit message、branch name、PR / issue / Discussion 的标题与正文、
+  code review、release note 默认使用英文；仅在本地化内容、原文引用或参与者明确需要时使用其他语言
+- **commit message**：英文 + `<type>(<scope>): <desc>`，可标 Phase D-N
 
 ## 4. 起步（clone 之后）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,10 @@
 - **命名**：Python 包 `inalpha_<service>` snake_case；tools `<service>.<verb>` 或 `mcp__<server>__<verb>`
 - **不要碰**：`.mastra/` / `docs/miro/` gitignored / `services/_shared/` 基础设施（改前评估）
 - **tool description 三段式**：功能 + 何时用 + 何时不用 + 坑
-- **commit**：中文 + `<type>(<scope>): <desc>`，可标 Phase D-N
+- **GitHub collaboration language**: use English by default for commit messages, branch names,
+  PR / issue / Discussion titles and bodies, code reviews, and release notes. Use another language
+  only for localized content, source quotations, or when participants explicitly need it
+- **commit**：英文 + `<type>(<scope>): <desc>`，可标 Phase D-N
 - **git 协作**：详 `CONTRIBUTING.md`
 
 ### 3.1 金融时效性硬约束（D-9 · 全 service 必守）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,11 +128,13 @@ CI workflow 改 job 名时必须同步更新 protection 的 `contexts`，否则 
 
 ## 8. Commit / PR conventions / Commit 规范
 
-- **Commit message**: Chinese, `<type>(<scope>): <desc>`; one logical change per commit — don't mix unrelated modules in one commit.
-  **Commit message**：中文 + `<type>(<scope>): <desc>`；一次 commit 只做一件事，不要把不相关模块揉进同一个 commit。
+- **Collaboration language**: use English by default for commit messages, branch names, PR / issue / Discussion titles and bodies, code reviews, and release notes. Other languages are welcome when needed for localized content, source quotations, or participant accessibility.
+  **协作语言**：commit message、branch name、PR / issue / Discussion 的标题与正文、code review、release note 默认使用英文；本地化内容、原文引用或参与者需要时可使用其他语言。
+- **Commit message**: English, `<type>(<scope>): <desc>`; one logical change per commit — don't mix unrelated modules in one commit.
+  **Commit message**：英文 + `<type>(<scope>): <desc>`；一次 commit 只做一件事，不要把不相关模块揉进同一个 commit。
 - **type**: `feat` / `fix` / `refactor` / `docs` / `test` / `chore` / `style` / `perf` / `ci`
 - **scope**: `data` / `paper` / `research` / `factor` / `evolver` / `orchestration` / `dashboard` / `web` / `docs` / `infra`, or a concrete module name / 或具体模块名
-- A Phase tag is welcome / 可标 Phase D-N（例：`feat(paper): 跨币种 cash 账本 (D-11)`）
+- A Phase tag is welcome / 可标 Phase D-N（例：`feat(paper): add cross-currency cash ledger (D-11)`）
 - Check untracked files before committing — a missing `git add` for a newly imported file breaks CI.
   commit 前 `git status` 检查 untracked——新 import 的实现文件漏 add 会让 CI 挂。
 - **PR template**: every self-review item in [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) must be checked.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,8 +25,8 @@ When you report, please include as much of the following as you can / 报告时�
 3. **Minimal reproduction steps** / **最小复现步骤**
 4. **Your assessment of the potential impact** / **你对潜在影响的评估**
 
-Reports in either English or 中文 are equally welcome.
-中英文报告同样欢迎。
+English is preferred for consistency with the project's collaboration language, but reports in any language are welcome when needed for accessibility.
+为保持项目协作语言一致，安全报告优先使用英文；如有沟通需要，任何语言都欢迎。
 
 ## Response commitments / 响应承诺
 

--- a/scripts/deepseek_review.py
+++ b/scripts/deepseek_review.py
@@ -82,8 +82,8 @@ SYSTEM_PROMPT = """\
 - **不重复 lint**：ruff / tsc / mypy 已能抓的不要再提
 - **误报闸**：设计 / 架构类意见必须能说出"在什么输入 / 时序下会真的出问题"的具体失败场景，
   说不出就降级或不提——宁可漏报一条主观的，不要用噪音淹没真问题
-- 用中文写 review，每条 finding 用 `[critical|major|medium] file:line — 一句描述 — 依据(CLAUDE.md §X 或 通用原则:<维度>)` 格式
-- 没问题 -> 一段中文 LGTM，不硬挑刺
+- Write the review in English. Format each finding as `[critical|major|medium] file:line — concise description — evidence (CLAUDE.md §X or general principle: <dimension>)`
+- If there are no findings, return a concise English LGTM; do not invent issues
 - 只维护一条 sticky 评论，不要逐行贴 inline 评论"""
 
 _SEV_ORDER = {"critical": 0, "major": 1, "medium": 2}
@@ -94,7 +94,7 @@ def _fail(msg: str) -> None:
     """写失败说明后正常退出（非阻塞）。"""
     print(f"deepseek_review: {msg}", file=sys.stderr)
     with open(OUT_PATH, "w") as f:
-        f.write(f"## 🤖 DeepSeek V4 Pro PR Review\n\n⚠️ review 未完成：{msg}\n")
+        f.write(f"## 🤖 DeepSeek V4 Pro PR Review\n\n⚠️ Review could not be completed: {msg}\n")
     sys.exit(0)
 
 
@@ -161,18 +161,19 @@ def _call_deepseek(api_key: str, title: str, diff: str, rules: str) -> str:
                 {
                     "role": "user",
                     "content": (
-                        "上一轮没有返回可发布的 review 正文。当前没有任何工具，"
-                        "禁止输出工具调用协议。请直接输出最终中文 review。"
+                        "The previous response did not contain a publishable review. "
+                        "No tools are available. Do not emit a tool-call protocol; "
+                        "return the final review in English now."
                     ),
                 }
             )
-    raise ValueError("DeepSeek 未返回可发布的 review 正文")
+    raise ValueError("DeepSeek did not return a publishable review")
 
 
 def main() -> None:
     api_key = os.environ.get("DEEPSEEK_API_KEY", "")
     if not api_key:
-        _fail("DEEPSEEK_API_KEY 未配置（repo Settings → Secrets → Actions）")
+        _fail("DEEPSEEK_API_KEY is not configured (repository Settings → Secrets → Actions)")
 
     try:
         with open(DIFF_PATH) as f:
@@ -182,18 +183,18 @@ def main() -> None:
         with open(RULES_PATH) as f:
             rules = f.read()
     except OSError as e:
-        _fail(f"读输入失败：{e}")
+        _fail(f"Failed to read review input: {e}")
 
     if not diff.strip():
-        _fail("diff 为空")
+        _fail("The PR diff is empty")
 
     try:
         content = _call_deepseek(api_key, title, diff, rules)
     except urllib.error.HTTPError as e:
         body = e.read().decode("utf-8", "replace")[:300]
-        _fail(f"DeepSeek API HTTP {e.code}：{body}")
+        _fail(f"DeepSeek API returned HTTP {e.code}: {body}")
     except Exception as e:
-        _fail(f"DeepSeek API 调用失败：{e}")
+        _fail(f"DeepSeek API request failed: {e}")
 
     body = "## 🤖 DeepSeek V4 Pro PR Review\n\n" + content
     with open(OUT_PATH, "w") as f:

--- a/tests/test_deepseek_review.py
+++ b/tests/test_deepseek_review.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import http.client
 import importlib.util
+import io
 import json
 import os
 import tempfile
@@ -79,6 +80,7 @@ class DeepSeekReviewTest(unittest.TestCase):
         self.assertEqual(request.get_header("Authorization"), "Bearer secret-value")
         self.assertEqual(payload["model"], "deepseek-v4-pro")
         self.assertEqual(payload["max_tokens"], 32768)
+        self.assertIn("Write the review in English", payload["messages"][0]["content"])
         self.assertIn("## 项目规则（CLAUDE.md）\nproject rules", payload["messages"][1]["content"])
         self.assertEqual(captured["timeout"], module.TIMEOUT_S)
 
@@ -100,6 +102,12 @@ class DeepSeekReviewTest(unittest.TestCase):
 
         self.assertEqual(result, "完整 review")
         self.assertEqual(urlopen.call_count, 2)
+        retry_request = urlopen.call_args_list[1].args[0]
+        retry_payload = json.loads(retry_request.data)
+        self.assertIn(
+            "return the final review in English now",
+            retry_payload["messages"][-1]["content"],
+        )
 
     def test_empty_content_retries_then_returns_review(self) -> None:
         module = _load_module()
@@ -155,7 +163,7 @@ class DeepSeekReviewTest(unittest.TestCase):
             "urlopen",
             side_effect=[_FakeResponse(""), _FakeResponse("   ")],
         ):
-            with self.assertRaisesRegex(ValueError, "未返回可发布"):
+            with self.assertRaisesRegex(ValueError, "did not return a publishable review"):
                 module._call_deepseek(
                     "secret-value", "PR title", "diff body", "project rules"
                 )
@@ -170,8 +178,99 @@ class DeepSeekReviewTest(unittest.TestCase):
             body = Path(module.OUT_PATH).read_text()
 
         self.assertIn("DeepSeek V4 Pro PR Review", body)
-        self.assertIn("DEEPSEEK_API_KEY 未配置", body)
+        self.assertIn("DEEPSEEK_API_KEY is not configured", body)
         self.assertNotIn("GLM-5.2", body)
+
+    def test_empty_diff_writes_english_failure(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.DIFF_PATH = str(root / "diff.txt")
+            module.TITLE_PATH = str(root / "title.txt")
+            module.RULES_PATH = str(root / "rules.md")
+            module.OUT_PATH = str(root / "review.md")
+            Path(module.DIFF_PATH).write_text("")
+            Path(module.TITLE_PATH).write_text("PR title")
+            Path(module.RULES_PATH).write_text("project rules")
+
+            with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "secret-value"}, clear=True):
+                with self.assertRaisesRegex(SystemExit, "0"):
+                    module.main()
+
+            body = Path(module.OUT_PATH).read_text()
+
+        self.assertIn("Review could not be completed: The PR diff is empty", body)
+
+    def test_input_read_error_writes_english_failure(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.DIFF_PATH = str(root / "missing-diff.txt")
+            module.OUT_PATH = str(root / "review.md")
+
+            with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "secret-value"}, clear=True):
+                with self.assertRaisesRegex(SystemExit, "0"):
+                    module.main()
+
+            body = Path(module.OUT_PATH).read_text()
+
+        self.assertIn("Review could not be completed: Failed to read review input", body)
+
+    def test_api_error_writes_english_failure(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.DIFF_PATH = str(root / "diff.txt")
+            module.TITLE_PATH = str(root / "title.txt")
+            module.RULES_PATH = str(root / "rules.md")
+            module.OUT_PATH = str(root / "review.md")
+            Path(module.DIFF_PATH).write_text("diff body")
+            Path(module.TITLE_PATH).write_text("PR title")
+            Path(module.RULES_PATH).write_text("project rules")
+
+            with (
+                patch.dict(os.environ, {"DEEPSEEK_API_KEY": "secret-value"}, clear=True),
+                patch.object(module, "_call_deepseek", side_effect=RuntimeError("boom")),
+            ):
+                with self.assertRaisesRegex(SystemExit, "0"):
+                    module.main()
+
+            body = Path(module.OUT_PATH).read_text()
+
+        self.assertIn("Review could not be completed: DeepSeek API request failed: boom", body)
+
+    def test_http_error_writes_english_failure(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.DIFF_PATH = str(root / "diff.txt")
+            module.TITLE_PATH = str(root / "title.txt")
+            module.RULES_PATH = str(root / "rules.md")
+            module.OUT_PATH = str(root / "review.md")
+            Path(module.DIFF_PATH).write_text("diff body")
+            Path(module.TITLE_PATH).write_text("PR title")
+            Path(module.RULES_PATH).write_text("project rules")
+            error = module.urllib.error.HTTPError(
+                "https://api.deepseek.com/v1/chat/completions",
+                429,
+                "Too Many Requests",
+                {},
+                io.BytesIO(b"rate limited"),
+            )
+
+            with (
+                patch.dict(os.environ, {"DEEPSEEK_API_KEY": "secret-value"}, clear=True),
+                patch.object(module, "_call_deepseek", side_effect=error),
+            ):
+                with self.assertRaisesRegex(SystemExit, "0"):
+                    module.main()
+
+            body = Path(module.OUT_PATH).read_text()
+
+        self.assertIn(
+            "Review could not be completed: DeepSeek API returned HTTP 429: rate limited",
+            body,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Make English the default language for commit messages, branch names, pull requests, issues, discussions, reviews, release notes, and security reports.
- Update the pull request and issue templates to surface the English-first convention while preserving accessibility exceptions.
- Make the automated DeepSeek pull request review and all non-blocking failure messages use English.
- Add regression coverage for the primary prompt, retry prompt, and every changed failure-output path.

## Test Coverage

All 8 changed language-output paths are covered by regression tests.

- Tests: 8 → 12 in `tests/test_deepseek_review.py` (+4)
- No new application control-flow branches were introduced.

## Pre-Landing Review

No issues found. Testing, maintainability, and adversarial reviews completed.

## Design Review

No product frontend files changed; design review was not applicable.

## Eval Results

No project eval suite maps to this standalone review-script prompt. Prompt contracts are covered by deterministic unit assertions.

## Scope Drift

Scope Check: CLEAN. The diff only changes collaboration-language policy, contributor templates, automated PR-review copy, and its tests.

## Plan Completion

No plan file detected.

## Verification Results

- [x] `python3 -m unittest tests/test_deepseek_review.py` — 12 passed
- [x] `python3 -m py_compile scripts/deepseek_review.py`
- [x] `bash scripts/check-consistency.sh` — 19 passed, 0 failed
- [x] `git diff --check`
- [x] Orchestration typecheck and Vitest — 535 passed
- [x] Evolver pytest — 113 passed
- [x] Ruff checks for all Python services

The local paper pytest suite could not start because the shared development database references migration `0044`, which is not present on `main`; this is unrelated to the changed files and CI uses a clean migration state.

## Test plan

- [x] Confirm all collaboration policy sources prefer English.
- [x] Confirm PR and issue templates request English by default.
- [x] Confirm automated review success, retry, and failure output is English.
- [x] Confirm no temporary dependency links or unrelated branch commits are included.
